### PR TITLE
[Jobs] Retry transient DB errors in a job's final cleanup and bookkeeping

### DIFF
--- a/sky/jobs/constants.py
+++ b/sky/jobs/constants.py
@@ -132,6 +132,12 @@ EMERGENCY_RECOVERY_BACKOFF_CAP_SECONDS = 30 * 60
 # the cluster forever.
 EMERGENCY_RECOVERY_RESET_WINDOW_SECONDS = 6 * 60 * 60
 
+# A job's final cleanup and bookkeeping retry transient DB errors in place,
+# backing off between attempts, until this budget is spent.
+JOB_FINALIZE_DB_RETRY_BACKOFF_BASE_SECONDS = 10
+JOB_FINALIZE_DB_RETRY_BACKOFF_CAP_SECONDS = 5 * 60
+JOB_FINALIZE_DB_RETRY_BUDGET_SECONDS = 60 * 60
+
 # Prefix used for service-account tokens issued to managed jobs that opt in
 # to api_server_access. The expired-token-cleanup daemon uses this prefix to
 # identify managed-job tokens that should be swept once their TTL passes.

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -102,19 +102,6 @@ async def create_background_task(coro: typing.Coroutine) -> None:
         task.add_done_callback(_background_tasks.discard)
 
 
-def _is_transient_db_error(error: BaseException) -> bool:
-    """Whether `error`, or an error it was raised from, is a transient DB
-    error (see sky.utils.db.retries)."""
-    seen: Set[int] = set()
-    current: Optional[BaseException] = error
-    while current is not None and id(current) not in seen:
-        if isinstance(current, db_retries.RETRYABLE_EXCEPTIONS):
-            return True
-        seen.add(id(current))
-        current = current.__cause__
-    return False
-
-
 async def _retry_on_transient_db_error(coro_fn: Callable[..., Awaitable[T]],
                                        *args, **kwargs) -> T:
     """Await `coro_fn(*args, **kwargs)`, retrying transient DB errors in place.
@@ -132,7 +119,7 @@ async def _retry_on_transient_db_error(coro_fn: Callable[..., Awaitable[T]],
         try:
             return await coro_fn(*args, **kwargs)
         except Exception as e:  # pylint: disable=broad-except
-            if not _is_transient_db_error(e) or time.time() >= deadline:
+            if not db_retries.is_transient(e) or time.time() >= deadline:
                 raise
             delay = backoff.current_backoff()
             logger.warning(f'Transient DB error in {name}, retrying in '

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -3413,7 +3413,8 @@ class ControllerManager:
                         ('Unexpected error occurred. For details, '
                          f'run: sky jobs logs --controller {job_id}')))
 
-            await finalize_step(lambda _: scheduler.job_done_async(job_id))
+            await finalize_step(
+                lambda _: scheduler.job_done_async(job_id, idempotent=True))
 
             async with self._job_tasks_lock:
                 try:

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -13,7 +13,8 @@ import threading
 import time
 import traceback
 import typing
-from typing import Any, Dict, List, Optional, Set, Tuple, Union
+from typing import (Any, Awaitable, Callable, Dict, List, Optional, Set, Tuple,
+                    TypeVar, Union)
 
 import dotenv
 import filelock
@@ -55,6 +56,7 @@ from sky.utils import dag_utils
 from sky.utils import log_links
 from sky.utils import status_lib
 from sky.utils import ux_utils
+from sky.utils.db import retries as db_retries
 from sky.utils.plugin_extensions import ExternalClusterFailure
 from sky.utils.plugin_extensions import ExternalFailureSource
 from sky.utils.plugin_extensions import LogDeliverySource
@@ -69,6 +71,8 @@ else:
     jobsv1_pb2 = adaptors_common.LazyImport('sky.schemas.generated.jobsv1_pb2')
 
 logger = sky_logging.init_logger('sky.jobs.controller')
+
+T = TypeVar('T')
 
 _background_tasks: Set[asyncio.Task] = set()
 _background_tasks_lock: asyncio.Lock = asyncio.Lock()
@@ -96,6 +100,44 @@ async def create_background_task(coro: typing.Coroutine) -> None:
         _background_tasks.add(task)
         # TODO(cooperc): Discard needs a lock?
         task.add_done_callback(_background_tasks.discard)
+
+
+def _is_transient_db_error(error: BaseException) -> bool:
+    """Whether `error`, or an error it was raised from, is a transient DB
+    error (see sky.utils.db.retries)."""
+    seen: Set[int] = set()
+    current: Optional[BaseException] = error
+    while current is not None and id(current) not in seen:
+        if isinstance(current, db_retries.RETRYABLE_EXCEPTIONS):
+            return True
+        seen.add(id(current))
+        current = current.__cause__
+    return False
+
+
+async def _retry_on_transient_db_error(coro_fn: Callable[..., Awaitable[T]],
+                                       *args, **kwargs) -> T:
+    """Await `coro_fn(*args, **kwargs)`, retrying transient DB errors in place.
+
+    Backs off between attempts until the budget in jobs_constants is spent,
+    then re-raises the last error. Any other error is re-raised immediately.
+    """
+    base = jobs_constants.JOB_FINALIZE_DB_RETRY_BACKOFF_BASE_SECONDS
+    cap = jobs_constants.JOB_FINALIZE_DB_RETRY_BACKOFF_CAP_SECONDS
+    backoff = common_utils.Backoff(initial_backoff=base,
+                                   max_backoff_factor=cap // base)
+    deadline = time.time() + jobs_constants.JOB_FINALIZE_DB_RETRY_BUDGET_SECONDS
+    name = getattr(coro_fn, '__name__', repr(coro_fn))
+    while True:
+        try:
+            return await coro_fn(*args, **kwargs)
+        except Exception as e:  # pylint: disable=broad-except
+            if not _is_transient_db_error(e) or time.time() >= deadline:
+                raise
+            delay = backoff.current_backoff()
+            logger.warning(f'Transient DB error in {name}, retrying in '
+                           f'{delay:.0f}s: {db_retries.summarize(e)}')
+            await asyncio.sleep(delay)
 
 
 def _get_dag(job_id: int) -> 'sky.Dag':
@@ -3347,10 +3389,12 @@ class ControllerManager:
             raise
         finally:
             try:
-                await self._cleanup(job_id,
-                                    pool=pool,
-                                    graceful=graceful,
-                                    graceful_timeout=graceful_timeout)
+                await _retry_on_transient_db_error(
+                    self._cleanup,
+                    job_id,
+                    pool=pool,
+                    graceful=graceful,
+                    graceful_timeout=graceful_timeout)
                 logger.info(f'Cluster of managed job {job_id} has been cleaned '
                             'up.')
             except Exception as e:  # pylint: disable=broad-except
@@ -3358,7 +3402,8 @@ class ControllerManager:
                     'Failed to clean up, resources may have leaked: '
                     f'{common_utils.format_exception(e)}. Please check '
                     'whether the job\'s cluster and storage still exist.')
-                await managed_job_state.set_failed_async(
+                await _retry_on_transient_db_error(
+                    managed_job_state.set_failed_async,
                     job_id,
                     task_id=None,
                     failure_type=managed_job_state.ManagedJobStatus.
@@ -3369,7 +3414,8 @@ class ControllerManager:
             if cancelling:
                 # Since it's set with cancelling
                 assert task_id is not None, job_id
-                await managed_job_state.set_cancelled_async(
+                await _retry_on_transient_db_error(
+                    managed_job_state.set_cancelled_async,
                     job_id=job_id,
                     callback_func=managed_job_utils.event_callback_func(
                         job_id=job_id, task_id=task_id,
@@ -3377,14 +3423,16 @@ class ControllerManager:
 
             # We should check job status after 'set_cancelled', otherwise
             # the job status is not terminal.
-            job_status = await managed_job_state.get_status_async(job_id)
+            job_status = await _retry_on_transient_db_error(
+                managed_job_state.get_status_async, job_id)
             assert job_status is not None
             # The job can be non-terminal if the controller exited
             # abnormally, e.g. failed to launch cluster after reaching
             # the MAX_RETRY.
             if not job_status.is_terminal():
                 logger.info(f'Previous job status: {job_status.value}')
-                await managed_job_state.set_failed_async(
+                await _retry_on_transient_db_error(
+                    managed_job_state.set_failed_async,
                     job_id,
                     task_id=None,
                     failure_type=managed_job_state.ManagedJobStatus.
@@ -3393,7 +3441,7 @@ class ControllerManager:
                         'Unexpected error occurred. For details, '
                         f'run: sky jobs logs --controller {job_id}'))
 
-            await scheduler.job_done_async(job_id)
+            await _retry_on_transient_db_error(scheduler.job_done_async, job_id)
 
             async with self._job_tasks_lock:
                 try:

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -13,8 +13,7 @@ import threading
 import time
 import traceback
 import typing
-from typing import (Any, Awaitable, Callable, Dict, List, Optional, Set, Tuple,
-                    TypeVar, Union)
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 import dotenv
 import filelock
@@ -72,8 +71,6 @@ else:
 
 logger = sky_logging.init_logger('sky.jobs.controller')
 
-T = TypeVar('T')
-
 _background_tasks: Set[asyncio.Task] = set()
 _background_tasks_lock: asyncio.Lock = asyncio.Lock()
 
@@ -100,31 +97,6 @@ async def create_background_task(coro: typing.Coroutine) -> None:
         _background_tasks.add(task)
         # TODO(cooperc): Discard needs a lock?
         task.add_done_callback(_background_tasks.discard)
-
-
-async def _retry_on_transient_db_error(coro_fn: Callable[..., Awaitable[T]],
-                                       *args, **kwargs) -> T:
-    """Await `coro_fn(*args, **kwargs)`, retrying transient DB errors in place.
-
-    Backs off between attempts until the budget in jobs_constants is spent,
-    then re-raises the last error. Any other error is re-raised immediately.
-    """
-    base = jobs_constants.JOB_FINALIZE_DB_RETRY_BACKOFF_BASE_SECONDS
-    cap = jobs_constants.JOB_FINALIZE_DB_RETRY_BACKOFF_CAP_SECONDS
-    backoff = common_utils.Backoff(initial_backoff=base,
-                                   max_backoff_factor=cap // base)
-    deadline = time.time() + jobs_constants.JOB_FINALIZE_DB_RETRY_BUDGET_SECONDS
-    name = getattr(coro_fn, '__name__', repr(coro_fn))
-    while True:
-        try:
-            return await coro_fn(*args, **kwargs)
-        except Exception as e:  # pylint: disable=broad-except
-            if not db_retries.is_transient(e) or time.time() >= deadline:
-                raise
-            delay = backoff.current_backoff()
-            logger.warning(f'Transient DB error in {name}, retrying in '
-                           f'{delay:.0f}s: {db_retries.summarize(e)}')
-            await asyncio.sleep(delay)
 
 
 def _get_dag(job_id: int) -> 'sky.Dag':
@@ -3375,13 +3347,25 @@ class ControllerManager:
                          f'{common_utils.format_exception(e)}')
             raise
         finally:
+            deadline = (time.monotonic() +
+                        jobs_constants.JOB_FINALIZE_DB_RETRY_BUDGET_SECONDS)
+
+            async def finalize_step(coro_fn):
+                return await db_retries.with_db_retries_async(
+                    coro_fn,
+                    max_retries=None,
+                    initial_backoff=jobs_constants.
+                    JOB_FINALIZE_DB_RETRY_BACKOFF_BASE_SECONDS,
+                    max_backoff=jobs_constants.
+                    JOB_FINALIZE_DB_RETRY_BACKOFF_CAP_SECONDS,
+                    deadline=deadline)
+
             try:
-                await _retry_on_transient_db_error(
-                    self._cleanup,
-                    job_id,
-                    pool=pool,
-                    graceful=graceful,
-                    graceful_timeout=graceful_timeout)
+                await finalize_step(
+                    lambda _: self._cleanup(job_id,
+                                            pool=pool,
+                                            graceful=graceful,
+                                            graceful_timeout=graceful_timeout))
                 logger.info(f'Cluster of managed job {job_id} has been cleaned '
                             'up.')
             except Exception as e:  # pylint: disable=broad-except
@@ -3389,46 +3373,47 @@ class ControllerManager:
                     'Failed to clean up, resources may have leaked: '
                     f'{common_utils.format_exception(e)}. Please check '
                     'whether the job\'s cluster and storage still exist.')
-                await _retry_on_transient_db_error(
-                    managed_job_state.set_failed_async,
-                    job_id,
-                    task_id=None,
-                    failure_type=managed_job_state.ManagedJobStatus.
-                    FAILED_CONTROLLER,
-                    failure_reason=failure_reason,
-                    override_terminal=True)
+                await finalize_step(
+                    lambda _: managed_job_state.set_failed_async(
+                        job_id,
+                        task_id=None,
+                        failure_type=managed_job_state.ManagedJobStatus.
+                        FAILED_CONTROLLER,
+                        failure_reason=failure_reason,
+                        override_terminal=True))
 
             if cancelling:
                 # Since it's set with cancelling
                 assert task_id is not None, job_id
-                await _retry_on_transient_db_error(
-                    managed_job_state.set_cancelled_async,
-                    job_id=job_id,
-                    callback_func=managed_job_utils.event_callback_func(
-                        job_id=job_id, task_id=task_id,
-                        task=dag.tasks[task_id]))
+                await finalize_step(
+                    lambda _: managed_job_state.set_cancelled_async(
+                        job_id=job_id,
+                        callback_func=managed_job_utils.event_callback_func(
+                            job_id=job_id,
+                            task_id=task_id,
+                            task=dag.tasks[task_id])))
 
             # We should check job status after 'set_cancelled', otherwise
             # the job status is not terminal.
-            job_status = await _retry_on_transient_db_error(
-                managed_job_state.get_status_async, job_id)
+            job_status = await finalize_step(
+                lambda _: managed_job_state.get_status_async(job_id))
             assert job_status is not None
             # The job can be non-terminal if the controller exited
             # abnormally, e.g. failed to launch cluster after reaching
             # the MAX_RETRY.
             if not job_status.is_terminal():
                 logger.info(f'Previous job status: {job_status.value}')
-                await _retry_on_transient_db_error(
-                    managed_job_state.set_failed_async,
-                    job_id,
-                    task_id=None,
-                    failure_type=managed_job_state.ManagedJobStatus.
-                    FAILED_CONTROLLER,
-                    failure_reason=(
-                        'Unexpected error occurred. For details, '
-                        f'run: sky jobs logs --controller {job_id}'))
+                await finalize_step(
+                    lambda _: managed_job_state.set_failed_async(
+                        job_id,
+                        task_id=None,
+                        failure_type=managed_job_state.ManagedJobStatus.
+                        FAILED_CONTROLLER,
+                        failure_reason=
+                        ('Unexpected error occurred. For details, '
+                         f'run: sky jobs logs --controller {job_id}')))
 
-            await _retry_on_transient_db_error(scheduler.job_done_async, job_id)
+            await finalize_step(lambda _: scheduler.job_done_async(job_id))
 
             async with self._job_tasks_lock:
                 try:

--- a/sky/utils/db/retries.py
+++ b/sky/utils/db/retries.py
@@ -139,12 +139,24 @@ def _new_backoff(initial_backoff: float,
                                                        initial_backoff))
 
 
-def _check_bounds(max_retries: Optional[int], deadline: Optional[float]):
+def _check_bounds(max_retries: Optional[int], deadline: Optional[float],
+                  initial_backoff: float, max_backoff: float):
     if max_retries is None and deadline is None:
         raise ValueError('Either max_retries or deadline must be set')
     if max_retries is not None and max_retries < 1:
         raise ValueError(
             f'max_retries must be greater than 0, got {max_retries}')
+    if initial_backoff <= 0 or max_backoff < initial_backoff:
+        raise ValueError('Need 0 < initial_backoff <= max_backoff, got '
+                         f'{initial_backoff} and {max_backoff}')
+
+
+def _next_delay(backoff: common_utils.Backoff,
+                deadline: Optional[float]) -> float:
+    delay = backoff.current_backoff()
+    if deadline is None:
+        return delay
+    return max(0.0, min(delay, deadline - time.monotonic()))
 
 
 def _budget_spent(failures: int, max_retries: Optional[int],
@@ -176,9 +188,10 @@ def with_db_retries(fn: Callable[[int], T],
 
     Gives up after `max_retries` attempts or once `time.monotonic()` passes
     `deadline`, whichever comes first; pass `max_retries=None` to bound the
-    loop by the deadline alone.
+    loop by the deadline alone. Backoff sleeps never run past the deadline,
+    so the last attempt starts no later than the deadline.
     """
-    _check_bounds(max_retries, deadline)
+    _check_bounds(max_retries, deadline, initial_backoff, max_backoff)
     backoff = _new_backoff(initial_backoff, max_backoff)
     attempt = 0
     while True:
@@ -196,7 +209,7 @@ def with_db_retries(fn: Callable[[int], T],
                 logger.error(f'Transient DB error: giving up after '
                              f'{attempt} attempts; {summarize(e)}')
                 raise
-            delay = backoff.current_backoff()
+            delay = _next_delay(backoff, deadline)
             _log_retry(attempt, max_retries, delay, e)
             time.sleep(delay)
 
@@ -209,7 +222,7 @@ async def with_db_retries_async(
         max_backoff: float = _DEFAULT_MAX_BACKOFF,
         deadline: Optional[float] = None) -> T:
     """Async equivalent of with_db_retries."""
-    _check_bounds(max_retries, deadline)
+    _check_bounds(max_retries, deadline, initial_backoff, max_backoff)
     backoff = _new_backoff(initial_backoff, max_backoff)
     attempt = 0
     while True:
@@ -227,7 +240,7 @@ async def with_db_retries_async(
                 logger.error(f'Transient DB error: giving up after '
                              f'{attempt} attempts; {summarize(e)}')
                 raise
-            delay = backoff.current_backoff()
+            delay = _next_delay(backoff, deadline)
             _log_retry(attempt, max_retries, delay, e)
             await asyncio.sleep(delay)
 

--- a/sky/utils/db/retries.py
+++ b/sky/utils/db/retries.py
@@ -9,7 +9,8 @@ catch-all's own DB write failing too, producing a silent RUNNING zombie.
 Wrap any DB-touching call site with one of these helpers. They catch
 `sqlalchemy.exc.OperationalError` (which wraps `psycopg2.OperationalError`
 and many asyncpg connection errors), plus raw driver/network exceptions
-that can escape SQLAlchemy, and retry with exponential backoff + jitter.
+that can escape SQLAlchemy, also when one of those is the `__cause__` of
+the raised exception, and retry with exponential backoff + jitter.
 """
 
 import asyncio
@@ -17,7 +18,7 @@ import functools
 import logging
 import socket
 import time
-from typing import Awaitable, Callable, Tuple, Type, TypeVar
+from typing import Awaitable, Callable, Optional, Set, Tuple, Type, TypeVar
 
 import sqlalchemy.exc
 
@@ -85,6 +86,26 @@ def _build_retryable_exceptions() -> Tuple[Type[BaseException], ...]:
 
 RETRYABLE_EXCEPTIONS = _build_retryable_exceptions()
 
+
+def is_transient(error: BaseException) -> bool:
+    """Whether `error`, or an error it was raised from, is a transient DB
+    error.
+
+    Follows `__cause__`: SQLAlchemy raises its `DBAPIError` wrapper from the
+    driver error (the asyncpg dialect maps every `PostgresError` to the
+    generic wrapper), and call sites such as `terminate_cluster` re-raise
+    with `from e`.
+    """
+    seen: Set[int] = set()
+    current: Optional[BaseException] = error
+    while current is not None and id(current) not in seen:
+        if isinstance(current, RETRYABLE_EXCEPTIONS):
+            return True
+        seen.add(id(current))
+        current = current.__cause__
+    return False
+
+
 # 5 attempts × exp backoff capped at 5s ≈ ~10s of backoff sleeps — covers
 # typical brief outages (DNS hiccup, sub-second RDS reconnect) and the
 # short tail of longer ones; very long outages (multi-second RDS failover)
@@ -125,7 +146,9 @@ def with_db_retries(fn: Callable[[int], T],
                 logger.info(
                     f'Transient DB error recovered after {attempt} retries.')
             return result
-        except RETRYABLE_EXCEPTIONS as e:
+        except Exception as e:  # pylint: disable=broad-except
+            if not is_transient(e):
+                raise
             if attempt == max_retries - 1:
                 logger.error(f'Transient DB error: giving up after '
                              f'{max_retries} attempts; {summarize(e)}')
@@ -154,7 +177,9 @@ async def with_db_retries_async(coro_fn: Callable[[int], Awaitable[T]],
                 logger.info(
                     f'Transient DB error recovered after {attempt} retries.')
             return result
-        except RETRYABLE_EXCEPTIONS as e:
+        except Exception as e:  # pylint: disable=broad-except
+            if not is_transient(e):
+                raise
             if attempt == max_retries - 1:
                 logger.error(f'Transient DB error: giving up after '
                              f'{max_retries} attempts; {summarize(e)}')

--- a/sky/utils/db/retries.py
+++ b/sky/utils/db/retries.py
@@ -42,6 +42,23 @@ def _build_retryable_exceptions() -> Tuple[Type[BaseException], ...]:
         psycopg2_excs = (psycopg2.OperationalError, psycopg2.InterfaceError)
     except ImportError:
         pass
+    # asyncpg.connect() runs inside the engine's async_creator, so an
+    # ErrorResponse received while connecting is raised as asyncpg's own
+    # class, not wrapped by SQLAlchemy: class 08 connection errors (which a
+    # pooler such as PgBouncer uses for every rejection it issues, 08P01),
+    # 57P03 (server starting up / shutting down) and 53300 (too many
+    # connections).
+    asyncpg_excs: Tuple[Type[BaseException], ...] = ()
+    try:
+        import asyncpg  # pylint: disable=import-outside-toplevel
+
+        asyncpg_excs = (
+            asyncpg.exceptions.PostgresConnectionError,
+            asyncpg.exceptions.CannotConnectNowError,
+            asyncpg.exceptions.TooManyConnectionsError,
+        )
+    except ImportError:
+        pass
     # `ConnectionError` is the Python builtin; asyncpg raises it
     # ("unexpected connection_lost() call") in some code paths without
     # SQLAlchemy wrapping it.
@@ -62,6 +79,7 @@ def _build_retryable_exceptions() -> Tuple[Type[BaseException], ...]:
         TimeoutError,
         asyncio.TimeoutError,
         *psycopg2_excs,
+        *asyncpg_excs,
     )
 
 

--- a/sky/utils/db/retries.py
+++ b/sky/utils/db/retries.py
@@ -9,7 +9,7 @@ catch-all's own DB write failing too, producing a silent RUNNING zombie.
 Wrap any DB-touching call site with one of these helpers. They catch
 `sqlalchemy.exc.OperationalError` (which wraps `psycopg2.OperationalError`
 and many asyncpg connection errors), plus raw driver/network exceptions
-that can escape SQLAlchemy, also when one of those is the `__cause__` of
+that can escape SQLAlchemy, also when a driver error is the `__cause__` of
 the raised exception, and retry with exponential backoff + jitter.
 """
 
@@ -17,6 +17,7 @@ import asyncio
 import functools
 import logging
 import socket
+import sys
 import time
 from typing import Awaitable, Callable, Optional, Set, Tuple, Type, TypeVar
 
@@ -29,7 +30,7 @@ logger = logging.getLogger(__name__)
 T = TypeVar('T')
 
 
-def _build_retryable_exceptions() -> Tuple[Type[BaseException], ...]:
+def _build_driver_exceptions() -> Tuple[Type[BaseException], ...]:
     # `psycopg2.OperationalError` is the raw driver error; SQLAlchemy
     # wraps it for normal session.execute() paths, but anything that
     # uses `engine.raw_connection()` (notably `PostgresLock`) raises
@@ -43,63 +44,70 @@ def _build_retryable_exceptions() -> Tuple[Type[BaseException], ...]:
         psycopg2_excs = (psycopg2.OperationalError, psycopg2.InterfaceError)
     except ImportError:
         pass
+    return (
+        sqlalchemy.exc.OperationalError,
+        sqlalchemy.exc.InterfaceError,
+        *psycopg2_excs,
+    )
+
+
+_DRIVER_EXCEPTIONS = _build_driver_exceptions()
+
+
+def _asyncpg_exceptions() -> Tuple[Type[BaseException], ...]:
     # asyncpg.connect() runs inside the engine's async_creator, so an
     # ErrorResponse received while connecting is raised as asyncpg's own
     # class, not wrapped by SQLAlchemy: class 08 connection errors (which a
     # pooler such as PgBouncer uses for every rejection it issues, 08P01),
     # 57P03 (server starting up / shutting down) and 53300 (too many
-    # connections).
-    asyncpg_excs: Tuple[Type[BaseException], ...] = ()
-    try:
-        import asyncpg  # pylint: disable=import-outside-toplevel
-
-        asyncpg_excs = (
-            asyncpg.exceptions.PostgresConnectionError,
-            asyncpg.exceptions.CannotConnectNowError,
-            asyncpg.exceptions.TooManyConnectionsError,
-        )
-    except ImportError:
-        pass
-    # `ConnectionError` is the Python builtin; asyncpg raises it
-    # ("unexpected connection_lost() call") in some code paths without
-    # SQLAlchemy wrapping it.
-    # `socket.gaierror` is what asyncpg raises on DNS resolution failure —
-    # it propagates uncaught through asyncpg.connect() and is NOT wrapped
-    # by SQLAlchemy when going through async_creator.
-    # `TimeoutError` / `asyncio.TimeoutError`: asyncpg.connect() wraps its
-    # internal `asyncio.wait_for(...)` and raises asyncio.TimeoutError on
-    # connect-timeout (e.g. RDS failover black-holing packets). SQLAlchemy
-    # does NOT recognize it as a DBAPI error, so it escapes unwrapped. On
-    # Python 3.11+ asyncio.TimeoutError is aliased to the builtin
-    # TimeoutError; on 3.8–3.10 they are distinct classes, so we list both.
+    # connections). Resolved from sys.modules rather than imported: the
+    # import costs ~40ms per process, and an asyncpg error can only be in
+    # flight in a process that has already imported asyncpg.
+    asyncpg = sys.modules.get('asyncpg')
+    if asyncpg is None:
+        return ()
     return (
-        sqlalchemy.exc.OperationalError,
-        sqlalchemy.exc.InterfaceError,
-        ConnectionError,
-        socket.gaierror,
-        TimeoutError,
-        asyncio.TimeoutError,
-        *psycopg2_excs,
-        *asyncpg_excs,
+        asyncpg.exceptions.PostgresConnectionError,
+        asyncpg.exceptions.CannotConnectNowError,
+        asyncpg.exceptions.TooManyConnectionsError,
     )
 
 
-RETRYABLE_EXCEPTIONS = _build_retryable_exceptions()
+# `ConnectionError` is the Python builtin; asyncpg raises it
+# ("unexpected connection_lost() call") in some code paths without
+# SQLAlchemy wrapping it.
+# `socket.gaierror` is what asyncpg raises on DNS resolution failure —
+# it propagates uncaught through asyncpg.connect() and is NOT wrapped
+# by SQLAlchemy when going through async_creator.
+# `TimeoutError` / `asyncio.TimeoutError`: asyncpg.connect() wraps its
+# internal `asyncio.wait_for(...)` and raises asyncio.TimeoutError on
+# connect-timeout (e.g. RDS failover black-holing packets). SQLAlchemy
+# does NOT recognize it as a DBAPI error, so it escapes unwrapped. On
+# Python 3.11+ asyncio.TimeoutError is aliased to the builtin
+# TimeoutError; on 3.8–3.10 they are distinct classes, so we list both.
+_NETWORK_EXCEPTIONS: Tuple[Type[BaseException], ...] = (
+    ConnectionError,
+    socket.gaierror,
+    TimeoutError,
+    asyncio.TimeoutError,
+)
+
+RETRYABLE_EXCEPTIONS = _DRIVER_EXCEPTIONS + _NETWORK_EXCEPTIONS
 
 
 def is_transient(error: BaseException) -> bool:
-    """Whether `error`, or an error it was raised from, is a transient DB
-    error.
+    """Whether `error` is a transient DB error, directly or by `__cause__`.
 
-    Follows `__cause__`: SQLAlchemy raises its `DBAPIError` wrapper from the
-    driver error (the asyncpg dialect maps every `PostgresError` to the
-    generic wrapper), and call sites such as `terminate_cluster` re-raise
-    with `from e`.
+    Along the cause chain only driver errors count: the bare network
+    builtins are retryable only when raised at the top level.
     """
+    driver_excs = _DRIVER_EXCEPTIONS + _asyncpg_exceptions()
+    if isinstance(error, driver_excs + _NETWORK_EXCEPTIONS):
+        return True
     seen: Set[int] = set()
-    current: Optional[BaseException] = error
+    current = error.__cause__
     while current is not None and id(current) not in seen:
-        if isinstance(current, RETRYABLE_EXCEPTIONS):
+        if isinstance(current, driver_excs):
             return True
         seen.add(id(current))
         current = current.__cause__
@@ -116,7 +124,7 @@ def is_transient(error: BaseException) -> bool:
 # ~10s backoff + 5×15s connect ≈ 85s, not ~10s.
 _DEFAULT_MAX_RETRIES = 5
 _DEFAULT_INITIAL_BACKOFF = 1.0
-_DEFAULT_MAX_BACKOFF_FACTOR = 5  # cap = 1.0 * 5 = 5s
+_DEFAULT_MAX_BACKOFF = 5.0
 
 
 def summarize(e: BaseException) -> str:
@@ -124,22 +132,56 @@ def summarize(e: BaseException) -> str:
     return f'{type(e).__name__}: {str(e).splitlines()[0] if str(e) else ""}'
 
 
+def _new_backoff(initial_backoff: float,
+                 max_backoff: float) -> common_utils.Backoff:
+    return common_utils.Backoff(initial_backoff=initial_backoff,
+                                max_backoff_factor=int(max_backoff //
+                                                       initial_backoff))
+
+
+def _check_bounds(max_retries: Optional[int], deadline: Optional[float]):
+    if max_retries is None and deadline is None:
+        raise ValueError('Either max_retries or deadline must be set')
+    if max_retries is not None and max_retries < 1:
+        raise ValueError(
+            f'max_retries must be greater than 0, got {max_retries}')
+
+
+def _budget_spent(failures: int, max_retries: Optional[int],
+                  deadline: Optional[float]) -> bool:
+    if max_retries is not None and failures >= max_retries:
+        return True
+    return deadline is not None and time.monotonic() >= deadline
+
+
+def _log_retry(failures: int, max_retries: Optional[int], delay: float,
+               e: BaseException) -> None:
+    budget = f'/{max_retries}' if max_retries is not None else ''
+    logger.warning(f'Transient DB error (attempt {failures}{budget}), '
+                   f'retrying in {delay:.1f}s: {summarize(e)}')
+
+
 def with_db_retries(fn: Callable[[int], T],
-                    max_retries: int = _DEFAULT_MAX_RETRIES) -> T:
+                    max_retries: Optional[int] = _DEFAULT_MAX_RETRIES,
+                    *,
+                    initial_backoff: float = _DEFAULT_INITIAL_BACKOFF,
+                    max_backoff: float = _DEFAULT_MAX_BACKOFF,
+                    deadline: Optional[float] = None) -> T:
     """Run `fn(attempt)` with retry/backoff on transient DB errors.
 
     `fn` receives the attempt index (0 = first call, 1+ = retry replay). Use
     it to keep otherwise-non-idempotent operations safe across commit-lost
     retries (e.g. accept the target state as already-applied on attempt>0).
     Callers that don't need attempt-awareness can just ignore the arg.
+
+    Gives up after `max_retries` attempts or once `time.monotonic()` passes
+    `deadline`, whichever comes first; pass `max_retries=None` to bound the
+    loop by the deadline alone.
     """
-    if max_retries < 1:
-        raise ValueError(
-            f'max_retries must be greater than 0, got {max_retries}')
-    backoff = common_utils.Backoff(
-        initial_backoff=_DEFAULT_INITIAL_BACKOFF,
-        max_backoff_factor=_DEFAULT_MAX_BACKOFF_FACTOR)
-    for attempt in range(max_retries):
+    _check_bounds(max_retries, deadline)
+    backoff = _new_backoff(initial_backoff, max_backoff)
+    attempt = 0
+    while True:
         try:
             result = fn(attempt)
             if attempt > 0:
@@ -149,28 +191,28 @@ def with_db_retries(fn: Callable[[int], T],
         except Exception as e:  # pylint: disable=broad-except
             if not is_transient(e):
                 raise
-            if attempt == max_retries - 1:
+            attempt += 1
+            if _budget_spent(attempt, max_retries, deadline):
                 logger.error(f'Transient DB error: giving up after '
-                             f'{max_retries} attempts; {summarize(e)}')
+                             f'{attempt} attempts; {summarize(e)}')
                 raise
             delay = backoff.current_backoff()
-            logger.warning(
-                f'Transient DB error (attempt {attempt + 1}/{max_retries}), '
-                f'retrying in {delay:.1f}s: {summarize(e)}')
+            _log_retry(attempt, max_retries, delay, e)
             time.sleep(delay)
-    raise AssertionError('with_db_retries: unreachable')
 
 
-async def with_db_retries_async(coro_fn: Callable[[int], Awaitable[T]],
-                                max_retries: int = _DEFAULT_MAX_RETRIES) -> T:
+async def with_db_retries_async(
+        coro_fn: Callable[[int], Awaitable[T]],
+        max_retries: Optional[int] = _DEFAULT_MAX_RETRIES,
+        *,
+        initial_backoff: float = _DEFAULT_INITIAL_BACKOFF,
+        max_backoff: float = _DEFAULT_MAX_BACKOFF,
+        deadline: Optional[float] = None) -> T:
     """Async equivalent of with_db_retries."""
-    if max_retries < 1:
-        raise ValueError(
-            f'max_retries must be greater than 0, got {max_retries}')
-    backoff = common_utils.Backoff(
-        initial_backoff=_DEFAULT_INITIAL_BACKOFF,
-        max_backoff_factor=_DEFAULT_MAX_BACKOFF_FACTOR)
-    for attempt in range(max_retries):
+    _check_bounds(max_retries, deadline)
+    backoff = _new_backoff(initial_backoff, max_backoff)
+    attempt = 0
+    while True:
         try:
             result = await coro_fn(attempt)
             if attempt > 0:
@@ -180,16 +222,14 @@ async def with_db_retries_async(coro_fn: Callable[[int], Awaitable[T]],
         except Exception as e:  # pylint: disable=broad-except
             if not is_transient(e):
                 raise
-            if attempt == max_retries - 1:
+            attempt += 1
+            if _budget_spent(attempt, max_retries, deadline):
                 logger.error(f'Transient DB error: giving up after '
-                             f'{max_retries} attempts; {summarize(e)}')
+                             f'{attempt} attempts; {summarize(e)}')
                 raise
             delay = backoff.current_backoff()
-            logger.warning(
-                f'Transient DB error (attempt {attempt + 1}/{max_retries}), '
-                f'retrying in {delay:.1f}s: {summarize(e)}')
+            _log_retry(attempt, max_retries, delay, e)
             await asyncio.sleep(delay)
-    raise AssertionError('with_db_retries_async: unreachable')
 
 
 def retry(fn):

--- a/tests/unit_tests/test_sky/jobs/test_controller.py
+++ b/tests/unit_tests/test_sky/jobs/test_controller.py
@@ -2486,7 +2486,7 @@ class TestRunJobLoopTransientDbErrors:
         assert target.await_count == 3
         assert len(sleeps) == 2
         managed_job_state.set_failed_async.assert_not_awaited()
-        scheduler.job_done_async.assert_awaited_once_with(1)
+        scheduler.job_done_async.assert_awaited_once_with(1, idempotent=True)
         assert 1 not in manager.job_tasks
 
     @pytest.mark.asyncio
@@ -2518,7 +2518,7 @@ class TestRunJobLoopTransientDbErrors:
             managed_job_state.ManagedJobStatus.FAILED_CONTROLLER)
         assert kwargs['override_terminal'] is True
         assert kwargs['failure_reason'].startswith('Failed to clean up')
-        scheduler.job_done_async.assert_awaited_once_with(1)
+        scheduler.job_done_async.assert_awaited_once_with(1, idempotent=True)
 
     @pytest.mark.asyncio
     async def test_cleanup_db_error_past_budget_fails_job(
@@ -2539,7 +2539,7 @@ class TestRunJobLoopTransientDbErrors:
         kwargs = managed_job_state.set_failed_async.await_args.kwargs
         assert kwargs['override_terminal'] is True
         assert 'OperationalError' in kwargs['failure_reason']
-        scheduler.job_done_async.assert_awaited_once_with(1)
+        scheduler.job_done_async.assert_awaited_once_with(1, idempotent=True)
 
     @pytest.mark.asyncio
     async def test_cancelled_job_ends_cancelled_after_cleanup_retry(
@@ -2557,4 +2557,4 @@ class TestRunJobLoopTransientDbErrors:
         managed_job_state.set_cancelling_async.assert_awaited_once()
         managed_job_state.set_cancelled_async.assert_awaited_once()
         managed_job_state.set_failed_async.assert_not_awaited()
-        scheduler.job_done_async.assert_awaited_once_with(1)
+        scheduler.job_done_async.assert_awaited_once_with(1, idempotent=True)

--- a/tests/unit_tests/test_sky/jobs/test_controller.py
+++ b/tests/unit_tests/test_sky/jobs/test_controller.py
@@ -12,7 +12,7 @@ import asyncio
 import copy
 import runpy
 import sys
-from types import SimpleNamespace
+import time
 from typing import Dict, List, Optional, Tuple
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
@@ -2405,14 +2405,8 @@ class TestJobGroupPhase2FailurePropagation:
 
 
 class TestRunJobLoopTransientDbErrors:
-    """The finally of ControllerManager.run_job_loop retries transient DB
-    errors in place instead of failing the job.
-
-    Drives the real run_job_loop with the JobController and every state
-    collaborator mocked. asyncio.sleep records the backoff and advances the
-    fake clock that time.time() reads, so the retry budget is exercised
-    without waiting.
-    """
+    """asyncio.sleep is patched to record each backoff and advance the fake
+    clock that the retry deadline reads."""
 
     @staticmethod
     def _db_error() -> sqlalchemy.exc.OperationalError:
@@ -2421,7 +2415,20 @@ class TestRunJobLoopTransientDbErrors:
             Exception('server closed the connection unexpectedly'))
 
     @pytest.fixture
-    def harness(self, monkeypatch, tmp_path):
+    def sleeps(self, monkeypatch) -> List[float]:
+        now = [1_000_000.0]
+        slept: List[float] = []
+
+        async def _fake_sleep(seconds):
+            slept.append(seconds)
+            now[0] += seconds
+
+        monkeypatch.setattr(asyncio, 'sleep', _fake_sleep)
+        monkeypatch.setattr(time, 'monotonic', lambda: now[0])
+        return slept
+
+    @pytest.fixture
+    def manager(self, monkeypatch) -> ControllerManager:
         manager = ControllerManager('test-uuid')
         manager.starting.add(1)
         manager._cleanup = AsyncMock()
@@ -2444,136 +2451,110 @@ class TestRunJobLoopTransientDbErrors:
                             MagicMock(return_value=dag))
         monkeypatch.setattr(managed_job_utils, 'event_callback_func',
                             MagicMock(return_value=None))
-
-        state = {
-            'set_failed_async': AsyncMock(),
-            'set_cancelled_async': AsyncMock(),
-            'set_cancelling_async': AsyncMock(),
-            'get_all_task_ids_statuses_async': AsyncMock(
-                return_value=[(0, managed_job_state.ManagedJobStatus.RUNNING)]),
-            'get_status_async': AsyncMock(
-                return_value=managed_job_state.ManagedJobStatus.SUCCEEDED),
-        }
-        for name, mock in state.items():
-            monkeypatch.setattr(managed_job_state, name, mock)
-        job_done = AsyncMock()
-        monkeypatch.setattr(scheduler, 'job_done_async', job_done)
-
-        now = [1_000_000.0]
-        sleeps: List[float] = []
-
-        async def _fake_sleep(seconds):
-            sleeps.append(seconds)
-            now[0] += seconds
-
-        monkeypatch.setattr(asyncio, 'sleep', _fake_sleep)
-        monkeypatch.setattr(controller_module.time, 'time', lambda: now[0])
-
-        return SimpleNamespace(manager=manager,
-                               run=job_controller.run,
-                               cleanup=manager._cleanup,
-                               state=state,
-                               job_done=job_done,
-                               sleeps=sleeps,
-                               log_file=str(tmp_path / '1.log'))
+        monkeypatch.setattr(managed_job_state, 'set_failed_async', AsyncMock())
+        monkeypatch.setattr(managed_job_state, 'set_cancelled_async',
+                            AsyncMock())
+        monkeypatch.setattr(managed_job_state, 'set_cancelling_async',
+                            AsyncMock())
+        monkeypatch.setattr(
+            managed_job_state, 'get_all_task_ids_statuses_async',
+            AsyncMock(
+                return_value=[(0, managed_job_state.ManagedJobStatus.RUNNING)]))
+        monkeypatch.setattr(
+            managed_job_state, 'get_status_async',
+            AsyncMock(
+                return_value=managed_job_state.ManagedJobStatus.SUCCEEDED))
+        monkeypatch.setattr(scheduler, 'job_done_async', AsyncMock())
+        return manager
 
     @pytest.mark.asyncio
-    async def test_cleanup_transient_db_error_is_retried(self, harness):
-        h = harness
-        h.cleanup.side_effect = [self._db_error(), self._db_error(), None]
+    @pytest.mark.parametrize('step', ['cleanup', 'get_status'])
+    async def test_transient_db_error_is_retried(self, manager, sleeps, step):
+        if step == 'cleanup':
+            target = manager._cleanup
+            target.side_effect = [self._db_error(), self._db_error(), None]
+        else:
+            target = managed_job_state.get_status_async
+            target.side_effect = [
+                self._db_error(),
+                self._db_error(),
+                managed_job_state.ManagedJobStatus.SUCCEEDED,
+            ]
 
-        await h.manager.run_job_loop(1, h.log_file)
+        await manager.run_job_loop(1, 'job.log')
 
-        assert h.cleanup.await_count == 3
-        assert len(h.sleeps) == 2
-        h.state['set_failed_async'].assert_not_awaited()
-        h.job_done.assert_awaited_once_with(1)
-        assert 1 not in h.manager.job_tasks
+        assert target.await_count == 3
+        assert len(sleeps) == 2
+        managed_job_state.set_failed_async.assert_not_awaited()
+        scheduler.job_done_async.assert_awaited_once_with(1)
+        assert 1 not in manager.job_tasks
 
     @pytest.mark.asyncio
-    async def test_cleanup_error_caused_by_db_error_is_retried(self, harness):
-        h = harness
+    async def test_cleanup_error_caused_by_db_error_is_retried(
+            self, manager, sleeps):
         wrapped = RuntimeError('Failed to terminate the cluster c.')
         wrapped.__cause__ = self._db_error()
-        h.cleanup.side_effect = [wrapped, None]
+        manager._cleanup.side_effect = [wrapped, None]
 
-        await h.manager.run_job_loop(1, h.log_file)
+        await manager.run_job_loop(1, 'job.log')
 
-        assert h.cleanup.await_count == 2
-        assert len(h.sleeps) == 1
-        h.state['set_failed_async'].assert_not_awaited()
-        h.job_done.assert_awaited_once_with(1)
+        assert manager._cleanup.await_count == 2
+        assert len(sleeps) == 1
+        managed_job_state.set_failed_async.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_cleanup_non_db_error_fails_job(self, harness):
-        h = harness
-        h.cleanup.side_effect = RuntimeError('boom')
-        h.state['get_status_async'].return_value = (
+    async def test_cleanup_non_db_error_fails_job(self, manager, sleeps):
+        manager._cleanup.side_effect = RuntimeError('boom')
+        managed_job_state.get_status_async.return_value = (
             managed_job_state.ManagedJobStatus.FAILED_CONTROLLER)
 
-        await h.manager.run_job_loop(1, h.log_file)
+        await manager.run_job_loop(1, 'job.log')
 
-        assert h.cleanup.await_count == 1
-        assert not h.sleeps
-        h.state['set_failed_async'].assert_awaited_once()
-        kwargs = h.state['set_failed_async'].await_args.kwargs
+        assert manager._cleanup.await_count == 1
+        assert not sleeps
+        managed_job_state.set_failed_async.assert_awaited_once()
+        kwargs = managed_job_state.set_failed_async.await_args.kwargs
         assert kwargs['failure_type'] == (
             managed_job_state.ManagedJobStatus.FAILED_CONTROLLER)
         assert kwargs['override_terminal'] is True
         assert kwargs['failure_reason'].startswith('Failed to clean up')
-        h.job_done.assert_awaited_once_with(1)
+        scheduler.job_done_async.assert_awaited_once_with(1)
 
     @pytest.mark.asyncio
-    async def test_cleanup_db_error_past_budget_fails_job(self, harness):
-        h = harness
-        h.cleanup.side_effect = self._db_error()
-        h.state['get_status_async'].return_value = (
+    async def test_cleanup_db_error_past_budget_fails_job(
+            self, manager, sleeps):
+        manager._cleanup.side_effect = self._db_error()
+        managed_job_state.get_status_async.return_value = (
             managed_job_state.ManagedJobStatus.FAILED_CONTROLLER)
 
-        await h.manager.run_job_loop(1, h.log_file)
+        await manager.run_job_loop(1, 'job.log')
 
-        assert h.cleanup.await_count > 2
-        assert sum(
-            h.sleeps) >= (jobs_constants.JOB_FINALIZE_DB_RETRY_BUDGET_SECONDS)
-        assert max(h.sleeps) <= (
+        assert manager._cleanup.await_count > 2
+        assert sum(sleeps) >= (
+            jobs_constants.JOB_FINALIZE_DB_RETRY_BUDGET_SECONDS)
+        assert max(sleeps) <= (
             jobs_constants.JOB_FINALIZE_DB_RETRY_BACKOFF_CAP_SECONDS *
             (1 + common_utils.Backoff.JITTER))
-        h.state['set_failed_async'].assert_awaited_once()
-        kwargs = h.state['set_failed_async'].await_args.kwargs
+        managed_job_state.set_failed_async.assert_awaited_once()
+        kwargs = managed_job_state.set_failed_async.await_args.kwargs
         assert kwargs['override_terminal'] is True
         assert 'OperationalError' in kwargs['failure_reason']
-        h.job_done.assert_awaited_once_with(1)
-
-    @pytest.mark.asyncio
-    async def test_bookkeeping_transient_db_error_is_retried(self, harness):
-        h = harness
-        h.state['get_status_async'].side_effect = [
-            self._db_error(),
-            self._db_error(),
-            managed_job_state.ManagedJobStatus.SUCCEEDED,
-        ]
-
-        await h.manager.run_job_loop(1, h.log_file)
-
-        assert h.state['get_status_async'].await_count == 3
-        assert len(h.sleeps) == 2
-        h.state['set_failed_async'].assert_not_awaited()
-        h.job_done.assert_awaited_once_with(1)
+        scheduler.job_done_async.assert_awaited_once_with(1)
 
     @pytest.mark.asyncio
     async def test_cancelled_job_ends_cancelled_after_cleanup_retry(
-            self, harness):
-        h = harness
-        h.run.side_effect = asyncio.CancelledError()
-        h.cleanup.side_effect = [self._db_error(), None]
-        h.state['get_status_async'].return_value = (
+            self, manager, sleeps):
+        controller_module.JobController.return_value.run.side_effect = (
+            asyncio.CancelledError())
+        manager._cleanup.side_effect = [self._db_error(), None]
+        managed_job_state.get_status_async.return_value = (
             managed_job_state.ManagedJobStatus.CANCELLED)
 
         with pytest.raises(asyncio.CancelledError):
-            await h.manager.run_job_loop(1, h.log_file)
+            await manager.run_job_loop(1, 'job.log')
 
-        assert h.cleanup.await_count == 2
-        h.state['set_cancelling_async'].assert_awaited_once()
-        h.state['set_cancelled_async'].assert_awaited_once()
-        h.state['set_failed_async'].assert_not_awaited()
-        h.job_done.assert_awaited_once_with(1)
+        assert manager._cleanup.await_count == 2
+        managed_job_state.set_cancelling_async.assert_awaited_once()
+        managed_job_state.set_cancelled_async.assert_awaited_once()
+        managed_job_state.set_failed_async.assert_not_awaited()
+        scheduler.job_done_async.assert_awaited_once_with(1)

--- a/tests/unit_tests/test_sky/jobs/test_controller.py
+++ b/tests/unit_tests/test_sky/jobs/test_controller.py
@@ -12,6 +12,7 @@ import asyncio
 import copy
 import runpy
 import sys
+from types import SimpleNamespace
 from typing import Dict, List, Optional, Tuple
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
@@ -19,17 +20,21 @@ from unittest.mock import patch
 import warnings
 
 import pytest
+import sqlalchemy.exc
 
 import sky
 from sky import task as task_lib
+from sky.jobs import constants as jobs_constants
 from sky.jobs import controller as controller_module
 from sky.jobs import job_group_networking
+from sky.jobs import scheduler
 from sky.jobs import state as managed_job_state
 from sky.jobs import utils as managed_job_utils
 from sky.jobs.controller import ControllerManager
 from sky.jobs.controller import JobController
 from sky.skylet import job_lib
 from sky.utils import common
+from sky.utils import common_utils
 from sky.utils import status_lib
 from sky.utils.plugin_extensions import LogDeliverySource
 
@@ -2397,3 +2402,178 @@ class TestJobGroupPhase2FailurePropagation:
                 await JobController._run_job_group(controller)
 
         controller._cleanup_job_group_clusters.assert_not_awaited()
+
+
+class TestRunJobLoopTransientDbErrors:
+    """The finally of ControllerManager.run_job_loop retries transient DB
+    errors in place instead of failing the job.
+
+    Drives the real run_job_loop with the JobController and every state
+    collaborator mocked. asyncio.sleep records the backoff and advances the
+    fake clock that time.time() reads, so the retry budget is exercised
+    without waiting.
+    """
+
+    @staticmethod
+    def _db_error() -> sqlalchemy.exc.OperationalError:
+        return sqlalchemy.exc.OperationalError(
+            'SELECT 1', {},
+            Exception('server closed the connection unexpectedly'))
+
+    @pytest.fixture
+    def harness(self, monkeypatch, tmp_path):
+        manager = ControllerManager('test-uuid')
+        manager.starting.add(1)
+        manager._cleanup = AsyncMock()
+        manager._download_logs_for_cancelled_job = AsyncMock()
+
+        job_controller = MagicMock()
+        job_controller.run = AsyncMock()
+        monkeypatch.setattr(controller_module, 'JobController',
+                            MagicMock(return_value=job_controller))
+        monkeypatch.setattr(controller_module.context, 'get',
+                            MagicMock(return_value=MagicMock()))
+        monkeypatch.setattr(controller_module.file_content_utils,
+                            'get_job_env_content', MagicMock(return_value=None))
+        monkeypatch.setattr(controller_module.usage_lib,
+                            'install_fresh_messages_for_current_context',
+                            MagicMock())
+        dag = MagicMock()
+        dag.tasks = [MagicMock()]
+        monkeypatch.setattr(controller_module, '_get_dag',
+                            MagicMock(return_value=dag))
+        monkeypatch.setattr(managed_job_utils, 'event_callback_func',
+                            MagicMock(return_value=None))
+
+        state = {
+            'set_failed_async': AsyncMock(),
+            'set_cancelled_async': AsyncMock(),
+            'set_cancelling_async': AsyncMock(),
+            'get_all_task_ids_statuses_async': AsyncMock(
+                return_value=[(0, managed_job_state.ManagedJobStatus.RUNNING)]),
+            'get_status_async': AsyncMock(
+                return_value=managed_job_state.ManagedJobStatus.SUCCEEDED),
+        }
+        for name, mock in state.items():
+            monkeypatch.setattr(managed_job_state, name, mock)
+        job_done = AsyncMock()
+        monkeypatch.setattr(scheduler, 'job_done_async', job_done)
+
+        now = [1_000_000.0]
+        sleeps: List[float] = []
+
+        async def _fake_sleep(seconds):
+            sleeps.append(seconds)
+            now[0] += seconds
+
+        monkeypatch.setattr(asyncio, 'sleep', _fake_sleep)
+        monkeypatch.setattr(controller_module.time, 'time', lambda: now[0])
+
+        return SimpleNamespace(manager=manager,
+                               run=job_controller.run,
+                               cleanup=manager._cleanup,
+                               state=state,
+                               job_done=job_done,
+                               sleeps=sleeps,
+                               log_file=str(tmp_path / '1.log'))
+
+    @pytest.mark.asyncio
+    async def test_cleanup_transient_db_error_is_retried(self, harness):
+        h = harness
+        h.cleanup.side_effect = [self._db_error(), self._db_error(), None]
+
+        await h.manager.run_job_loop(1, h.log_file)
+
+        assert h.cleanup.await_count == 3
+        assert len(h.sleeps) == 2
+        h.state['set_failed_async'].assert_not_awaited()
+        h.job_done.assert_awaited_once_with(1)
+        assert 1 not in h.manager.job_tasks
+
+    @pytest.mark.asyncio
+    async def test_cleanup_error_caused_by_db_error_is_retried(self, harness):
+        h = harness
+        wrapped = RuntimeError('Failed to terminate the cluster c.')
+        wrapped.__cause__ = self._db_error()
+        h.cleanup.side_effect = [wrapped, None]
+
+        await h.manager.run_job_loop(1, h.log_file)
+
+        assert h.cleanup.await_count == 2
+        assert len(h.sleeps) == 1
+        h.state['set_failed_async'].assert_not_awaited()
+        h.job_done.assert_awaited_once_with(1)
+
+    @pytest.mark.asyncio
+    async def test_cleanup_non_db_error_fails_job(self, harness):
+        h = harness
+        h.cleanup.side_effect = RuntimeError('boom')
+        h.state['get_status_async'].return_value = (
+            managed_job_state.ManagedJobStatus.FAILED_CONTROLLER)
+
+        await h.manager.run_job_loop(1, h.log_file)
+
+        assert h.cleanup.await_count == 1
+        assert not h.sleeps
+        h.state['set_failed_async'].assert_awaited_once()
+        kwargs = h.state['set_failed_async'].await_args.kwargs
+        assert kwargs['failure_type'] == (
+            managed_job_state.ManagedJobStatus.FAILED_CONTROLLER)
+        assert kwargs['override_terminal'] is True
+        assert kwargs['failure_reason'].startswith('Failed to clean up')
+        h.job_done.assert_awaited_once_with(1)
+
+    @pytest.mark.asyncio
+    async def test_cleanup_db_error_past_budget_fails_job(self, harness):
+        h = harness
+        h.cleanup.side_effect = self._db_error()
+        h.state['get_status_async'].return_value = (
+            managed_job_state.ManagedJobStatus.FAILED_CONTROLLER)
+
+        await h.manager.run_job_loop(1, h.log_file)
+
+        assert h.cleanup.await_count > 2
+        assert sum(
+            h.sleeps) >= (jobs_constants.JOB_FINALIZE_DB_RETRY_BUDGET_SECONDS)
+        assert max(h.sleeps) <= (
+            jobs_constants.JOB_FINALIZE_DB_RETRY_BACKOFF_CAP_SECONDS *
+            (1 + common_utils.Backoff.JITTER))
+        h.state['set_failed_async'].assert_awaited_once()
+        kwargs = h.state['set_failed_async'].await_args.kwargs
+        assert kwargs['override_terminal'] is True
+        assert 'OperationalError' in kwargs['failure_reason']
+        h.job_done.assert_awaited_once_with(1)
+
+    @pytest.mark.asyncio
+    async def test_bookkeeping_transient_db_error_is_retried(self, harness):
+        h = harness
+        h.state['get_status_async'].side_effect = [
+            self._db_error(),
+            self._db_error(),
+            managed_job_state.ManagedJobStatus.SUCCEEDED,
+        ]
+
+        await h.manager.run_job_loop(1, h.log_file)
+
+        assert h.state['get_status_async'].await_count == 3
+        assert len(h.sleeps) == 2
+        h.state['set_failed_async'].assert_not_awaited()
+        h.job_done.assert_awaited_once_with(1)
+
+    @pytest.mark.asyncio
+    async def test_cancelled_job_ends_cancelled_after_cleanup_retry(
+            self, harness):
+        h = harness
+        h.run.side_effect = asyncio.CancelledError()
+        h.cleanup.side_effect = [self._db_error(), None]
+        h.state['get_status_async'].return_value = (
+            managed_job_state.ManagedJobStatus.CANCELLED)
+
+        with pytest.raises(asyncio.CancelledError):
+            await h.manager.run_job_loop(1, h.log_file)
+
+        assert h.cleanup.await_count == 2
+        h.state['set_cancelling_async'].assert_awaited_once()
+        h.state['set_cancelled_async'].assert_awaited_once()
+        h.state['set_failed_async'].assert_not_awaited()
+        h.job_done.assert_awaited_once_with(1)

--- a/tests/unit_tests/test_sky/utils/test_db_retries.py
+++ b/tests/unit_tests/test_sky/utils/test_db_retries.py
@@ -197,3 +197,42 @@ async def _coro_returning(value):
 
 async def _coro_raising(exc):
     raise exc
+
+
+class TestIsTransient:
+
+    def test_direct_retryable_exception(self):
+        assert retries.is_transient(_make_op_error())
+
+    def test_non_db_exception(self):
+        assert not retries.is_transient(RuntimeError('boom'))
+
+    def test_follows_cause_chain(self):
+        err = RuntimeError('Failed to terminate the cluster c.')
+        err.__cause__ = _make_op_error()
+        assert retries.is_transient(err)
+
+    def test_sqlalchemy_wrapper_around_asyncpg_error(self):
+        # The asyncpg dialect maps PostgresError to the generic DBAPIError;
+        # the asyncpg class survives only as the cause.
+        adapter_err = Exception('adapter')
+        adapter_err.__cause__ = asyncpg.exceptions.ProtocolViolationError(
+            'query_wait_timeout')
+        err = sqlalchemy.exc.DBAPIError('SELECT 1', {}, adapter_err)
+        err.__cause__ = adapter_err
+        assert retries.is_transient(err)
+
+    def test_cause_cycle_terminates(self):
+        a = RuntimeError('a')
+        b = RuntimeError('b')
+        a.__cause__ = b
+        b.__cause__ = a
+        assert not retries.is_transient(a)
+
+    def test_with_db_retries_retries_cause_chained_error(self):
+        err = RuntimeError('wrapped')
+        err.__cause__ = _make_op_error()
+        fn = mock.Mock(side_effect=[err, 'ok'])
+        with mock.patch.object(retries.time, 'sleep'):
+            assert retries.with_db_retries(fn) == 'ok'
+        assert fn.call_count == 2

--- a/tests/unit_tests/test_sky/utils/test_db_retries.py
+++ b/tests/unit_tests/test_sky/utils/test_db_retries.py
@@ -3,6 +3,7 @@
 import socket
 from unittest import mock
 
+import asyncpg
 import psycopg2
 import pytest
 import sqlalchemy.exc
@@ -32,6 +33,12 @@ class TestWithDbRetries:
         lambda: psycopg2.OperationalError('server closed the connection'),
         lambda: psycopg2.InterfaceError('connection already closed'),
         lambda: socket.gaierror(8, 'nodename nor servname provided'),
+        lambda: asyncpg.exceptions.ProtocolViolationError(
+            'database "d" is disabled'),
+        lambda: asyncpg.exceptions.CannotConnectNowError(
+            'the database system is starting up'),
+        lambda: asyncpg.exceptions.TooManyConnectionsError(
+            'too many connections for role "r"'),
     ])
     def test_retries_on_each_retryable_exception(self, exc_factory):
         # Fail twice, then succeed.
@@ -130,6 +137,8 @@ class TestWithDbRetriesAsync:
         lambda: ConnectionError('unexpected connection_lost() call'),
         lambda: socket.gaierror(8, 'nodename nor servname provided'),
         lambda: psycopg2.OperationalError('server closed the connection'),
+        lambda: asyncpg.exceptions.ProtocolViolationError(
+            'database "d" is disabled'),
     ])
     async def test_retries_on_each_retryable_exception(self, exc_factory):
         results = [

--- a/tests/unit_tests/test_sky/utils/test_db_retries.py
+++ b/tests/unit_tests/test_sky/utils/test_db_retries.py
@@ -253,7 +253,20 @@ class TestDeadlineBudget:
                                         max_backoff=300,
                                         deadline=1000.0)
         assert fn.call_count > retries._DEFAULT_MAX_RETRIES
-        assert clock[0] >= 1000.0
+        # The last sleep is clamped to the remaining budget, so the final
+        # attempt starts exactly at the deadline.
+        assert clock[0] == pytest.approx(1000.0)
+
+    @pytest.mark.parametrize('initial_backoff,max_backoff', [(0, 5.0),
+                                                             (10.0, 5.0)])
+    def test_invalid_backoff_bounds_raise_value_error(self, initial_backoff,
+                                                      max_backoff):
+        fn = mock.Mock()
+        with pytest.raises(ValueError, match='initial_backoff'):
+            retries.with_db_retries(fn,
+                                    initial_backoff=initial_backoff,
+                                    max_backoff=max_backoff)
+        fn.assert_not_called()
 
     def test_attempt_bound_still_applies_with_deadline(self):
         fn = mock.Mock(side_effect=_make_op_error('persistent'))

--- a/tests/unit_tests/test_sky/utils/test_db_retries.py
+++ b/tests/unit_tests/test_sky/utils/test_db_retries.py
@@ -1,6 +1,7 @@
 """Unit tests for sky.utils.db.retries."""
 # pylint: disable=missing-class-docstring,protected-access,unnecessary-lambda
 import socket
+from typing import Optional
 from unittest import mock
 
 import asyncpg
@@ -15,6 +16,14 @@ def _make_op_error(msg: str = 'boom') -> sqlalchemy.exc.OperationalError:
     return sqlalchemy.exc.OperationalError(statement='SELECT 1',
                                            params={},
                                            orig=Exception(msg))
+
+
+def _wrapped(cause: BaseException,
+             outer: Optional[BaseException] = None) -> BaseException:
+    """`outer` (default RuntimeError) raised `from cause`."""
+    err = outer if outer is not None else RuntimeError('wrapped')
+    err.__cause__ = cause
+    return err
 
 
 class TestWithDbRetries:
@@ -39,6 +48,7 @@ class TestWithDbRetries:
             'the database system is starting up'),
         lambda: asyncpg.exceptions.TooManyConnectionsError(
             'too many connections for role "r"'),
+        lambda: _wrapped(_make_op_error()),
     ])
     def test_retries_on_each_retryable_exception(self, exc_factory):
         # Fail twice, then succeed.
@@ -208,31 +218,54 @@ class TestIsTransient:
         assert not retries.is_transient(RuntimeError('boom'))
 
     def test_follows_cause_chain(self):
-        err = RuntimeError('Failed to terminate the cluster c.')
-        err.__cause__ = _make_op_error()
-        assert retries.is_transient(err)
+        assert retries.is_transient(_wrapped(_make_op_error()))
 
     def test_sqlalchemy_wrapper_around_asyncpg_error(self):
         # The asyncpg dialect maps PostgresError to the generic DBAPIError;
-        # the asyncpg class survives only as the cause.
-        adapter_err = Exception('adapter')
-        adapter_err.__cause__ = asyncpg.exceptions.ProtocolViolationError(
-            'query_wait_timeout')
+        # the asyncpg class survives only two levels down the cause chain.
+        adapter_err = _wrapped(
+            asyncpg.exceptions.ProtocolViolationError('query_wait_timeout'),
+            Exception('adapter'))
         err = sqlalchemy.exc.DBAPIError('SELECT 1', {}, adapter_err)
         err.__cause__ = adapter_err
         assert retries.is_transient(err)
 
-    def test_cause_cycle_terminates(self):
-        a = RuntimeError('a')
-        b = RuntimeError('b')
-        a.__cause__ = b
-        b.__cause__ = a
-        assert not retries.is_transient(a)
+    def test_bare_network_error_counts_only_at_top_level(self):
+        assert retries.is_transient(ConnectionResetError('reset'))
+        assert not retries.is_transient(_wrapped(ConnectionResetError('reset')))
 
-    def test_with_db_retries_retries_cause_chained_error(self):
-        err = RuntimeError('wrapped')
-        err.__cause__ = _make_op_error()
-        fn = mock.Mock(side_effect=[err, 'ok'])
+
+class TestDeadlineBudget:
+
+    def test_deadline_bounds_the_loop(self):
+        clock = [0.0]
+
+        def fake_sleep(seconds):
+            clock[0] += seconds
+
+        fn = mock.Mock(side_effect=_make_op_error('persistent'))
+        with mock.patch.object(retries.time, 'sleep', fake_sleep), \
+             mock.patch.object(retries.time, 'monotonic', lambda: clock[0]):
+            with pytest.raises(sqlalchemy.exc.OperationalError):
+                retries.with_db_retries(fn,
+                                        max_retries=None,
+                                        initial_backoff=10,
+                                        max_backoff=300,
+                                        deadline=1000.0)
+        assert fn.call_count > retries._DEFAULT_MAX_RETRIES
+        assert clock[0] >= 1000.0
+
+    def test_attempt_bound_still_applies_with_deadline(self):
+        fn = mock.Mock(side_effect=_make_op_error('persistent'))
         with mock.patch.object(retries.time, 'sleep'):
-            assert retries.with_db_retries(fn) == 'ok'
+            with pytest.raises(sqlalchemy.exc.OperationalError):
+                retries.with_db_retries(fn,
+                                        max_retries=2,
+                                        deadline=float('inf'))
         assert fn.call_count == 2
+
+    def test_requires_a_bound(self):
+        fn = mock.Mock()
+        with pytest.raises(ValueError, match='max_retries or deadline'):
+            retries.with_db_retries(fn, max_retries=None)
+        fn.assert_not_called()


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

The `finally` of `ControllerManager.run_job_loop` treats any exception from `_cleanup` as terminal: it marks the job `FAILED_CONTROLLER` with `override_terminal=True`. A transient DB error reaches it in two ways. `task_cleanup` calls `core.status` with no retry, and in the server process that read loads the RBAC policy from the DB. `terminate_cluster` does retry, but wraps its final failure in `RuntimeError(...) from e`, so a connection drop during teardown surfaces with the DB error only in `__cause__`. The trailing bookkeeping in the same `finally` (`set_cancelled_async`, `get_status_async`, `set_failed_async`, `job_done_async`) retries for about 10 s per call; past that the `finally` aborts and the job is left non-terminal with its schedule slot held, and nothing reconciles it while the controller process stays alive.

This PR retries transient DB errors in place in that `finally`. Every step (`_cleanup` and the trailing bookkeeping calls) runs through `db_retries.with_db_retries_async` under one shared budget: backoff from 10 s up to 5 min, deadline 1 h after the `finally` starts (`JOB_FINALIZE_DB_RETRY_*` in `sky/jobs/constants.py`). Any other exception, or an exhausted budget, takes the existing `FAILED_CONTROLLER` path unchanged; the schedule state is marked DONE idempotently so a replay after a lost commit acknowledgement succeeds. A job whose cleanup succeeds once the DB is back now ends in its real terminal state instead of `FAILED_CONTROLLER`.

Changes in `sky/utils/db/retries.py` that this relies on:

- `with_db_retries` / `with_db_retries_async` accept `initial_backoff`, `max_backoff` and a monotonic `deadline`; `max_retries=None` bounds the loop by the deadline alone, and sleeps are clamped so the last attempt starts no later than the deadline. Defaults are unchanged for existing callers.
- `is_transient(error)` is the single classifier, used by the helpers and the controller. It follows `__cause__` for driver errors, so `terminate_cluster`'s `RuntimeError(...) from e` and SQLAlchemy's generic `DBAPIError` wrapper (the asyncpg dialect maps every `PostgresError` to it) count as transient. The bare network builtins (`ConnectionError`, `TimeoutError`, `socket.gaierror`) still count only when raised at the top level, since cleanup also runs cloud and SSH paths that chain those.
- asyncpg's connection-class errors (`PostgresConnectionError`, `CannotConnectNowError`, `TooManyConnectionsError`) are transient. `asyncpg.connect()` runs inside the engine's `async_creator`, so a rejection received while connecting (for example PgBouncer's 08P01) is raised as asyncpg's own class and never wrapped by SQLAlchemy; the async state engine did not retry those at all, while the psycopg2 path already classified the same failures as `OperationalError`. The classes are resolved from `sys.modules` so importing `sky` does not import asyncpg.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - `tests/unit_tests/test_sky/jobs/test_controller.py::TestRunJobLoopTransientDbErrors`: cleanup is retried on `OperationalError` and on a `RuntimeError` caused by one; a non-DB cleanup error fails the job once; DB errors lasting past the budget fail the job; a failing `get_status_async` is retried and the `finally` completes; a cancelled job ends `CANCELLED` after its cleanup retry.
  - `tests/unit_tests/test_sky/utils/test_db_retries.py`: asyncpg `ProtocolViolationError`, `CannotConnectNowError`, `TooManyConnectionsError` and a `RuntimeError` caused by an `OperationalError` are retried; a bare `ConnectionResetError` counts only at the top level; the deadline bound stops the loop and `max_retries=None` without a deadline is rejected.
  - Manual, on a Kubernetes API server in consolidation mode with PgBouncer in front of the state DB: launched a managed job, cancelled it, and had PgBouncer reject new client connections for 150 s starting right after the CANCELLING transition. The controller log shows the async engine's decorator giving up after its 5 attempts, then the `finally` retrying `_cleanup` five times (backoff 6.5 s, 10.5 s, 20.1 s, 31.1 s, 66.4 s); once connections were allowed again the cluster was torn down and the job ended `CANCELLED` with no leftover cluster. On the build without the asyncpg classes the same run left the job wedged in CANCELLING with a dead loop.
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)
