### PR TITLE
[Azure] Pass typed models to storage account and blob container create calls

### DIFF
--- a/sky/adaptors/azure.py
+++ b/sky/adaptors/azure.py
@@ -78,6 +78,9 @@ def azure_mgmt_models(name: str):
     elif name == 'network':
         from azure.mgmt.network import models
         return models
+    elif name == 'storage':
+        from azure.mgmt.storage import models
+        return models
 
 
 # We should keep the order of the decorators having 'lru_cache' followed

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -3523,25 +3523,28 @@ class AzureBlobStore(AbstractStore):
                 created already exists or fails to assign role to the create
                 storage account.
         """
+        # Use typed models instead of a raw dict: the dict shape relies on
+        # msrest (azure-mgmt-storage <= 24.x) remapping the top-level
+        # 'encryption' key to 'properties.encryption'. The TypeSpec-based
+        # serializer in azure-mgmt-storage >= 25.0.0 serializes dicts
+        # verbatim, and ARM rejects the malformed body. Typed models
+        # serialize correctly under both. See #9775.
+        storage_models = azure.azure_mgmt_models('storage')
         try:
             creation_response = (
                 self.storage_client.storage_accounts.begin_create(
-                    resource_group_name, storage_account_name, {
-                        'sku': {
-                            'name': 'Standard_GRS'
-                        },
-                        'kind': 'StorageV2',
-                        'location': self.region,
-                        'encryption': {
-                            'services': {
-                                'blob': {
-                                    'key_type': 'Account',
-                                    'enabled': True
-                                }
-                            },
-                            'key_source': 'Microsoft.Storage'
-                        },
-                    }).result())
+                    resource_group_name, storage_account_name,
+                    storage_models.StorageAccountCreateParameters(
+                        sku=storage_models.Sku(name='Standard_GRS'),
+                        kind='StorageV2',
+                        location=self.region,
+                        encryption=storage_models.Encryption(
+                            services=storage_models.EncryptionServices(
+                                blob=storage_models.EncryptionService(
+                                    key_type='Account', enabled=True)),
+                            key_source='Microsoft.Storage',
+                        ),
+                    )).result())
         except azure.exceptions().ResourceExistsError as error:
             with ux_utils.print_exception_no_traceback():
                 raise exceptions.StorageBucketCreateError(
@@ -3909,7 +3912,8 @@ class AzureBlobStore(AbstractStore):
                 self.resource_group_name,
                 self.storage_account_name,
                 container_name,
-                blob_container={})
+                blob_container=azure.azure_mgmt_models(
+                    'storage').BlobContainer())
             logger.info(f'  {colorama.Style.DIM}Created AZ Container '
                         f'{container_name!r} in {self.region!r} under storage '
                         f'account {self.storage_account_name!r}.'


### PR DESCRIPTION
Fixes #9775.

## Summary

Implements the fix proposed in the issue: `_create_storage_account` now passes a typed `StorageAccountCreateParameters` (with `Sku`/`Encryption`/`EncryptionServices`/`EncryptionService`) instead of a hand-built dict.

The dict only worked on azure-mgmt-storage <= 24.x because msrest's `_attribute_map` silently remapped the top-level `encryption` key to `properties.encryption` on the wire. The TypeSpec-based `_model_base` in 25.0.0 serializes dicts verbatim (`json.dumps(parameters, cls=SdkJSONEncoder)`), so ARM rejects the malformed body with `InvalidRequestContent`. Typed models produce the correct body under both serializers, which unblocks removing the `<25.0.0` pin from #9774 as a follow-up.

Per the issue's audit note, the same file's `blob_containers.create(..., blob_container={})` is also switched to a typed `BlobContainer()` — harmless today (empty dict), but the same latent pattern.

Plumbing: `sky/adaptors/azure.azure_mgmt_models` gains a `'storage'` branch alongside the existing `'compute'`/`'network'`, keeping the lazy-import discipline (models are only imported inside the storage codepath).

## Tested

- `python -m py_compile` on both files; ruff clean on the touched lines.
- Model construction verified against both azure-mgmt-storage 24.x (msrest models) and 25.0.0 (TypeSpec models) — the class names and constructor kwargs used here exist with identical signatures in both.
- No behavioral change intended for <= 24.x users: the typed model serializes to the same request body the old dict produced after msrest remapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10662" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->