### PR TITLE
[Slurm] Fix container-cluster stop/start on NFS-backed clusters

### DIFF
--- a/sky/adaptors/slurm.py
+++ b/sky/adaptors/slurm.py
@@ -1177,18 +1177,6 @@ class SlurmClient:
         """Returns the remote user's home directory."""
         return self._runner.get_remote_home_dir()
 
-    def check_file_exists(self, path: str) -> bool:
-        """Check if a file exists on the remote host."""
-        cmd = f'test -f {shlex.quote(path)}'
-        rc, stdout, stderr = self._run_slurm_cmd(cmd)
-        if rc not in (0, 1):
-            subprocess_utils.handle_returncode(
-                rc,
-                cmd,
-                f'Failed to check for file: {path}',
-                stderr=f'{stdout}\n{stderr}')
-        return rc == 0
-
     def check_fuse_enabled(self) -> bool:
         """Check if FUSE is available on the cluster.
 

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2247,6 +2247,49 @@ class CloudVmRayResourceHandle(backends.backend.ResourceHandle):
                 internal_external_ips[1:], key=lambda x: x[1])
         self.stable_internal_external_ips = stable_internal_external_ips
 
+    # TODO(kevin): Remove this backcompat migration in v0.15. It exists only
+    # for Slurm container clusters launched before provider.container_image
+    # was persisted; by v0.15 those allocations will have been recreated.
+    def _maybe_backfill_slurm_container_image(self) -> None:
+        """Backfill provider.container_image for pre-upgrade Slurm clusters.
+
+        Slurm container-ness is read from provider.container_image in the
+        cluster record (see provision/slurm/instance.py). Clusters launched
+        before that field existed lack it, which would run their containers
+        on the host. Reconcile the record with the launched resources, which
+        carry the image and are the source of truth used elsewhere (e.g. the
+        SSH proxy in server.py). Idempotent: writes only when the record is
+        missing the value or disagrees with the launched resources, so it is
+        a no-op for clusters launched with the field.
+        """
+        launched_resources = self.launched_resources
+        if (launched_resources is None or
+                not isinstance(launched_resources.cloud, clouds.Slurm)):
+            return
+        container_image = launched_resources.extract_docker_image()
+        if container_image is None:
+            return
+        try:
+            config = global_user_state.get_cluster_yaml_dict(self.cluster_yaml)
+            provider_config = config.get('provider')
+            if provider_config is None:
+                return
+            if provider_config.get('container_image') == container_image:
+                return
+            provider_config['container_image'] = container_image
+            global_user_state.set_cluster_yaml(self.cluster_name,
+                                               yaml_utils.dump_yaml_str(config))
+        except Exception as e:  # pylint: disable=broad-except
+            # Best-effort migration: a failure here just leaves the record as
+            # it was, so do not fail the operation that needed the runners.
+            logger.warning(
+                'Failed to backfill provider.container_image for Slurm '
+                f'cluster {self.cluster_name!r}: '
+                f'{common_utils.format_exception(e)}')
+            return
+        logger.info('Backfilled provider.container_image for Slurm cluster '
+                    f'{self.cluster_name!r} ({container_image}).')
+
     @context_utils.cancellation_guard
     # we expect different request to be acting on different clusters
     # (= different handles) so we have no real expectation of cache hit
@@ -2260,6 +2303,9 @@ class CloudVmRayResourceHandle(backends.backend.ResourceHandle):
                             avoid_ssh_control: bool = False
                            ) -> List[command_runner.CommandRunner]:
         """Returns a list of command runners for the cluster."""
+        # Pre-upgrade Slurm container clusters lack provider.container_image;
+        # reconcile the record from the launched resources before it is read.
+        self._maybe_backfill_slurm_container_image()
         ssh_credentials = backend_utils.ssh_credential_from_yaml(
             self.cluster_yaml, self.docker_user, self.ssh_user)
         if avoid_ssh_control:

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -1187,6 +1187,22 @@ touch {sky_cluster_home_dir}/.hushlogin
         cmd,
         'Failed to create provision scripts directory on login node.',
         stderr=f'{stdout}\n{stderr}')
+    if snapshot_manifest is not None:
+        # A stop leaves only sky_logs in the shared home. If stale NFS
+        # handles interrupted that cleanup, remove the leftovers now: the
+        # runtime setup is not idempotent against a half-cleaned home
+        # (e.g. a partially deleted uv-managed Python install breaks the
+        # venv creation). This runs before the sbatch is submitted so it
+        # only sees the stop's leftovers and a failure surfaces while the
+        # snapshot is still unconsumed; the sbatch writes its control
+        # files after it.
+        _run_on_login_node(
+            login_node_runner,
+            _remove_shared_state_script(sky_cluster_home_dir,
+                                        preserve_logs=True),
+            'Failed to clean leftover shared state before restoring the '
+            'Slurm cluster.')
+
     # Rsync the provision script to the login node
     with tempfile.NamedTemporaryFile(mode='w', suffix='.sh', delete=True) as f:
         f.write(provision_script)
@@ -1249,20 +1265,6 @@ touch {sky_cluster_home_dir}/.hushlogin
                          f'{stdout}'
                          f'=== End of Slurm job logs ===')
         raise e
-
-    if snapshot_manifest is not None:
-        # A stop leaves only sky_logs in the shared home. If stale NFS
-        # handles interrupted that cleanup, remove the leftovers now: the
-        # runtime setup is not idempotent against a half-cleaned home
-        # (e.g. a partially deleted uv-managed Python install breaks the
-        # venv creation). By restore time the stale handles have usually
-        # cleared, so this pass removes what the stop could not.
-        _run_on_login_node(
-            login_node_runner,
-            _remove_shared_state_script(sky_cluster_home_dir,
-                                        preserve_logs=True),
-            'Failed to clean leftover shared state after restoring the '
-            'Slurm cluster.')
 
     return common.ProvisionRecord(provider_name='slurm',
                                   region=region,
@@ -1803,9 +1805,12 @@ def _remove_shared_state_script(sky_cluster_home_dir: str,
                       '! -name sky_logs '
                       '-exec rm -rf -- {} +')
         # GNU find exits 0 even when the invoked rm fails, so the result
-        # must be verified separately.
-        verify_cmd = (f'[ -z "$(find {home} -mindepth 1 -maxdepth 1 '
-                      '! -name sky_logs -print -quit)" ]')
+        # must be verified separately. The command substitution takes
+        # find's exit status (a stale handle makes find error out), so a
+        # find failure cannot be mistaken for an empty home.
+        verify_cmd = (f'leftovers="$(find {home} -mindepth 1 -maxdepth 1 '
+                      '! -name sky_logs -print -quit)" && '
+                      '[ -z "$leftovers" ]')
     else:
         remove_cmd = f'rm -rf -- {home}'
         verify_cmd = f'[ ! -e {home} ]'

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -1250,6 +1250,20 @@ touch {sky_cluster_home_dir}/.hushlogin
                          f'=== End of Slurm job logs ===')
         raise e
 
+    if snapshot_manifest is not None:
+        # A stop leaves only sky_logs in the shared home. If stale NFS
+        # handles interrupted that cleanup, remove the leftovers now: the
+        # runtime setup is not idempotent against a half-cleaned home
+        # (e.g. a partially deleted uv-managed Python install breaks the
+        # venv creation). By restore time the stale handles have usually
+        # cleared, so this pass removes what the stop could not.
+        _run_on_login_node(
+            login_node_runner,
+            _remove_shared_state_script(sky_cluster_home_dir,
+                                        preserve_logs=True),
+            'Failed to clean leftover shared state after restoring the '
+            'Slurm cluster.')
+
     return common.ProvisionRecord(provider_name='slurm',
                                   region=region,
                                   zone=partition,
@@ -1766,6 +1780,42 @@ def _wait_for_job_states(client: 'slurm.SlurmClient', job_name: str,
         time.sleep(POLL_INTERVAL_SECONDS)
 
 
+# An NFS client can transiently serve stale file handles that make rm fail
+# partway through a directory. Retrying clears them once the client
+# revalidates; the sleep between attempts gives that time to happen.
+_SHARED_STATE_CLEANUP_ATTEMPTS = 3
+_SHARED_STATE_CLEANUP_RETRY_INTERVAL_SECONDS = 10
+
+
+def _remove_shared_state_script(sky_cluster_home_dir: str,
+                                preserve_logs: bool) -> str:
+    """Build a script that empties the shared cluster home on the login node.
+
+    A stop keeps the logs referenced by the jobs database that start restores;
+    teardown removes the whole home. The removal is verified and retried:
+    a stale-file-handle failure would otherwise leave a half-deleted home,
+    and the leftovers (e.g. a partially deleted uv-managed Python install)
+    break the next start's runtime setup.
+    """
+    home = shlex.quote(sky_cluster_home_dir)
+    if preserve_logs:
+        remove_cmd = (f'find {home} -mindepth 1 -maxdepth 1 '
+                      '! -name sky_logs '
+                      '-exec rm -rf -- {} +')
+        # GNU find exits 0 even when the invoked rm fails, so the result
+        # must be verified separately.
+        verify_cmd = (f'[ -z "$(find {home} -mindepth 1 -maxdepth 1 '
+                      '! -name sky_logs -print -quit)" ]')
+    else:
+        remove_cmd = f'rm -rf -- {home}'
+        verify_cmd = f'[ ! -e {home} ]'
+    return (f'for attempt in $(seq {_SHARED_STATE_CLEANUP_ATTEMPTS}); do\n'
+            f'  {remove_cmd} && {verify_cmd} && exit 0\n'
+            f'  sleep {_SHARED_STATE_CLEANUP_RETRY_INTERVAL_SECONDS}\n'
+            'done\n'
+            'exit 1')
+
+
 def _cleanup_slurm_allocation(
     client: 'slurm.SlurmClient',
     login_node_runner: command_runner.CommandRunner,
@@ -1826,18 +1876,10 @@ rm -rf -- {shlex.quote(skypilot_runtime_dir)}
         login_node_runner, cleanup_node_cmd,
         'Failed to clean up the Slurm allocation before cancellation.')
 
-    if preserve_logs:
-        # A stop keeps the logs referenced by the jobs database that start
-        # will restore.
-        remove_shared_state_cmd = (f'find {shlex.quote(sky_cluster_home_dir)} '
-                                   '-mindepth 1 -maxdepth 1 '
-                                   '! -name sky_logs '
-                                   '-exec rm -rf -- {} +')
-    else:
-        remove_shared_state_cmd = (
-            f'rm -rf -- {shlex.quote(sky_cluster_home_dir)}')
     _run_on_login_node(
-        login_node_runner, remove_shared_state_cmd,
+        login_node_runner,
+        _remove_shared_state_script(sky_cluster_home_dir,
+                                    preserve_logs=preserve_logs),
         'Failed to clean up shared Slurm cluster state before cancellation.')
 
 

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -833,7 +833,6 @@ def _create_virtual_instance(
     # between registry and path. See:
     # https://github.com/NVIDIA/pyxis/wiki/Usage#registry-syntax
     container_image = resources.get('image_id')
-    original_container_image = container_image
     if snapshot_manifest is not None:
         if container_image is None:
             raise RuntimeError('A Slurm container snapshot exists for this '
@@ -927,8 +926,6 @@ apt-get install -y ca-certificates rsync curl git wget fuse
 echo 'alias sudo=""' >> ~/.bashrc
 echo "[container-init] Packages installed in $((SECONDS - INIT_START))s"
 """
-        container_marker_file = (f'{sky_cluster_home_dir}/'
-                                 f'{slurm_utils.SLURM_CONTAINER_MARKER_FILE}')
         container_init_done_dir = (
             f'{sky_cluster_home_dir}/.sky_container_init_done')
         pyxis_args = (f'--container-name={shlex.quote(container_name)}:create '
@@ -1027,7 +1024,6 @@ done
 echo "[container] ERROR: Container is not running as $global_target or $job_target." >&2
 exit 1
 """
-        assert original_container_image is not None
         snapshot_restore_complete_block = ''
         if snapshot_manifest is not None:
             snapshot_restore_complete_block = (
@@ -1065,8 +1061,6 @@ exit 1
             f'{shlex.quote(container_ready_script)}'
             f' || exit 1\n'
             f'echo "[container] Ready in $((SECONDS - CONTAINER_START))s"\n'
-            f'printf \'%s\\n\' {shlex.quote(original_container_image)} > '
-            f'{container_marker_file}\n'
             f'{snapshot_restore_complete_block}'
             f'touch {ready_signal}')
 
@@ -1479,27 +1473,17 @@ def stop_instances(
     job_id = running_jobs[0]
     nodes, _ = client.get_job_nodes(job_id)
 
-    sky_cluster_home_dir = _sky_cluster_home_dir(sky_base_dir,
-                                                 cluster_name_on_cloud)
-    container_marker = (
-        f'{sky_cluster_home_dir}/{slurm_utils.SLURM_CONTAINER_MARKER_FILE}')
-    rc, stdout = _run_on_login_node(
-        login_node_runner,
-        f'cat {shlex.quote(container_marker)}',
-        'Failed to read the Slurm container marker.',
-        tolerate_returncodes=(1,))
-    if rc != 0:
+    # Container-ness is persisted in the cluster config at launch
+    # (provider.container_image) and never probed over the shared
+    # filesystem: NFS attribute caching on the login node can hide the
+    # marker file right after the allocation wrote it, which would
+    # silently run a container cluster on the host as the login user.
+    image_id = provider_config.get('container_image')
+    if image_id is None:
         raise exceptions.NotSupportedError(
-            'Stopping Slurm clusters is supported only for containers '
-            'launched with Pyxis. The running cluster has no container '
-            'snapshot metadata.')
-    image_id = stdout.strip()
-    # An empty marker identifies a Pyxis cluster without the image metadata
-    # required to create a restorable snapshot.
-    if not image_id:
-        raise exceptions.NotSupportedError(
-            'The running Slurm cluster has no container snapshot metadata. '
-            'Relaunch the cluster before stopping it.')
+            'Stopping Slurm clusters is supported only for container '
+            'clusters, and the cluster record has no container image. '
+            'Relaunch the cluster with --image-id to use stop.')
     previous_manifest = _read_snapshot_manifest(login_node_runner, snapshot_dir)
 
     skypilot_runtime_dir = _resolve_skypilot_runtime_dir(
@@ -1509,16 +1493,29 @@ def stop_instances(
         inside_slurm_cluster=inside_slurm_cluster)
 
     cancel_jobs_code = job_lib.JobLibCodeGen.cancel_jobs(None, cancel_all=True)
+    # The cancel code sources the runtime venv, which a half-broken cluster
+    # may no longer have. Skipping the cancel keeps stop working as the
+    # recovery path: without a runtime there is no job driver left to cancel,
+    # and the allocation teardown below reclaims everything regardless.
+    runtime_venv_activate = shlex.quote(
+        f'{skypilot_runtime_dir}/'
+        f'{skylet_constants.SKY_REMOTE_PYTHON_ENV_NAME}/bin/activate')
+    runtime_venv_check = f'test -f {runtime_venv_activate}'
     if inside_slurm_cluster:
         # Skylet runs in the same environment as the job driver, so the
         # cancel runs locally against the shared jobs database.
-        cancel_cmd = (f'export '
-                      f'{skylet_constants.SKY_RUNTIME_DIR_ENV_VAR_KEY}='
-                      f'{shlex.quote(skypilot_runtime_dir)} && '
-                      f'{cancel_jobs_code}')
-        rc, stdout, stderr = login_node_runner.run(cancel_cmd,
-                                                   require_outputs=True,
-                                                   stream_logs=False)
+        rc, _, _ = login_node_runner.run(runtime_venv_check,
+                                         require_outputs=True,
+                                         stream_logs=False)
+        has_runtime = rc == 0
+        if has_runtime:
+            cancel_cmd = (f'export '
+                          f'{skylet_constants.SKY_RUNTIME_DIR_ENV_VAR_KEY}='
+                          f'{shlex.quote(skypilot_runtime_dir)} && '
+                          f'{cancel_jobs_code}')
+            rc, stdout, stderr = login_node_runner.run(cancel_cmd,
+                                                       require_outputs=True,
+                                                       stream_logs=False)
     else:
         cluster_info = get_cluster_info('', cluster_name_on_cloud,
                                         provider_config)
@@ -1526,15 +1523,28 @@ def stop_instances(
         if not command_runners:
             raise RuntimeError('Cannot stop Slurm cluster because its head '
                                'node command runner is unavailable.')
-        rc, stdout, stderr = command_runners[0].run_driver(cancel_jobs_code,
-                                                           require_outputs=True,
-                                                           stream_logs=False)
-    subprocess_utils.handle_returncode(
-        rc,
-        cancel_jobs_code,
-        'Failed to cancel jobs before snapshotting the Slurm container.',
-        stderr=f'{stdout}\n{stderr}',
-        stream_logs=False)
+        head_runner = command_runners[0]
+        rc, _, _ = head_runner.run_driver(runtime_venv_check,
+                                          require_outputs=True,
+                                          stream_logs=False)
+        has_runtime = rc == 0
+        if has_runtime:
+            rc, stdout, stderr = head_runner.run_driver(cancel_jobs_code,
+                                                        require_outputs=True,
+                                                        stream_logs=False)
+    if not has_runtime:
+        logger.warning(
+            f'SkyPilot runtime venv missing on the head node '
+            f'({skypilot_runtime_dir}/'
+            f'{skylet_constants.SKY_REMOTE_PYTHON_ENV_NAME}); skipping job '
+            'cancellation before the snapshot.')
+    else:
+        subprocess_utils.handle_returncode(
+            rc,
+            cancel_jobs_code,
+            'Failed to cancel jobs before snapshotting the Slurm container.',
+            stderr=f'{stdout}\n{stderr}',
+            stream_logs=False)
     _drain_slurm_workload_steps(client, job_id)
 
     if not inside_slurm_cluster:
@@ -2074,11 +2084,14 @@ def get_command_runners(
     sky_base_dir = _resolve_sky_base_dir(client, provider_config)
     sky_cluster_home_dir = _sky_cluster_home_dir(sky_base_dir,
                                                  cluster_name_on_cloud)
-    container_marker = (
-        f'{sky_cluster_home_dir}/{slurm_utils.SLURM_CONTAINER_MARKER_FILE}')
-    has_container = client.check_file_exists(container_marker)
-    container_args = _build_pyxis_args(
-        cluster_name_on_cloud) if has_container else None
+    # Container-ness is persisted in the cluster config at launch
+    # (provider.container_image). It must not be probed over the shared
+    # filesystem: NFS attribute caching on the login node can hide the
+    # marker file right after the allocation wrote it, which would
+    # silently run a container cluster on the host as the login user.
+    container_image = provider_config.get('container_image')
+    container_args = (_build_pyxis_args(cluster_name_on_cloud)
+                      if container_image is not None else None)
 
     runners = [
         # Note: For Slurm, the external IP for all instances is the same,

--- a/sky/provision/slurm/utils.py
+++ b/sky/provision/slurm/utils.py
@@ -31,7 +31,6 @@ _VAR_PATTERN = re.compile(r'\$(\w+|\{[^}]*\})')
 _SLURM_USER_PATTERN = re.compile(r'^[a-z_][a-z0-9_.-]*$')
 
 SLURM_MARKER_FILE = '.sky_slurm_cluster'
-SLURM_CONTAINER_MARKER_FILE = '.sky_slurm_container'
 
 # Regex pattern for parsing GPU GRES strings.
 # Format: 'gpu[:acc_type]:acc_count(optional_extra_info)'

--- a/sky/templates/slurm-ray.yml.j2
+++ b/sky/templates/slurm-ray.yml.j2
@@ -16,6 +16,12 @@ provider:
   partition: "{{slurm_partition}}"
   provision_timeout: {{provision_timeout}}
   sky_base_dir: {{sky_base_dir | tojson}}
+{% if image_id is not none %}
+  # Container-ness is read from this persisted field (see
+  # provision/slurm/instance.py::get_command_runners); it must not be probed
+  # over the shared filesystem, where NFS caching can hide the file.
+  container_image: {{image_id | tojson}}
+{% endif %}
 {% if slurm_user is defined and slurm_user is not none %}
   slurm_user: {{slurm_user | tojson}}
 {% endif %}

--- a/sky/templates/slurm-ray.yml.j2
+++ b/sky/templates/slurm-ray.yml.j2
@@ -20,6 +20,10 @@ provider:
   # Container-ness is read from this persisted field (see
   # provision/slurm/instance.py::get_command_runners); it must not be probed
   # over the shared filesystem, where NFS caching can hide the file.
+  # It renders from the same deploy variable as node_config.image_id below
+  # (docker: prefix already stripped by extract_docker_image); snapshot
+  # restore validates the manifest's image_id against node_config.image_id,
+  # so the two must stay identical.
   container_image: {{image_id | tojson}}
 {% endif %}
 {% if slurm_user is defined and slurm_user is not none %}

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -714,9 +714,7 @@ def test_slurm_container_stop_start(generic_cloud: str):
             f'sky logs {name} 1 --status',
             f'sky exec {name} -- echo pre-stop-job-2',
             f'sky logs {name} 2 --status',
-            # Shared-FS cleanup can transiently return stale handles; Slurm
-            # stop is idempotent, so retry once.
-            f'sky stop -y {name} || sky stop -y {name}',
+            f'sky stop -y {name}',
             smoke_tests_utils.get_cmd_wait_until_cluster_status_contains(
                 cluster_name=name,
                 cluster_status=[sky.ClusterStatus.STOPPED],
@@ -770,9 +768,7 @@ def test_slurm_container_stop_start_multi_node(generic_cloud: str):
             "'echo pre-stop-rank-$SKYPILOT_NODE_RANK; "
             "echo rank-$SKYPILOT_NODE_RANK > /snapshot_rank_marker'",
             f'sky logs {name} 1 --status',
-            # Shared-FS cleanup can transiently return stale handles; Slurm
-            # stop is idempotent, so retry once.
-            f'sky stop -y {name} || sky stop -y {name}',
+            f'sky stop -y {name}',
             smoke_tests_utils.get_cmd_wait_until_cluster_status_contains(
                 cluster_name=name,
                 cluster_status=[sky.ClusterStatus.STOPPED],

--- a/tests/unit_tests/test_sky/backends/test_cloud_vm_ray_backend.py
+++ b/tests/unit_tests/test_sky/backends/test_cloud_vm_ray_backend.py
@@ -803,3 +803,72 @@ class TestProvisionClusterLockParking:
                                      is_launched_by_jobs_controller=True)
         assert result is sentinel
         assert locked_provision.call_count == 2
+
+
+class TestSlurmContainerImageBackfill:
+    """Backfilling provider.container_image for pre-upgrade Slurm clusters."""
+
+    @staticmethod
+    def _handle(cloud, image):
+        launched = MagicMock()
+        launched.cloud = MagicMock(spec=cloud)
+        launched.extract_docker_image.return_value = image
+        return CloudVmRayResourceHandle(
+            cluster_name='test-cluster',
+            cluster_name_on_cloud='test-cluster-abc',
+            cluster_yaml='test-cluster.yml',
+            launched_nodes=1,
+            launched_resources=launched,
+        )
+
+    def test_backfills_legacy_container_cluster(self):
+        handle = self._handle(clouds.Slurm, 'ubuntu:24.04')
+        with patch('sky.global_user_state.get_cluster_yaml_dict',
+                   return_value={'provider': {'cluster': 'c'}}), \
+             patch('sky.global_user_state.set_cluster_yaml') as mock_set:
+            handle._maybe_backfill_slurm_container_image()
+        mock_set.assert_called_once()
+        name, written = mock_set.call_args.args
+        assert name == 'test-cluster'
+        from sky.utils import yaml_utils
+        assert (yaml_utils.safe_load(written)['provider']['container_image'] ==
+                'ubuntu:24.04')
+
+    def test_noop_when_already_present(self):
+        handle = self._handle(clouds.Slurm, 'ubuntu:24.04')
+        with patch('sky.global_user_state.get_cluster_yaml_dict',
+                   return_value={'provider': {
+                       'container_image': 'ubuntu:24.04'
+                   }}), \
+             patch('sky.global_user_state.set_cluster_yaml') as mock_set:
+            handle._maybe_backfill_slurm_container_image()
+        mock_set.assert_not_called()
+
+    def test_reconciles_stale_value(self):
+        handle = self._handle(clouds.Slurm, 'ubuntu:24.04')
+        with patch('sky.global_user_state.get_cluster_yaml_dict',
+                   return_value={'provider': {
+                       'container_image': 'old:1'
+                   }}), \
+             patch('sky.global_user_state.set_cluster_yaml') as mock_set:
+            handle._maybe_backfill_slurm_container_image()
+        _, written = mock_set.call_args.args
+        from sky.utils import yaml_utils
+        assert (yaml_utils.safe_load(written)['provider']['container_image'] ==
+                'ubuntu:24.04')
+
+    def test_noop_for_non_container_slurm(self):
+        handle = self._handle(clouds.Slurm, None)
+        with patch('sky.global_user_state.get_cluster_yaml_dict') as mock_get, \
+             patch('sky.global_user_state.set_cluster_yaml') as mock_set:
+            handle._maybe_backfill_slurm_container_image()
+        mock_get.assert_not_called()
+        mock_set.assert_not_called()
+
+    def test_noop_for_non_slurm_cloud(self):
+        handle = self._handle(clouds.AWS, 'ubuntu:24.04')
+        with patch('sky.global_user_state.get_cluster_yaml_dict') as mock_get, \
+             patch('sky.global_user_state.set_cluster_yaml') as mock_set:
+            handle._maybe_backfill_slurm_container_image()
+        mock_get.assert_not_called()
+        mock_set.assert_not_called()

--- a/tests/unit_tests/test_sky/clouds/test_slurm.py
+++ b/tests/unit_tests/test_sky/clouds/test_slurm.py
@@ -1678,6 +1678,18 @@ class TestCreateVirtualInstance:
             'has_job_db': False,
             'nodes': ['node1'],
         }
+        cleanup_script = slurm_instance._remove_shared_state_script(
+            '/home/testuser/.sky_clusters/test-cluster', preserve_logs=True)
+        submitted = {}
+
+        def check_submit(partition, cluster_name, tgt_path):
+            del partition, cluster_name, tgt_path
+            submitted['cleanup_seen'] = any(
+                call.args[0] == cleanup_script
+                for call in mock_ssh_runner.return_value.run.call_args_list)
+            return '5576'
+
+        mock_slurm_client.return_value.submit_job.side_effect = check_submit
 
         with patch('tempfile.NamedTemporaryFile') as mock_tempfile:
             mock_file = mock.MagicMock()
@@ -1693,13 +1705,15 @@ class TestCreateVirtualInstance:
                     config=config,
                 )
 
-        cleanup_script = slurm_instance._remove_shared_state_script(
-            '/home/testuser/.sky_clusters/test-cluster', preserve_logs=True)
         run_commands = [
             call.args[0]
             for call in mock_ssh_runner.return_value.run.call_args_list
         ]
         assert cleanup_script in run_commands
+        # The cleanup must precede the sbatch submission: afterwards the
+        # sbatch writes control files into the home, which the cleanup
+        # must not delete.
+        assert submitted['cleanup_seen'] is True
 
     @patch('sky.provision.slurm.instance._wait_for_job_nodes')
     @patch('sky.provision.slurm.instance.slurm_utils.get_proctrack_type')

--- a/tests/unit_tests/test_sky/clouds/test_slurm.py
+++ b/tests/unit_tests/test_sky/clouds/test_slurm.py
@@ -433,6 +433,10 @@ class TestSubmitUserTemplate:
             assert config['provider']['slurm_user'] == slurm_user
         assert config['provider']['ssh']['user'] == transport_user
         assert config['provider']['sky_base_dir'] == '/fsx/alice'
+        if image_id is None:
+            assert 'container_image' not in config['provider']
+        else:
+            assert config['provider']['container_image'] == image_id
         assert config['auth']['ssh_user'] == expected_ssh_user
         assert config['available_node_types']['ray_head_default'][
             'node_config']['volume_mounts'][0]['path'] == '/data'

--- a/tests/unit_tests/test_sky/clouds/test_slurm.py
+++ b/tests/unit_tests/test_sky/clouds/test_slurm.py
@@ -3,6 +3,7 @@
 import os
 from pathlib import Path
 import re
+from unittest.mock import call
 from unittest.mock import patch
 import unittest.mock as mock
 
@@ -1625,6 +1626,143 @@ class TestCreateVirtualInstance:
 
         written_script = self._run_and_capture_script('test-cluster', config)
         assert_sbatch_matches_snapshot('containers', written_script)
+
+    @patch('sky.provision.slurm.instance._wait_for_job_nodes')
+    @patch('sky.provision.slurm.instance.slurm_utils.get_proctrack_type')
+    @patch('sky.provision.slurm.instance.slurm_utils.get_partition_info')
+    @patch('sky.provision.slurm.instance.slurm.SlurmClient')
+    @patch('sky.provision.slurm.instance.command_runner.'
+           'SlurmLoginNodeCommandRunner')
+    def test_restore_cleans_leftover_shared_state(self, mock_ssh_runner,
+                                                  mock_slurm_client,
+                                                  mock_get_partition_info,
+                                                  mock_get_proctrack_type,
+                                                  mock_wait_for_job_nodes):
+        """A restore empties the shared home before runtime setup runs."""
+        from sky.provision import common
+
+        self._setup_mocks(mock_ssh_runner, mock_slurm_client,
+                          mock_get_partition_info, 'gpu')
+        mock_get_proctrack_type.return_value = 'cgroup'
+
+        config = common.ProvisionConfig(
+            provider_config={
+                'ssh': {
+                    'hostname': 'login.example.com',
+                    'port': '22',
+                    'user': 'testuser',
+                    'private_key': '/path/to/key',
+                },
+                'cluster': 'test-slurm',
+                'partition': 'gpu',
+                'provision_timeout': 300,
+                'sky_base_dir': '/home/testuser',
+            },
+            authentication_config={},
+            docker_config={},
+            node_config={
+                'cpus': 4,
+                'memory': 16,
+                'image_id': 'nvcr.io/nvidia/pytorch:24.01-py3',
+            },
+            count=1,
+            tags={},
+            resume_stopped_nodes=True,
+            ports_to_open_on_launch=None,
+        )
+        manifest = {
+            'version': slurm_instance.SNAPSHOT_MANIFEST_VERSION,
+            'generation': '0123456789abcdef0123456789abcdef',
+            'image_id': 'nvcr.io/nvidia/pytorch:24.01-py3',
+            'created_at': 1234.5,
+            'has_job_db': False,
+            'nodes': ['node1'],
+        }
+
+        with patch('tempfile.NamedTemporaryFile') as mock_tempfile:
+            mock_file = mock.MagicMock()
+            mock_file.__enter__.return_value = mock_file
+            mock_tempfile.return_value = mock_file
+            with patch.object(slurm_instance,
+                              '_read_snapshot_manifest',
+                              return_value=manifest):
+                slurm_instance._create_virtual_instance(
+                    region='us-west-2',
+                    cluster_name='test-cluster',
+                    cluster_name_on_cloud='test-cluster',
+                    config=config,
+                )
+
+        cleanup_script = slurm_instance._remove_shared_state_script(
+            '/home/testuser/.sky_clusters/test-cluster', preserve_logs=True)
+        run_commands = [
+            call.args[0]
+            for call in mock_ssh_runner.return_value.run.call_args_list
+        ]
+        assert cleanup_script in run_commands
+
+    @patch('sky.provision.slurm.instance._wait_for_job_nodes')
+    @patch('sky.provision.slurm.instance.slurm_utils.get_proctrack_type')
+    @patch('sky.provision.slurm.instance.slurm_utils.get_partition_info')
+    @patch('sky.provision.slurm.instance.slurm.SlurmClient')
+    @patch('sky.provision.slurm.instance.command_runner.'
+           'SlurmLoginNodeCommandRunner')
+    def test_fresh_launch_keeps_shared_state(self, mock_ssh_runner,
+                                             mock_slurm_client,
+                                             mock_get_partition_info,
+                                             mock_get_proctrack_type,
+                                             mock_wait_for_job_nodes):
+        """Without a snapshot, the shared home is not cleaned at provision."""
+        from sky.provision import common
+
+        self._setup_mocks(mock_ssh_runner, mock_slurm_client,
+                          mock_get_partition_info, 'gpu')
+        mock_get_proctrack_type.return_value = 'cgroup'
+
+        config = common.ProvisionConfig(
+            provider_config={
+                'ssh': {
+                    'hostname': 'login.example.com',
+                    'port': '22',
+                    'user': 'testuser',
+                    'private_key': '/path/to/key',
+                },
+                'cluster': 'test-slurm',
+                'partition': 'gpu',
+                'provision_timeout': 300,
+                'sky_base_dir': '/home/testuser',
+            },
+            authentication_config={},
+            docker_config={},
+            node_config={
+                'cpus': 4,
+                'memory': 16,
+                'image_id': 'nvcr.io/nvidia/pytorch:24.01-py3',
+            },
+            count=1,
+            tags={},
+            resume_stopped_nodes=False,
+            ports_to_open_on_launch=None,
+        )
+
+        with patch('tempfile.NamedTemporaryFile') as mock_tempfile:
+            mock_file = mock.MagicMock()
+            mock_file.__enter__.return_value = mock_file
+            mock_tempfile.return_value = mock_file
+            slurm_instance._create_virtual_instance(
+                region='us-west-2',
+                cluster_name='test-cluster',
+                cluster_name_on_cloud='test-cluster',
+                config=config,
+            )
+
+        cleanup_script = slurm_instance._remove_shared_state_script(
+            '/home/testuser/.sky_clusters/test-cluster', preserve_logs=True)
+        run_commands = [
+            call.args[0]
+            for call in mock_ssh_runner.return_value.run.call_args_list
+        ]
+        assert cleanup_script not in run_commands
 
         config.node_config['volume_mounts'] = [
             {

--- a/tests/unit_tests/test_sky/clouds/testdata/slurm_sbatch/containers.sh
+++ b/tests/unit_tests/test_sky/clouds/testdata/slurm_sbatch/containers.sh
@@ -113,7 +113,6 @@ echo "[container] ERROR: Container is not running as $global_target or $job_targ
 exit 1
 ' || exit 1
 echo "[container] Ready in $((SECONDS - CONTAINER_START))s"
-printf '%s\n' nvcr.io/nvidia/pytorch:24.01-py3 > /home/testuser/.sky_clusters/test-cluster/.sky_slurm_container
 touch /home/testuser/.sky_clusters/test-cluster/.sky_sbatch_ready
 
 # Host-side keeper step that starts skylet and restarts it if it dies.

--- a/tests/unit_tests/test_sky/provision/slurm/test_instance.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_instance.py
@@ -20,6 +20,11 @@ _PROVIDER_CONFIG = {
         'private_key': '/path/to/key',
     }
 }
+_CONTAINER_IMAGE = 'ubuntu:24.04'
+_CONTAINER_PROVIDER_CONFIG = {
+    **_PROVIDER_CONFIG,
+    'container_image': _CONTAINER_IMAGE,
+}
 _SNAPSHOT_GENERATION = '0123456789abcdef0123456789abcdef'
 _NEW_SNAPSHOT_GENERATION = 'fedcba9876543210fedcba9876543210'
 
@@ -522,9 +527,7 @@ class TestStopInstances:
         login_runner = mock.MagicMock()
 
         def run(command, **kwargs):
-            del kwargs
-            if command.startswith('cat '):
-                return 0, 'ubuntu:24.04\n', ''
+            del command, kwargs
             return 0, '', ''
 
         login_runner.run.side_effect = run
@@ -592,7 +595,8 @@ class TestStopInstances:
 
         login_runner.run.side_effect = run
 
-        instance.stop_instances(_CLUSTER, provider_config=_PROVIDER_CONFIG)
+        instance.stop_instances(_CLUSTER,
+                                provider_config=_CONTAINER_PROVIDER_CONFIG)
 
         assert events.index('cancel jobs') < events.index('drain steps')
         assert events.index('drain steps') < events.index('backup jobs db')
@@ -602,12 +606,17 @@ class TestStopInstances:
         _, login_runner, head_runner, write_manifest, cancel_slurm_job = (
             self._setup(monkeypatch, nodes))
 
-        instance.stop_instances(_CLUSTER, provider_config=_PROVIDER_CONFIG)
+        instance.stop_instances(_CLUSTER,
+                                provider_config=_CONTAINER_PROVIDER_CONFIG)
 
-        head_runner.run_driver.assert_called_once()
+        driver_commands = [
+            call.args[0] for call in head_runner.run_driver.call_args_list
+        ]
+        assert len(driver_commands) == 2
+        assert driver_commands[0].startswith('test -f ')
+        assert driver_commands[0].endswith('/skypilot-runtime/bin/activate')
+        assert 'cancel_jobs_encoded_results' in driver_commands[1]
         head_runner.run.assert_not_called()
-        assert ('cancel_jobs_encoded_results'
-                in head_runner.run_driver.call_args.args[0])
         stop_skylet_commands = [
             call.args[0]
             for call in login_runner.run.call_args_list
@@ -728,7 +737,8 @@ class TestStopInstances:
         monkeypatch.setattr(instance, '_cleanup_slurm_allocation',
                             cleanup_slurm_allocation)
 
-        instance.stop_instances(_CLUSTER, provider_config=_PROVIDER_CONFIG)
+        instance.stop_instances(_CLUSTER,
+                                provider_config=_CONTAINER_PROVIDER_CONFIG)
         cleanup = cancel_slurm_job.call_args.kwargs['pre_batch_cancel']
         cleanup()
 
@@ -761,7 +771,8 @@ class TestStopInstances:
         warning = mock.MagicMock()
         monkeypatch.setattr(instance.logger, 'warning', warning)
 
-        instance.stop_instances(_CLUSTER, provider_config=_PROVIDER_CONFIG)
+        instance.stop_instances(_CLUSTER,
+                                provider_config=_CONTAINER_PROVIDER_CONFIG)
 
         write_manifest.assert_called_once()
         cleanup.assert_called_once()
@@ -774,18 +785,64 @@ class TestStopInstances:
         warning.assert_called_once()
         assert 'cleanup failed' in warning.call_args.args[0]
 
-    def test_empty_container_marker_requires_relaunch(self, monkeypatch):
-        _, login_runner, head_runner, write_manifest, cancel_slurm_job = (
-            self._setup(monkeypatch, ['node-a']))
-        login_runner.run.side_effect = lambda command, **kwargs: (0, '', '')
+    def test_stop_without_container_image_is_rejected(self, monkeypatch):
+        _, _, head_runner, write_manifest, cancel_slurm_job = (self._setup(
+            monkeypatch, ['node-a']))
 
         with pytest.raises(exceptions.NotSupportedError,
-                           match='Relaunch the cluster before stopping it'):
+                           match='no container image'):
             instance.stop_instances(_CLUSTER, provider_config=_PROVIDER_CONFIG)
 
+        # Nothing that touches the allocation may run: the cluster cannot
+        # be snapshotted without persisted container metadata.
         head_runner.run_driver.assert_not_called()
         write_manifest.assert_not_called()
         cancel_slurm_job.assert_not_called()
+
+    def test_missing_runtime_venv_skips_job_cancellation(self, monkeypatch):
+        _, _, head_runner, write_manifest, cancel_slurm_job = (self._setup(
+            monkeypatch, ['node-a']))
+        head_runner.run_driver.side_effect = [(1, '', ''), (0, '', '')]
+        warning = mock.MagicMock()
+        monkeypatch.setattr(instance.logger, 'warning', warning)
+
+        instance.stop_instances(_CLUSTER,
+                                provider_config=_CONTAINER_PROVIDER_CONFIG)
+
+        # The venv check ran, the cancel itself was skipped, and the stop
+        # continued so the cluster can still be recovered.
+        head_runner.run_driver.assert_called_once()
+        assert head_runner.run_driver.call_args.args[0].startswith('test -f ')
+        warning.assert_called_once()
+        assert 'runtime venv missing' in warning.call_args.args[0]
+        write_manifest.assert_called_once()
+        cancel_slurm_job.assert_called_once()
+
+    def test_missing_runtime_venv_skips_local_cancel(self, monkeypatch):
+        _, local_runner, _, write_manifest, cancel_slurm_job = (self._setup(
+            monkeypatch, ['node-a'], inside=True))
+
+        def run(command, **kwargs):
+            del kwargs
+            if (command.startswith('test -f ') and
+                    '/skypilot-runtime/bin/activate' in command):
+                return 1, '', ''
+            return 0, '', ''
+
+        local_runner.run.side_effect = run
+        warning = mock.MagicMock()
+        monkeypatch.setattr(instance.logger, 'warning', warning)
+
+        instance.stop_instances(_CLUSTER,
+                                provider_config=_CONTAINER_PROVIDER_CONFIG)
+
+        commands = [call.args[0] for call in local_runner.run.call_args_list]
+        assert not any(
+            'cancel_jobs_encoded_results' in command for command in commands)
+        warning.assert_called_once()
+        assert 'runtime venv missing' in warning.call_args.args[0]
+        write_manifest.assert_called_once()
+        cancel_slurm_job.assert_called_once()
 
     def test_export_failure_preserves_previous_snapshot(self, monkeypatch):
         client, login_runner, _, write_manifest, cancel_slurm_job = self._setup(
@@ -802,7 +859,8 @@ class TestStopInstances:
         login_runner.run.side_effect = fail_rank_one
 
         with pytest.raises(exceptions.CommandError, match='rank 1'):
-            instance.stop_instances(_CLUSTER, provider_config=_PROVIDER_CONFIG)
+            instance.stop_instances(_CLUSTER,
+                                    provider_config=_CONTAINER_PROVIDER_CONFIG)
 
         write_manifest.assert_not_called()
         cancel_slurm_job.assert_not_called()
@@ -836,7 +894,8 @@ class TestStopInstances:
         write_manifest.side_effect = lambda *args: events.append(
             'publish manifest')
 
-        instance.stop_instances(_CLUSTER, provider_config=_PROVIDER_CONFIG)
+        instance.stop_instances(_CLUSTER,
+                                provider_config=_CONTAINER_PROVIDER_CONFIG)
 
         assert events == [
             'commit generation',
@@ -852,7 +911,8 @@ class TestStopInstances:
         write_manifest.side_effect = RuntimeError('publish failed')
 
         with pytest.raises(RuntimeError, match='publish failed'):
-            instance.stop_instances(_CLUSTER, provider_config=_PROVIDER_CONFIG)
+            instance.stop_instances(_CLUSTER,
+                                    provider_config=_CONTAINER_PROVIDER_CONFIG)
 
         previous_generation_dir = instance._snapshot_generation_dir(
             '/home/test/.sky_snapshots/test-cluster',
@@ -884,7 +944,8 @@ class TestStopInstances:
         login_runner.run.side_effect = fail_node_preflight
 
         with pytest.raises(exceptions.CommandError, match='node node-b'):
-            instance.stop_instances(_CLUSTER, provider_config=_PROVIDER_CONFIG)
+            instance.stop_instances(_CLUSTER,
+                                    provider_config=_CONTAINER_PROVIDER_CONFIG)
 
         commands = [call.args[0] for call in login_runner.run.call_args_list]
         assert not any(
@@ -898,7 +959,8 @@ class TestStopInstances:
         (client, local_runner, head_runner, write_manifest,
          cancel_slurm_job) = self._setup(monkeypatch, ['node-a'], inside=True)
 
-        instance.stop_instances(_CLUSTER, provider_config=_PROVIDER_CONFIG)
+        instance.stop_instances(_CLUSTER,
+                                provider_config=_CONTAINER_PROVIDER_CONFIG)
 
         # No SSH to the login node: the local client is built directly.
         client.test_make_client.assert_not_called()
@@ -924,7 +986,8 @@ class TestStopInstances:
         _, local_runner, _, _, _ = self._setup(monkeypatch, ['node-a'],
                                                inside=True)
 
-        instance.stop_instances(_CLUSTER, provider_config=_PROVIDER_CONFIG)
+        instance.stop_instances(_CLUSTER,
+                                provider_config=_CONTAINER_PROVIDER_CONFIG)
 
         # The skylet executing the stop is the process the skylet-kill step
         # would stop, so the stop flow must not touch its keeper spec or pid.
@@ -966,7 +1029,8 @@ class TestStopInstances:
 
         client.cancel_jobs_by_name.side_effect = cancel
 
-        instance.stop_instances(_CLUSTER, provider_config=_PROVIDER_CONFIG)
+        instance.stop_instances(_CLUSTER,
+                                provider_config=_CONTAINER_PROVIDER_CONFIG)
 
         assert events == [
             'cancel jobs',
@@ -993,13 +1057,101 @@ class TestStopInstances:
         monkeypatch.setattr(instance, '_cleanup_slurm_allocation', cleanup)
 
         with pytest.raises(RuntimeError, match='scancel failed'):
-            instance.stop_instances(_CLUSTER, provider_config=_PROVIDER_CONFIG)
+            instance.stop_instances(_CLUSTER,
+                                    provider_config=_CONTAINER_PROVIDER_CONFIG)
 
         write_manifest.assert_called_once()
         cleanup.assert_not_called()
         commands = [call.args[0] for call in local_runner.run.call_args_list]
         assert not any(
             command == 'rm -rf -- /tmp/test-cluster' for command in commands)
+
+
+class TestGetCommandRunners:
+    """Container-ness must come from persisted config, not a filesystem probe."""
+
+    @staticmethod
+    def _cluster_info(provider_config):
+        instance_info = instance.common.InstanceInfo(
+            instance_id='123,node-a',
+            internal_ip='10.0.0.1',
+            external_ip='login.example.com',
+            ssh_port=22,
+            tags={
+                instance.constants.TAG_SKYPILOT_CLUSTER_NAME: _CLUSTER,
+                'job_id': '123',
+                'node': 'node-a',
+            },
+            node_name='123,node-a')
+        return instance.common.ClusterInfo(
+            instances={'123,node-a': [instance_info]},
+            head_instance_id='123,node-a',
+            provider_name='slurm',
+            provider_config=provider_config,
+        )
+
+    @staticmethod
+    def _resolve_paths(monkeypatch, client):
+        monkeypatch.setattr(instance.slurm, 'SlurmClient',
+                            mock.MagicMock(return_value=client))
+        monkeypatch.setattr(instance, '_resolve_sky_base_dir',
+                            mock.MagicMock(return_value='/home/test'))
+        monkeypatch.setattr(instance.skypilot_config,
+                            'get_effective_region_config',
+                            mock.MagicMock(return_value=None))
+        monkeypatch.setattr(instance.slurm_utils,
+                            'get_slurm_cluster_from_config',
+                            mock.MagicMock(return_value='test-slurm'))
+
+    @staticmethod
+    def _provider_config(tmp_path, container: bool) -> dict:
+        key = tmp_path / 'key'
+        key.write_text('')
+        config = {
+            **_PROVIDER_CONFIG,
+            'ssh': {
+                **_PROVIDER_CONFIG['ssh'],
+                'private_key': str(key),
+            },
+        }
+        if container:
+            config['container_image'] = _CONTAINER_IMAGE
+        return config
+
+    def test_container_cluster_gets_container_runners(self, monkeypatch,
+                                                      tmp_path):
+        self._resolve_paths(monkeypatch, mock.MagicMock())
+
+        runners = instance.get_command_runners(
+            self._cluster_info(self._provider_config(tmp_path, container=True)))
+
+        assert len(runners) == 1
+        assert runners[0].container_args is not None
+        assert ':exec' in runners[0].container_args
+
+    def test_non_container_cluster_runs_on_host(self, monkeypatch, tmp_path):
+        self._resolve_paths(monkeypatch, mock.MagicMock())
+
+        runners = instance.get_command_runners(
+            self._cluster_info(self._provider_config(tmp_path,
+                                                     container=False)))
+
+        assert len(runners) == 1
+        assert runners[0].container_args is None
+
+    def test_false_filesystem_probe_does_not_cause_host_execution(
+            self, monkeypatch, tmp_path):
+        # A stale NFS lookup previously made this check return False for a
+        # running container cluster, silently executing it on the host.
+        client = mock.MagicMock()
+        client.check_file_exists.return_value = False
+        self._resolve_paths(monkeypatch, client)
+
+        runners = instance.get_command_runners(
+            self._cluster_info(self._provider_config(tmp_path, container=True)))
+
+        client.check_file_exists.assert_not_called()
+        assert runners[0].container_args is not None
 
 
 class TestQueryInstances:

--- a/tests/unit_tests/test_sky/provision/slurm/test_instance.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_instance.py
@@ -1,5 +1,6 @@
 """Unit tests for sky.provision.slurm.instance."""
 import json
+import os
 import shlex
 import subprocess
 from unittest import mock
@@ -684,8 +685,61 @@ class TestStopInstances:
                 in node_cleanup)
         assert 'rm -rf -- /tmp/test-cluster' in node_cleanup
         shared_cleanup = login_runner.run.call_args_list[1].args[0]
-        assert shared_cleanup == (
-            'rm -rf -- /home/test/.sky_clusters/test-cluster')
+        assert shared_cleanup == instance._remove_shared_state_script(
+            '/home/test/.sky_clusters/test-cluster', preserve_logs=False)
+
+    def test_remove_shared_state_script_preserves_logs(self):
+        script = instance._remove_shared_state_script(
+            '/home/test/.sky_clusters/test-cluster', preserve_logs=True)
+        assert '! -name sky_logs' in script
+        assert '-print -quit' in script
+
+    def test_remove_shared_state_script_retries_until_verified(self):
+        script = instance._remove_shared_state_script(
+            '/home/test/.sky_clusters/test-cluster', preserve_logs=False)
+        assert script.count('sleep') == 1
+        assert 'exit 0' in script
+        assert 'exit 1' in script
+
+    def test_cleanup_retries_stale_removal(self, monkeypatch, tmp_path):
+        # A stale NFS handle fails the first rm and clears later: the cleanup
+        # script must retry instead of leaving a half-deleted home behind.
+        fake_bin = tmp_path / 'bin'
+        fake_bin.mkdir()
+        real_rm = subprocess.run(['/usr/bin/which', 'rm'],
+                                 check=True,
+                                 capture_output=True,
+                                 text=True).stdout.strip()
+        (fake_bin /
+         'rm').write_text('#!/bin/bash\n'
+                          'echo "$@" >> "$CLEANUP_LOG"\n'
+                          '[ "$(wc -l < "$CLEANUP_LOG")" -ge 2 ] && exec ' +
+                          real_rm + ' "$@"\n'
+                          'exit 1\n')
+        os.chmod(fake_bin / 'rm', 0o755)
+        home = tmp_path / '.sky_clusters' / _CLUSTER
+        (home / 'sky_workdir').mkdir(parents=True)
+        (home / 'sky_workdir' / 'file').write_text('state')
+        log_file = tmp_path / 'cleanup.log'
+        log_file.touch()
+        env = {
+            **os.environ, 'PATH': f'{fake_bin}:{os.environ["PATH"]}',
+            'CLEANUP_LOG': str(log_file)
+        }
+        monkeypatch.setattr(instance,
+                            '_SHARED_STATE_CLEANUP_RETRY_INTERVAL_SECONDS', 0)
+        script = instance._remove_shared_state_script(str(home),
+                                                      preserve_logs=False)
+
+        result = subprocess.run(['/bin/bash', '-c', script],
+                                check=False,
+                                capture_output=True,
+                                text=True,
+                                env=env)
+
+        assert result.returncode == 0, result.stderr
+        assert not home.exists()
+        assert len(log_file.read_text().splitlines()) == 2
 
     def test_cleanup_allocation_preserves_logs(self, monkeypatch, tmp_path):
         client = mock.MagicMock()

--- a/tests/unit_tests/test_sky/provision/slurm/test_instance.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_instance.py
@@ -693,6 +693,9 @@ class TestStopInstances:
             '/home/test/.sky_clusters/test-cluster', preserve_logs=True)
         assert '! -name sky_logs' in script
         assert '-print -quit' in script
+        # The verification must fail when find itself errors (e.g. a stale
+        # file handle), not only when leftovers remain.
+        assert '[ -z "$leftovers" ]' in script
 
     def test_remove_shared_state_script_retries_until_verified(self):
         script = instance._remove_shared_state_script(
@@ -700,6 +703,30 @@ class TestStopInstances:
         assert script.count('sleep') == 1
         assert 'exit 0' in script
         assert 'exit 1' in script
+
+    def test_cleanup_fails_after_exhausted_retries(self, monkeypatch, tmp_path):
+        # A removal that keeps failing must not be reported as success.
+        fake_bin = tmp_path / 'bin'
+        fake_bin.mkdir()
+        (fake_bin / 'rm').write_text('#!/bin/bash\nexit 1\n')
+        os.chmod(fake_bin / 'rm', 0o755)
+        home = tmp_path / '.sky_clusters' / _CLUSTER
+        (home / 'sky_workdir').mkdir(parents=True)
+        (home / 'sky_workdir' / 'file').write_text('state')
+        env = {**os.environ, 'PATH': f'{fake_bin}:{os.environ["PATH"]}'}
+        monkeypatch.setattr(instance,
+                            '_SHARED_STATE_CLEANUP_RETRY_INTERVAL_SECONDS', 0)
+        script = instance._remove_shared_state_script(str(home),
+                                                      preserve_logs=False)
+
+        result = subprocess.run(['/bin/bash', '-c', script],
+                                check=False,
+                                capture_output=True,
+                                text=True,
+                                env=env)
+
+        assert result.returncode == 1
+        assert (home / 'sky_workdir' / 'file').exists()
 
     def test_cleanup_retries_stale_removal(self, monkeypatch, tmp_path):
         # A stale NFS handle fails the first rm and clears later: the cleanup


### PR DESCRIPTION
## Why it broke

Stop/start of Pyxis container clusters is broken on Slurm clusters whose shared home is on NFS, while staying green on FSx for Lustre-backed ones (where the smoke lane runs).

**Failure 1 — restart silently ran on the host.** `get_command_runners` decided host-vs-container execution for every stage (including runtime setup) from a single login-node `test -f` of the container marker file (`.sky_slurm_container`, introduced with container support in [#8604](https://github.com/skypilot-org/skypilot/pull/8604); the restart flow in [#10544](https://github.com/skypilot-org/skypilot/pull/10544) made the failure user-visible). NFS attribute/negative-entry caching on the login node can keep serving a pre-write lookup after the allocation has already written the marker, so the probe returns False for a running container cluster. The runner then silently executes the cluster on the host as the login user: runtime setup installs uv under the login user's home, fails on `/root … Permission denied`, and the node-local venv is never created — `sky start` fails while the allocation stays up. A subsequent `sky stop` dies sourcing the venv that was never created. On a strongly consistent filesystem the probe always sees the marker, which is why the smoke lane stayed green.

Container-ness is fixed state known at launch; it should never be re-derived over a shared filesystem per stage.

**Failure 2 — stop cleanup poisoned the next start.** The stop-time cleanup of the shared home is a single `rm -rf` (keeping `sky_logs`). On NFS, a stale file handle fails it partway, and the leftover half-deleted state breaks the next start: a partially deleted uv-managed Python install still matches `uv venv --python 3.10` discovery but is unusable, so the restore's runtime setup dies with `Python installation is missing a _sysconfigdata_ file`. (Verified live: the same launch succeeds because uv re-downloads into a clean home; only the stop-interrupted remnant breaks it.)

## What changed

- Persist the container image as `provider.container_image` in the cluster config at launch (same pattern as `sky_base_dir`) and read it in `get_command_runners` and `stop_instances`. The marker file, its sbatch write, and `SlurmClient.check_file_exists` are removed — no filesystem probe is left to return a stale answer.
- Stop's job-cancel now checks for the runtime venv and skips with a warning when it is missing, so stop stays usable as the recovery path for a half-broken cluster.
- The shared-home cleanup verifies its result and retries; a snapshot restore re-runs the same verified cleanup right after the allocation is ready, so leftovers a stop could not remove are gone before runtime setup runs.
- Dropped the `sky stop || sky stop` retry in the container stop/start smoke tests, which papered over the stale-handle failures instead of exposing them.

## Test plan

- New unit tests: `get_command_runners` derives container mode from persisted config and never consults a filesystem probe (a forced-False probe result cannot cause host execution); non-container clusters stay host-mode; stop rejects a cluster record without `container_image`; the job-cancel is skipped with a warning when the runtime venv is missing (both driver and inside-cluster paths); the template persists `provider.container_image`; the cleanup script preserves `sky_logs`, verifies, and retries past a transient `rm` failure.
- Live e2e on an NFS-backed Slurm cluster (the exact failing case): launch (setup in-container as root, node-local venv present) → stop → start restores rootfs state (`/snapshot_marker` and an apt-installed package) and job history; repeated for two full stop/start cycles; a stop with the runtime venv deliberately deleted warns and completes instead of dying.
- Live e2e on an FSx for Lustre-backed Slurm cluster: two full stop/start cycles with the same checks — no regression.
