### PR TITLE
[Verda] Do not send os_volume when image_id is a customized OS volume

### DIFF
--- a/sky/provision/verda/instance.py
+++ b/sky/provision/verda/instance.py
@@ -2,6 +2,7 @@
 
 import time
 from typing import Any, Dict, List, Optional, Tuple
+import uuid
 
 from sky import exceptions
 from sky import sky_logging
@@ -59,6 +60,22 @@ def _get_head_instance_id(instances: Dict[str, Instance]) -> Optional[str]:
             head_instance_id = inst_id
             break
     return head_instance_id
+
+
+def _is_os_volume_id(image: str) -> bool:
+    """Whether `image` is a customized OS volume ID rather than an image type.
+
+    Verda's `POST /instances` accepts either an OS image type (e.g.
+    `ubuntu-24.04-cuda-12.8-open-docker`) or the UUID of a previously
+    customized OS volume. The `os_volume` field describes the *new* volume to
+    create and must only be sent for the former; sending it alongside a
+    volume UUID makes the request fail with `not_found`.
+    """
+    try:
+        uuid.UUID(image)
+    except ValueError:
+        return False
+    return True
 
 
 def find_ssh_key_id(public_key: str):
@@ -152,11 +169,14 @@ def run_instances(
                 'image': image,
                 'description': 'Created by SkyPilot',
                 'ssh_key_ids': [ssh_key_id],
-                'os_volume': {
+            }
+            if not _is_os_volume_id(image):
+                # Booting from an existing customized OS volume: the volume
+                # already exists, so there is no new one to describe.
+                instance_data['os_volume'] = {
                     'name': f'{cluster_name_on_cloud}-{node_type}',
                     'size': disk_size,
                 }
-            }
             response = verda.instance_create(instance_data)
             instance_id = response.instance_id
         except Exception as e:  # pylint: disable=broad-except

--- a/tests/unit_tests/test_verda.py
+++ b/tests/unit_tests/test_verda.py
@@ -12,6 +12,8 @@ from sky.adaptors.verda import Instance
 from sky.adaptors.verda import InstanceStatus
 from sky.adaptors.verda import VerdaClient
 from sky.clouds import verda
+from sky.provision import common as provision_common
+from sky.provision.verda import instance as verda_instance
 
 
 def test_verda_cloud_basics():
@@ -310,3 +312,67 @@ class TestVerdaClientInstanceCreation:
             client.instance_create({})
 
         assert "Can't connect to Verda Cloud" in str(exc_info.value)
+
+
+class TestRunInstancesOsVolume:
+    """`os_volume` must only be sent when `image` is an OS image type."""
+
+    def _run(self, monkeypatch, image_id: str) -> dict:
+        created = []
+
+        def instances_get():
+            if not created:
+                return []
+            inst = MagicMock()
+            inst.instance_id = 'inst-1'
+            inst.hostname = 'sky-abc-head'
+            inst.status = InstanceStatus.RUNNING
+            return [inst]
+
+        def instance_create(payload):
+            created.append(payload)
+            response = MagicMock()
+            response.instance_id = 'inst-1'
+            return response
+
+        ssh_key = MagicMock()
+        ssh_key.public_key = 'ssh-ed25519 AAAA test'
+        ssh_key.id = 'key-1'
+        client = MagicMock()
+        client.instances_get.side_effect = instances_get
+        client.instance_create.side_effect = instance_create
+        client.ssh_keys_get.return_value = [ssh_key]
+        monkeypatch.setattr(verda_instance, 'verda', client)
+        monkeypatch.setattr(verda_instance.time, 'sleep', lambda _: None)
+
+        config = provision_common.ProvisionConfig(
+            provider_config={'zones': None},
+            authentication_config={},
+            docker_config={},
+            node_config={
+                'InstanceType': '1A100.22V',
+                'DiskSize': 100,
+                'ImageId': image_id,
+                'PublicKey': 'ssh-ed25519 AAAA test',
+            },
+            count=1,
+            tags={},
+            resume_stopped_nodes=False,
+            ports_to_open_on_launch=None,
+        )
+        record = verda_instance.run_instances('FIN-01', 'sky-abc', 'sky-abc',
+                                              config)
+        assert record.created_instance_ids == ['inst-1']
+        assert len(created) == 1
+        return created[0]
+
+    def test_image_type_sends_os_volume(self, monkeypatch):
+        payload = self._run(monkeypatch, 'ubuntu-24.04-cuda-12.8-open-docker')
+        assert payload['image'] == 'ubuntu-24.04-cuda-12.8-open-docker'
+        assert payload['os_volume'] == {'name': 'sky-abc-head', 'size': 100}
+
+    def test_os_volume_id_omits_os_volume(self, monkeypatch):
+        volume_id = '0b1e7c3a-5d2f-4e8a-9c6b-1f2a3b4c5d6e'
+        payload = self._run(monkeypatch, volume_id)
+        assert payload['image'] == volume_id
+        assert 'os_volume' not in payload


### PR DESCRIPTION
Fixes #10481.

**What was wrong.** On Verda, `image_id: <customized-os-volume-uuid>` can never provision. Every launch fails with

```
ResourcesUnavailableError: Failed to provision all possible launchable resources
```

and only `provision.log` shows the real cause:

```
W instance.py:188] API error during instance launch: error code: not_found
                    message: Operating system or volume not found `<uuid>`
```

**Root cause.** `run_instances()` in `sky/provision/verda/instance.py` always put `os_volume: {name, size}` in the `POST /instances` body. Verda's API reference (`https://api.verda.com/v1/docs`, `POST /instances`) documents `image` as either "OS image type" or "Previously customized OS volume ID", and `os_volume` as "Newly created OS volume name and size (in GB). Use when `image` property is an OS image type." Sending `os_volume` next to a volume UUID is rejected with `not_found`. The reporter verified against the API that the identical body without `os_volume` succeeds and boots from the volume.

**The fix.** Add `_is_os_volume_id()` (a `uuid.UUID()` parse; image-type slugs such as `ubuntu-24.04-cuda-12.8-open-docker` are never UUID-shaped) and only add `os_volume` to the request when the image is an image type. Nothing else in the request changes.

Not included here, deliberately: reclassifying `not_found` / `invalid_request` API errors as a provisioning error instead of `ResourcesUnavailableError` (second half of the issue). That touches the failover semantics for every Verda error path and deserves its own change.

Tested (run the relevant ones):

- [x] Code formatting: `yapf` + `isort` on both files; `mypy --python-version 3.12 sky/provision/verda/instance.py` clean; `pylint` reports nothing on the new code (remaining messages are pre-existing lines of `test_verda.py`)
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

New tests in `tests/unit_tests/test_verda.py` (`TestRunInstancesOsVolume`), driving `run_instances()` end to end with the module-level `VerdaClient` replaced by a mock that records the `instance_create` payload:

- `test_image_type_sends_os_volume`: image type slug -> payload has `os_volume == {'name': 'sky-abc-head', 'size': 100}` (unchanged behaviour).
- `test_os_volume_id_omits_os_volume`: UUID image -> payload has no `os_volume` key. Fails on `master` (`AssertionError: assert 'os_volume' not in {...}`), passes with this change.

```
pytest tests/unit_tests/test_verda.py -n 0
# master: 10 tests, 1 failed (the new UUID test)
# this branch: 10 passed
```

I do not have a Verda account, so this is verified at the unit-test level against the documented API contract and the reporter's direct API comparison (CPU only, no GPU). @shreymodi1 offered to send this change on the issue; happy to close this in favour of theirs if they'd rather land it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10660" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->