### PR TITLE
[Jobs] Surface who requested a cancellation in the job's details

### DIFF
--- a/sky/dashboard/src/data/connectors/jobs.jsx
+++ b/sky/dashboard/src/data/connectors/jobs.jsx
@@ -17,14 +17,19 @@ import { trackJobAction } from '@/lib/analytics';
 import { applyEnhancements } from '@/plugins/dataEnhancement';
 
 /**
- * Tooltip for a job's status badge: pending reason for PENDING jobs, and
- * the failure details (which carry the failure attribution and exit code,
+ * Tooltip for a job's status badge: pending reason for PENDING jobs, the
+ * failure details (which carry the failure attribution and exit code,
  * e.g. "Job exited with exit code 7 (user program failure). ...") for
- * FAILED* jobs. Same text as the details column, surfaced on hover.
+ * FAILED* jobs, and who requested the cancellation (e.g. "Cancellation
+ * requested by user alice (request ID: ...)") for CANCELLING/CANCELLED
+ * jobs. Same text as the details column, surfaced on hover.
  */
 function getStatusTooltip(job) {
   if (job.status === 'PENDING' || job.status?.startsWith('FAILED')) {
     return job.details || job.failure_reason || null;
+  }
+  if (job.status === 'CANCELLING' || job.status === 'CANCELLED') {
+    return job.details || null;
   }
   return null;
 }

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -4121,6 +4121,52 @@ def _get_latest_event_reasons(
     return result
 
 
+# Prefix of the CANCELLING job-event reason written when a cancellation is
+# requested, naming who asked and under which API request (see
+# utils.CancelRequestInfo.event_reason):
+#   'Cancellation requested by user alice (request ID: 9b6e6396-...)'
+# The controller writes its own generic CANCELLING event ('Job is cancelling')
+# once it acts on the request, so the queue looks the attributed event up by
+# this prefix rather than taking the latest CANCELLING reason.
+CANCEL_REQUESTED_EVENT_REASON_PREFIX = 'Cancellation requested'
+
+
+def get_cancel_request_reasons(job_ids: List[int]) -> Dict[int, str]:
+    """Return {job_id: reason} naming who requested each job's cancellation.
+
+    The reason is the *first* CANCELLING event whose text starts with
+    ``CANCEL_REQUESTED_EVENT_REASON_PREFIX``, e.g. 'Cancellation requested by
+    user alice (request ID: ...)': the request that caused the cancellation.
+    A later request (e.g. a fleet-wide ``sky jobs cancel --all --all-users``
+    arriving while the job was already CANCELLING) is also recorded in the
+    event log but did not cancel the job. A job cancelled without an
+    attributed request (an old controller, or a controller-internal cancel
+    such as a job group tearing down its auxiliary jobs) has no entry. One
+    batched query so the queue stays off the per-job path.
+    """
+    result: Dict[int, str] = {}
+    if not job_ids:
+        return result
+    engine = _db_manager.get_engine()
+    with orm.Session(engine) as session:
+        rows = session.execute(
+            sqlalchemy.select(
+                job_events_table.c.spot_job_id,
+                job_events_table.c.reason,
+            ).where(
+                job_events_table.c.new_status ==
+                ManagedJobStatus.CANCELLING.value,
+                job_events_table.c.spot_job_id.in_(job_ids),
+                job_events_table.c.reason.like(
+                    f'{CANCEL_REQUESTED_EVENT_REASON_PREFIX}%'),
+            ).order_by(job_events_table.c.timestamp.asc())).fetchall()
+    # rows are oldest-first; keep the first attributed request per job.
+    for spot_job_id, reason in rows:
+        if spot_job_id not in result and reason:
+            result[spot_job_id] = reason
+    return result
+
+
 def get_latest_recovery_and_pending_reasons(
         recovering_job_ids: List[int],
         pending_job_ids: List[int]) -> Tuple[Dict[int, str], Dict[int, str]]:

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -4143,6 +4143,10 @@ def get_cancel_request_reasons(job_ids: List[int]) -> Dict[int, str]:
     attributed request (an old controller, or a controller-internal cancel
     such as a job group tearing down its auxiliary jobs) has no entry. One
     batched query so the queue stays off the per-job path.
+
+    These events are exempt from job-event retention
+    (cleanup_job_events_with_retention_async), so the requester stays with
+    the job for as long as the job record does.
     """
     result: Dict[int, str] = {}
     if not job_ids:
@@ -4198,10 +4202,24 @@ async def cleanup_job_events_with_retention_async(
     cutoff_time = datetime.datetime.now() - datetime.timedelta(
         hours=retention_hours)
 
+    # The attributed cancel-request event ('Cancellation requested by user
+    # ...', see get_cancel_request_reasons) is the record of who cancelled a
+    # job and is surfaced in the job's details for as long as the job itself
+    # is kept, so it is exempt from retention: one small row per cancelled
+    # job. Spelled out NULL-safely, since NOT (a AND b) over a NULL reason
+    # would keep every CANCELLING event with no reason.
+    cancel_prefix = f'{CANCEL_REQUESTED_EVENT_REASON_PREFIX}%'
+    not_cancel_request = sqlalchemy.or_(
+        job_events_table.c.new_status.is_(None),
+        job_events_table.c.new_status != ManagedJobStatus.CANCELLING.value,
+        job_events_table.c.reason.is_(None),
+        sqlalchemy.not_(job_events_table.c.reason.like(cancel_prefix)),
+    )
+
     async with sql_async.AsyncSession(engine) as session:
         result = await session.execute(
             sqlalchemy.delete(job_events_table).where(
-                job_events_table.c.timestamp < cutoff_time))
+                job_events_table.c.timestamp < cutoff_time, not_cancel_request))
         count = result.rowcount
         if count > 0:
             logger.debug(f'Deleted {count} job events older than '

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -1544,10 +1544,14 @@ class CancelRequestInfo:
         who = self.user_name or self.user_hash
         if who is None and self.request_id is None:
             return None
+        # The queue finds this event by its prefix to surface the requester
+        # in the job's `details` (see
+        # managed_job_state.get_cancel_request_reasons).
+        prefix = managed_job_state.CANCEL_REQUESTED_EVENT_REASON_PREFIX
         if who is not None:
-            reason = f'Cancellation requested by user {who}'
+            reason = f'{prefix} by user {who}'
         else:
-            reason = 'Cancellation requested'
+            reason = prefix
         if self.request_id is not None:
             reason += f' (request ID: {self.request_id})'
         return reason
@@ -2924,8 +2928,10 @@ def _format_job_details(*,
                         job: Dict[str, Any],
                         highest_blocking_priority: int,
                         recovery_reason: Optional[str] = None,
-                        pending_reason: Optional[str] = None) -> None:
-    """Add details about schedule state / backoff / recovery / pending."""
+                        pending_reason: Optional[str] = None,
+                        cancel_reason: Optional[str] = None) -> None:
+    """Add details about schedule state / backoff / recovery / pending /
+    who requested a cancellation."""
     state_details = None
     if job['schedule_state'] == 'ALIVE_BACKOFF':
         state_details = 'In backoff, waiting for resources'
@@ -2941,6 +2947,15 @@ def _format_job_details(*,
         job['details'] = f'{state_details} - {job["failure_reason"]}'
     elif state_details:
         job['details'] = state_details
+    elif cancel_reason:
+        # Surface who asked for the cancellation, and under which API
+        # request, e.g. 'Cancellation requested by user alice (request ID:
+        # ...)', so a CANCELLING/CANCELLED job's row and detail page answer
+        # "who cancelled this?" without opening the event table. Takes
+        # precedence over a failure_reason left from before the cancel (e.g.
+        # the preemption a RECOVERING job was recovering from): the cancel is
+        # why the job ended.
+        job['details'] = cancel_reason
     elif job['failure_reason']:
         job['details'] = f'Failure: {job["failure_reason"]}'
     elif recovery_reason:
@@ -3201,6 +3216,7 @@ def get_managed_job_queue(
     # an extra DB round trip. `job['status']` is already stringified above.
     recovery_reasons: Dict[int, str] = {}
     pending_reasons: Dict[int, str] = {}
+    cancel_reasons: Dict[int, str] = {}
     if not fields or 'details' in fields:
         recovering_job_ids = [
             job['job_id'] for job in jobs if job['status'] ==
@@ -3214,6 +3230,17 @@ def get_managed_job_queue(
         recovery_reasons, pending_reasons = (
             managed_job_state.get_latest_recovery_and_pending_reasons(
                 recovering_job_ids, pending_job_ids))
+        # Who requested the cancellation of each cancelled job (the
+        # attributed CANCELLING event written when the cancel request was
+        # handled), so the requester and request ID are visible in `details`
+        # rather than only in the event table.
+        cancelled_job_ids = list({
+            job['job_id'] for job in jobs if job['status'] in (
+                managed_job_state.ManagedJobStatus.CANCELLING.value,
+                managed_job_state.ManagedJobStatus.CANCELLED.value)
+        })
+        cancel_reasons = managed_job_state.get_cancel_request_reasons(
+            cancelled_job_ids)
 
     for job in jobs:
         if not fields or 'details' in fields:
@@ -3221,7 +3248,8 @@ def get_managed_job_queue(
                 job=job,
                 highest_blocking_priority=highest_blocking_priority,
                 recovery_reason=recovery_reasons.get(job['job_id']),
-                pending_reason=pending_reasons.get(job['job_id']))
+                pending_reason=pending_reasons.get(job['job_id']),
+                cancel_reason=cancel_reasons.get(job['job_id']))
 
         # Derive is_job_group from execution column
         job['is_job_group'] = (

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -2932,6 +2932,19 @@ def _format_job_details(*,
                         cancel_reason: Optional[str] = None) -> None:
     """Add details about schedule state / backoff / recovery / pending /
     who requested a cancellation."""
+    if cancel_reason:
+        # Surface who asked for the cancellation, and under which API
+        # request, e.g. 'Cancellation requested by user alice (request ID:
+        # ...)', so a CANCELLING/CANCELLED job's row and detail page answer
+        # "who cancelled this?" without opening the event table. Checked
+        # first: a job cancelled while in launch backoff or waiting to launch
+        # keeps that schedule state until the controller finishes cleaning
+        # up, and a job cancelled while recovering keeps the failure_reason
+        # of the preemption it was recovering from. Neither is why the job
+        # is ending; the cancel is.
+        job['details'] = cancel_reason
+        return
+
     state_details = None
     if job['schedule_state'] == 'ALIVE_BACKOFF':
         state_details = 'In backoff, waiting for resources'
@@ -2947,15 +2960,6 @@ def _format_job_details(*,
         job['details'] = f'{state_details} - {job["failure_reason"]}'
     elif state_details:
         job['details'] = state_details
-    elif cancel_reason:
-        # Surface who asked for the cancellation, and under which API
-        # request, e.g. 'Cancellation requested by user alice (request ID:
-        # ...)', so a CANCELLING/CANCELLED job's row and detail page answer
-        # "who cancelled this?" without opening the event table. Takes
-        # precedence over a failure_reason left from before the cancel (e.g.
-        # the preemption a RECOVERING job was recovering from): the cancel is
-        # why the job ended.
-        job['details'] = cancel_reason
     elif job['failure_reason']:
         job['details'] = f'Failure: {job["failure_reason"]}'
     elif recovery_reason:

--- a/tests/unit_tests/test_sky/jobs/test_jobs_state.py
+++ b/tests/unit_tests/test_sky/jobs/test_jobs_state.py
@@ -870,6 +870,70 @@ class TestGetLatestRecoveryReasons:
         assert state.get_latest_recovery_and_pending_reasons([1], [])[0] == {}
 
 
+class TestGetLatestCancelRequestReasons:
+    """Who-requested-the-cancel lookup for the `details` column."""
+
+    def test_empty_job_ids(self, _mock_managed_jobs_db_conn):
+        assert state.get_cancel_request_reasons([]) == {}
+
+    def test_attributed_request_wins_over_generic_cancelling(
+            self, _mock_managed_jobs_db_conn):
+        early = datetime.datetime(2026, 1, 1, 0, 0, 0)
+        late = datetime.datetime(2026, 1, 1, 0, 5, 0)
+        attributed = ('Cancellation requested by user alice '
+                      '(request ID: 9b6e6396-0000-4000-8000-000000000000)')
+        # The request event is written first; the controller's generic
+        # CANCELLING event lands later and must not shadow it.
+        state.add_job_event(1,
+                            None,
+                            state.ManagedJobStatus.CANCELLING,
+                            attributed,
+                            timestamp=early)
+        state.add_job_event(1,
+                            None,
+                            state.ManagedJobStatus.CANCELLING,
+                            'Job is cancelling',
+                            timestamp=late)
+        state.add_job_event(1,
+                            None,
+                            state.ManagedJobStatus.CANCELLED,
+                            'Job has been cancelled',
+                            timestamp=late)
+        # Job 2 was cancelled without an attributed request (internal cancel).
+        state.add_job_event(2,
+                            None,
+                            state.ManagedJobStatus.CANCELLING,
+                            'Job is cancelling',
+                            timestamp=late)
+        # Job 3 is attributed but not requested.
+        state.add_job_event(3,
+                            None,
+                            state.ManagedJobStatus.CANCELLING,
+                            'Cancellation requested by user bob',
+                            timestamp=late)
+        assert state.get_cancel_request_reasons([1, 2]) == {1: attributed}
+
+    def test_first_attributed_request_wins(self, _mock_managed_jobs_db_conn):
+        # alice's targeted cancel caused the cancellation; bob's fleet-wide
+        # cancel arrived while the job was already CANCELLING and is in the
+        # event log but is not why the job ended.
+        early = datetime.datetime(2026, 1, 1, 0, 0, 0)
+        late = datetime.datetime(2026, 1, 1, 0, 5, 0)
+        state.add_job_event(1,
+                            None,
+                            state.ManagedJobStatus.CANCELLING,
+                            'Cancellation requested by user alice',
+                            timestamp=early)
+        state.add_job_event(1,
+                            None,
+                            state.ManagedJobStatus.CANCELLING,
+                            'Cancellation requested by user bob',
+                            timestamp=late)
+        assert state.get_cancel_request_reasons([1]) == {
+            1: 'Cancellation requested by user alice'
+        }
+
+
 class TestSetRecoveringEventReason:
     """Reason/code selection for the RECOVERING event in set_recovering_async.
 

--- a/tests/unit_tests/test_sky/jobs/test_jobs_state.py
+++ b/tests/unit_tests/test_sky/jobs/test_jobs_state.py
@@ -934,6 +934,64 @@ class TestGetLatestCancelRequestReasons:
         }
 
 
+class TestJobEventRetentionKeepsCancelRequests:
+    """The attributed cancel-request event outlives job-event retention."""
+
+    @pytest.mark.asyncio
+    async def test_cancel_request_event_survives_cleanup(
+            self, _mock_managed_jobs_db_conn):
+        old = datetime.datetime.now() - datetime.timedelta(days=60)
+        recent = datetime.datetime.now()
+        attributed = ('Cancellation requested by user alice '
+                      '(request ID: 9b6e6396-0000-4000-8000-000000000000)')
+        state.add_job_event(1,
+                            None,
+                            state.ManagedJobStatus.CANCELLING,
+                            attributed,
+                            timestamp=old)
+        # Everything else past the cutoff goes, including the controller's
+        # generic CANCELLING event, a CANCELLING event with no reason at all,
+        # and the terminal CANCELLED event.
+        state.add_job_event(1,
+                            None,
+                            state.ManagedJobStatus.CANCELLING,
+                            'Job is cancelling',
+                            timestamp=old)
+        state.add_job_event(1,
+                            None,
+                            state.ManagedJobStatus.CANCELLING,
+                            None,
+                            timestamp=old)
+        state.add_job_event(1,
+                            None,
+                            state.ManagedJobStatus.CANCELLED,
+                            'Job has been cancelled',
+                            timestamp=old)
+        state.add_job_event(2,
+                            0,
+                            state.ManagedJobStatus.RUNNING,
+                            'Job has started',
+                            timestamp=old)
+        state.add_job_event(3,
+                            0,
+                            state.ManagedJobStatus.RUNNING,
+                            'Job has started',
+                            timestamp=recent)
+
+        await state.cleanup_job_events_with_retention_async(30 * 24)
+
+        remaining = sorted(
+            (e['spot_job_id'], e['new_status'].value, e['reason'])
+            for job_id in (1, 2, 3)
+            for e in state.get_job_events(job_id))
+        assert remaining == [
+            (1, 'CANCELLING', attributed),
+            (3, 'RUNNING', 'Job has started'),
+        ]
+        # And the requester is still what the queue surfaces.
+        assert state.get_cancel_request_reasons([1]) == {1: attributed}
+
+
 class TestSetRecoveringEventReason:
     """Reason/code selection for the RECOVERING event in set_recovering_async.
 

--- a/tests/unit_tests/test_sky/jobs/test_utils.py
+++ b/tests/unit_tests/test_sky/jobs/test_utils.py
@@ -1099,6 +1099,7 @@ class TestFormatJobDetails:
                  status='RECOVERING',
                  recovery_reason=None,
                  pending_reason=None,
+                 cancel_reason=None,
                  cloud=None):
         job = {
             'schedule_state': schedule_state,
@@ -1109,8 +1110,35 @@ class TestFormatJobDetails:
         jobs_utils._format_job_details(job=job,
                                        highest_blocking_priority=0,
                                        recovery_reason=recovery_reason,
-                                       pending_reason=pending_reason)
+                                       pending_reason=pending_reason,
+                                       cancel_reason=cancel_reason)
         return job['details']
+
+    def test_cancel_reason_surfaced(self):
+        # Who asked for the cancellation shows in the details column verbatim.
+        reason = ('Cancellation requested by user alice '
+                  '(request ID: 9b6e6396-0000-4000-8000-000000000000)')
+        assert self._details(status='CANCELLED',
+                             schedule_state='DONE',
+                             cancel_reason=reason) == reason
+
+    def test_cancel_reason_takes_precedence_over_stale_failure(self):
+        # A job cancelled while recovering keeps the preemption in
+        # failure_reason; the cancel is why it ended, so it wins.
+        assert self._details(
+            status='CANCELLED',
+            schedule_state='DONE',
+            failure_reason='preempted',
+            cancel_reason='Cancellation requested by user alice'
+        ) == 'Cancellation requested by user alice'
+
+    def test_no_cancel_reason_falls_through(self):
+        # An unattributed cancel (old controller, internal cancel) keeps the
+        # existing behaviour.
+        assert self._details(status='CANCELLED',
+                             schedule_state='DONE',
+                             failure_reason='boom') == 'Failure: boom'
+        assert self._details(status='CANCELLED', schedule_state='DONE') is None
 
     def test_recovery_reason_surfaced(self):
         assert self._details(

--- a/tests/unit_tests/test_sky/jobs/test_utils.py
+++ b/tests/unit_tests/test_sky/jobs/test_utils.py
@@ -1132,6 +1132,25 @@ class TestFormatJobDetails:
             cancel_reason='Cancellation requested by user alice'
         ) == 'Cancellation requested by user alice'
 
+    def test_cancel_reason_beats_stale_schedule_state(self):
+        # A job cancelled while in launch backoff or waiting to launch keeps
+        # that schedule state until cleanup marks it DONE; the requester must
+        # show through, not the stale scheduling message.
+        reason = 'Cancellation requested by user alice'
+        for schedule_state in ('ALIVE_BACKOFF', 'ALIVE_WAITING', 'WAITING'):
+            assert self._details(status='CANCELLING',
+                                 schedule_state=schedule_state,
+                                 cancel_reason=reason) == reason
+            assert self._details(status='CANCELLING',
+                                 schedule_state=schedule_state,
+                                 failure_reason='no capacity',
+                                 cancel_reason=reason) == reason
+
+    def test_schedule_state_still_shown_without_cancel_reason(self):
+        # Unchanged for jobs that are not being cancelled.
+        assert self._details(status='PENDING', schedule_state='ALIVE_BACKOFF'
+                            ) == 'In backoff, waiting for resources'
+
     def test_no_cancel_reason_falls_through(self):
         # An unattributed cancel (old controller, internal cancel) keeps the
         # existing behaviour.


### PR DESCRIPTION
## Summary
<img width="1207" height="805" alt="Screenshot 2026-09-04 at 5 47 26 PM" src="https://github.com/user-attachments/assets/fddef3b2-b239-4df0-aa13-90992925a1d8" />

A cancelled managed job's event log records who asked for the cancellation and under which API request (`Cancellation requested by user alice (request ID: ...)`, from #10619), but that row is only visible in the event table. The job's `details` said nothing for a CANCELLING or CANCELLED job, so answering "who cancelled this job?" meant opening the events of every job.

This PR surfaces the attributed cancel request as the job's `details`:

- `sky jobs queue -v` DETAILS column
- the Details section of the dashboard job page and the Details column of the jobs table
- the dashboard status-badge tooltip for CANCELLING / CANCELLED jobs (same treatment PENDING and FAILED* already get)

## Design

- `state.get_cancel_request_reasons(job_ids)`: one batched query for the attributed CANCELLING events (found by the `Cancellation requested` prefix, now a shared constant), scoped to the CANCELLING/CANCELLED jobs of the page, alongside the existing recovery/pending reason lookup.
- **First attributed request wins.** A later request (e.g. `sky jobs cancel --all --all-users` arriving while the job was already CANCELLING) is still in the event log but did not end the job.
- The cancel reason takes precedence over a `failure_reason` left from before the cancel (e.g. the preemption a RECOVERING job was recovering from): the cancel is why the job ended.
- A job cancelled without an attributed request (old controller, controller-internal cancel such as a job group tearing down auxiliary jobs) keeps the existing behaviour.
- The cancel reason is checked before the scheduling state, so a job cancelled while in launch backoff or waiting to launch shows the requester rather than the stale scheduling message until cleanup finishes.
- The attributed cancel-request event is exempt from job-event retention (30 days by default), so the requester stays with the job for as long as the job record does. One small row per cancelled job; every other event is still cleaned up.

## Testing

- New unit tests: `TestFormatJobDetails` (cancel reason surfaced, precedence over stale failure, fall-through) and `TestGetCancelRequestReasons` (attributed event wins over the controller's generic `Job is cancelling`, first request wins, unattributed jobs absent).
- `pytest tests/unit_tests/test_sky/jobs/test_utils.py -k FormatJobDetails`, `test_jobs_state.py`, `test_cancel_events.py`: all pass.
- `format.sh`: yapf/isort clean, pylint 10.00/10, mypy clean, dashboard ESLint clean.
- Manual, local API server in consolidation mode: launched two managed jobs, cancelled one by ID as one user and the rest with `--all --all-users` as another. `sky jobs queue -v` and the dashboard job page show `Cancellation requested by user lloyd (request ID: ccfad62a-...)` for the first and `... by user alice (request ID: bf5981bf-...)` for the second; the status badge tooltip shows the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10661" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
