### PR TITLE
[Core] Validate persisted Skylet tunnel process identity

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1957,9 +1957,27 @@ class RetryingVmProvisioner(object):
 class SSHTunnelInfo:
     port: int
     pid: int
+    started_at: Optional[float] = None
+    hostname: Optional[str] = None
+
+    def get_process(self) -> Optional[psutil.Process]:
+        """Return the original local process, never a reused PID."""
+        if self.started_at is None or self.hostname != socket.gethostname():
+            return None
+        try:
+            process = psutil.Process(self.pid)
+            if (process.create_time() == self.started_at and
+                    process.is_running() and
+                    process.status() != psutil.STATUS_ZOMBIE):
+                return process
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            pass
+        return None
 
 
 def _is_tunnel_healthy(tunnel: SSHTunnelInfo) -> bool:
+    if tunnel.get_process() is None:
+        return False
     try:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             s.settimeout(0.5)
@@ -2444,12 +2462,14 @@ class CloudVmRayResourceHandle(backends.backend.ResourceHandle):
             self.cluster_name)
         if metadata is None:
             return None
-        return SSHTunnelInfo(port=metadata[0], pid=metadata[1])
+        # Legacy (port, pid) records cannot establish process ownership.
+        return SSHTunnelInfo(*metadata)
 
     def _set_skylet_ssh_tunnel(self, tunnel: Optional[SSHTunnelInfo]) -> None:
         global_user_state.set_cluster_skylet_ssh_tunnel_metadata(
             self.cluster_name,
-            (tunnel.port, tunnel.pid) if tunnel is not None else None)
+            (tunnel.port, tunnel.pid, tunnel.started_at,
+             tunnel.hostname) if tunnel is not None else None)
 
     def close_skylet_ssh_tunnel(self) -> None:
         """Terminate the SSH tunnel process and clear its metadata."""
@@ -2577,11 +2597,11 @@ class CloudVmRayResourceHandle(backends.backend.ResourceHandle):
     def _terminate_ssh_tunnel_process(self, tunnel_info: SSHTunnelInfo) -> None:
         """Terminate the SSH tunnel process."""
         try:
-            proc = psutil.Process(tunnel_info.pid)
-            if proc.is_running() and proc.status() != psutil.STATUS_ZOMBIE:
+            proc = tunnel_info.get_process()
+            if proc is not None:
                 logger.debug(
                     f'Terminating SSH tunnel process {tunnel_info.pid}')
-                subprocess_utils.kill_children_processes(proc.pid)
+                subprocess_utils.kill_children_processes(proc)
         except psutil.NoSuchProcess:
             pass
         except Exception as e:  # pylint: disable=broad-except
@@ -2617,7 +2637,10 @@ class CloudVmRayResourceHandle(backends.backend.ResourceHandle):
                     f'{e.error_msg}\n{e.detailed_reason}')
                 continue
             tunnel_info = SSHTunnelInfo(port=local_port,
-                                        pid=ssh_tunnel_proc.pid)
+                                        pid=ssh_tunnel_proc.pid,
+                                        started_at=psutil.Process(
+                                            ssh_tunnel_proc.pid).create_time(),
+                                        hostname=socket.gethostname())
             break
 
         try:

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -1843,7 +1843,9 @@ def set_cluster_storage_mounts_metadata(
 
 @metrics_lib.time_me
 def get_cluster_skylet_ssh_tunnel_metadata(
-        cluster_name: str) -> Optional[Tuple[int, int]]:
+    cluster_name: str
+) -> Optional[Union[Tuple[int, int], Tuple[int, int, Optional[float],
+                                           Optional[str]]]]:
     engine = _db_manager.get_engine()
     with orm.Session(engine) as session:
         row = session.query(
@@ -1856,8 +1858,10 @@ def get_cluster_skylet_ssh_tunnel_metadata(
 
 @metrics_lib.time_me
 def set_cluster_skylet_ssh_tunnel_metadata(
-        cluster_name: str,
-        skylet_ssh_tunnel_metadata: Optional[Tuple[int, int]]) -> None:
+    cluster_name: str,
+    skylet_ssh_tunnel_metadata: Optional[Tuple[int, int, Optional[float],
+                                               Optional[str]]]
+) -> None:
     engine = _db_manager.get_engine()
     with orm.Session(engine) as session:
         value = pickle.dumps(

--- a/sky/utils/subprocess_utils.py
+++ b/sky/utils/subprocess_utils.py
@@ -282,7 +282,7 @@ def handle_returncode(returncode: int,
 
 
 def kill_children_processes(parent_pids: Optional[Union[
-    int, List[Optional[int]]]] = None,
+    int, psutil.Process, List[Optional[Union[int, psutil.Process]]]]] = None,
                             force: bool = False) -> None:
     """Kill children processes recursively.
 
@@ -293,14 +293,15 @@ def kill_children_processes(parent_pids: Optional[Union[
        etc. while we are cleaning up the clusters.
 
     Args:
-        parent_pids: Optional PIDs of a series of processes. The processes and
+        parent_pids: Optional PIDs or identity-checked psutil.Process objects.
+          Passing a Process preserves PID-reuse protection. The processes and
           their children will be killed.  If a list of PID is specified, it is
           killed by the order in the list. This is for guaranteeing the order
           of cleaning up and suppress flaky errors.
         force: bool, send SIGKILL if force, otherwise, use SIGTERM for
           gracefully kill the process.
     """
-    if isinstance(parent_pids, int):
+    if isinstance(parent_pids, (int, psutil.Process)):
         parent_pids = [parent_pids]
 
     parent_processes = []
@@ -309,7 +310,8 @@ def kill_children_processes(parent_pids: Optional[Union[
     else:
         for pid in parent_pids:
             try:
-                process = psutil.Process(pid)
+                process = pid if isinstance(
+                    pid, psutil.Process) else psutil.Process(pid)
             except psutil.NoSuchProcess:
                 continue
             parent_processes.append(process)

--- a/tests/unit_tests/test_sky/backends/test_cloud_vm_ray_backend.py
+++ b/tests/unit_tests/test_sky/backends/test_cloud_vm_ray_backend.py
@@ -430,6 +430,7 @@ class TestCloudVmRayBackendGetGrpcChannel:
 
             with patch.object(handle, '_get_skylet_ssh_tunnel', side_effect=mock_get_tunnel_side_effect), \
                 patch.object(handle, '_open_and_update_skylet_tunnel', side_effect=mock_open_tunnel), \
+                patch.object(SSHTunnelInfo, 'get_process', return_value=MagicMock()), \
                 patch('grpc.insecure_channel', side_effect=lambda addr, options: addr), \
                 patch('socket.socket') as mock_socket:
 

--- a/tests/unit_tests/test_sky/backends/test_skylet_tunnel_identity.py
+++ b/tests/unit_tests/test_sky/backends/test_skylet_tunnel_identity.py
@@ -1,0 +1,120 @@
+"""A persisted tunnel must never reuse or terminate an unrelated process."""
+
+import dataclasses
+import socket
+import subprocess
+import sys
+from unittest import mock
+
+import psutil
+import pytest
+
+from sky import global_user_state
+from sky.backends import cloud_vm_ray_backend as backend
+from sky.utils import subprocess_utils
+
+
+@pytest.fixture
+def listener():
+    process = subprocess.Popen([
+        sys.executable, '-u', '-c', 'import socket, time; s = socket.socket(); '
+        's.bind(("127.0.0.1", 0)); s.listen(); '
+        'print(s.getsockname()[1], flush=True); time.sleep(60)'
+    ],
+                               stdout=subprocess.PIPE,
+                               text=True,
+                               start_new_session=True)
+    try:
+        port = int(process.stdout.readline())
+        tunnel = backend.SSHTunnelInfo(
+            port, process.pid,
+            psutil.Process(process.pid).create_time(), socket.gethostname())
+        yield process, tunnel
+    finally:
+        if process.poll() is None:
+            process.terminate()
+        process.wait(timeout=5)
+        process.stdout.close()
+
+
+@pytest.fixture
+def handle():
+    resource_handle = object.__new__(backend.CloudVmRayResourceHandle)
+    resource_handle.cluster_name = 'tunnel-identity-test'
+    return resource_handle
+
+
+@pytest.mark.parametrize('record', ['legacy', 'reused_pid', 'other_host'])
+def test_unrelated_listener_is_neither_reused_nor_killed(
+        listener, handle, record):
+    process, tunnel = listener
+    if record == 'legacy':
+        tunnel = backend.SSHTunnelInfo(tunnel.port, tunnel.pid)
+    elif record == 'reused_pid':
+        tunnel = dataclasses.replace(tunnel, started_at=tunnel.started_at - 1)
+    else:
+        tunnel = dataclasses.replace(tunnel, hostname='another-api-server')
+
+    with mock.patch.object(socket, 'socket') as connect:
+        assert not backend._is_tunnel_healthy(tunnel)
+        connect.assert_not_called()
+    handle._terminate_ssh_tunnel_process(tunnel)
+    assert process.poll() is None
+
+
+def test_owned_listener_is_reused_and_terminated(listener, handle):
+    process, tunnel = listener
+    assert backend._is_tunnel_healthy(tunnel)
+    with mock.patch.object(handle, '_get_skylet_ssh_tunnel', return_value=tunnel), \
+         mock.patch.object(handle, '_open_and_update_skylet_tunnel') as open_tunnel, \
+         mock.patch.object(backend.grpc, 'insecure_channel') as channel:
+        assert handle.get_grpc_channel() is channel.return_value
+        open_tunnel.assert_not_called()
+    handle._terminate_ssh_tunnel_process(tunnel)
+    assert process.poll() is not None
+    assert not backend._is_tunnel_healthy(tunnel)
+
+
+def test_metadata_preserves_identity_and_reads_legacy_records(listener, handle):
+    _, tunnel = listener
+    with mock.patch.object(global_user_state,
+                           'set_cluster_skylet_ssh_tunnel_metadata') as save:
+        handle._set_skylet_ssh_tunnel(tunnel)
+    metadata = save.call_args.args[1]
+    assert metadata == dataclasses.astuple(tunnel)
+    with mock.patch.object(global_user_state,
+                           'get_cluster_skylet_ssh_tunnel_metadata',
+                           return_value=metadata):
+        assert handle._get_skylet_ssh_tunnel() == tunnel
+    with mock.patch.object(global_user_state,
+                           'get_cluster_skylet_ssh_tunnel_metadata',
+                           return_value=metadata[:2]):
+        assert handle._get_skylet_ssh_tunnel().get_process() is None
+
+
+def test_opened_tunnel_persists_process_identity(listener, handle):
+    process, expected = listener
+    with mock.patch.object(handle, 'get_command_runners', return_value=[mock.Mock()]), \
+         mock.patch.object(backend.random, 'randint', return_value=expected.port), \
+         mock.patch.object(backend.backend_utils, 'open_ssh_tunnel', return_value=process), \
+         mock.patch.object(backend.grpc, 'channel_ready_future'), \
+         mock.patch.object(handle, '_get_skylet_ssh_tunnel', return_value=None), \
+         mock.patch.object(handle, '_set_skylet_ssh_tunnel') as save:
+        assert handle._open_and_update_skylet_tunnel() == expected
+        save.assert_called_once_with(expected)
+
+
+@pytest.mark.parametrize('error', [psutil.NoSuchProcess, psutil.AccessDenied])
+def test_unavailable_process_is_untrusted(listener, error):
+    _, tunnel = listener
+    with mock.patch.object(psutil, 'Process', side_effect=error(tunnel.pid)):
+        assert tunnel.get_process() is None
+
+
+def test_cleanup_preserves_verified_process_object(listener):
+    _, tunnel = listener
+    process = tunnel.get_process()
+    with mock.patch.object(subprocess_utils, '_safe_children', return_value=[]), \
+         mock.patch.object(subprocess_utils, 'kill_process_with_grace_period') as kill:
+        subprocess_utils.kill_children_processes(process)
+        assert kill.call_args.args[0] is process


### PR DESCRIPTION
Persisted Skylet tunnel metadata currently contains only a local port and PID. After a container restart or PID reuse, the PID can refer to an unrelated process. Reopening or closing the tunnel then terminates that process and its children; the port-only health check can also reuse an unrelated listener.

This records the creating host and process creation time, checks both before reuse or teardown, and passes the verified `psutil.Process` through recursive cleanup so PID-reuse protection is preserved. Legacy two-field records are treated as untrusted and rebuilt. This uses the shared backend for all supported cloud/Kubernetes transports, with no provider-specific behavior or database schema migration.

Tested:

- 94 backend, subprocess, serializer and tunnel tests pass, including nine new identity regressions using real disposable listener processes.
- A separate reproduction against unmodified source kills an unrelated disposable process from legacy metadata. Patched source preserves legacy/reused-PID/foreign-host processes and still cleans up the matching owned process.
- `format.sh --files ...` ran with pinned tool versions: formatting completed; the repository-wide mypy stage reports 67 missing dependency/stub errors in the minimal tool environment.
- Checked current master: it still contains the PID-only implementation.

Deployed integration verification: an image containing this change ran 301 simultaneous native managed jobs across Azure and GCP. Busy API Recreate and gRPC OFF→ON preserved all accepted jobs; 13 sampled workers retained their boot ID, computation PID/start time and heartbeat progress. All 23 managed-job controller process identities remained stable within each observed pod lifetime. A real deployed stale-metadata fault preserved an unrelated disposable process and rebuilt the tunnel. Router failures exercised tunnel reconnection. All 301 jobs subsequently cancelled through the native API, with zero owned compute or cluster records remaining.

The historical busy-restart incident's precise causality remains unproven; the disposable-process baseline/treatment establishes the PID reuse defect independently. Integration verification included other controller fixes, so it is not a controlled attribution of that historical incident to this patch alone.
