### PR TITLE
[Serve] Restore autoscaler version when recreating controller

### DIFF
--- a/sky/serve/controller.py
+++ b/sky/serve/controller.py
@@ -54,6 +54,7 @@ class SkyServeController:
                                                     version=version))
         self._autoscaler: autoscalers.Autoscaler = (
             autoscalers.Autoscaler.from_spec(service_name, service_spec))
+        self._autoscaler.latest_version = version
         self._host = host
         self._port = port
         self._app = fastapi.FastAPI(lifespan=self.lifespan)

--- a/tests/unit_tests/test_serve_controller.py
+++ b/tests/unit_tests/test_serve_controller.py
@@ -1,0 +1,32 @@
+"""Tests for SkyServe controller version recovery."""
+from unittest import mock
+
+import pytest
+
+from sky.serve import controller
+from sky.serve import replica_managers
+from sky.serve import serve_state
+from sky.serve import service_spec
+
+
+@pytest.mark.parametrize('version', [1, 2, 7])
+def test_restored_controller_does_not_replace_current_replica(version):
+    spec = service_spec.SkyServiceSpec.from_yaml_config({
+        'readiness_probe': '/healthz',
+        'replicas': 1,
+    })
+    with mock.patch.object(replica_managers, 'SkyPilotReplicaManager'):
+        restored = controller.SkyServeController('test-service', spec, version,
+                                                 '127.0.0.1', 30000)
+
+    ready = mock.Mock(spec=replica_managers.ReplicaInfo)
+    ready.replica_id = 1
+    ready.cluster_name = 'test-service-1'
+    ready.version = version
+    ready.status = serve_state.ReplicaStatus.READY
+    ready.is_ready = True
+    ready.is_terminal = False
+
+    assert restored._autoscaler.latest_version == version
+    assert restored._autoscaler.generate_scaling_decisions([ready],
+                                                           [version]) == []


### PR DESCRIPTION
## Summary

A reconstructed SkyServe controller passes the restored version to the replica manager, but creates an autoscaler whose latest_version defaults to 1. For a service already at version 2 or later, the autoscaler can classify current replicas as outdated while trying to launch a version-1 replacement. The replica manager launches the current version, so the next cycle cancels that provisioning replica and requests another one.

Initialize the autoscaler's version from the controller's restored version. Add regression coverage for initial version 1 and recovered versions 2 and 7, asserting that one current ready replica produces no scaling decisions.

## Tested

- Before the change, recovered versions 2 and 7 fail; version 1 passes.
- After the change, all 7 controller/autoscaler tests pass.
- Changed files pass pinned YAPF 0.32.0 and isort 5.12.0; controller passes mypy 1.19.1 with Python 3.12 and installed SkyPilot dependencies.
- The full format.sh command could not run because its toolchain is not installed; equivalent changed-file formatting was run separately. Full cloud smoke/restart validation remains outstanding.

Manual test: launch a one-replica CPU SkyServe service, perform a rolling update to version 2, then reconstruct its controller with the persisted version and service spec. Confirm the ready replica stays serving and the controller does not alternate cancellation of a provisioning replica with a new scale-up request. Repeat at version 1 to verify ordinary startup.
