### PR TITLE
[Serve] Preserve installed TLS credentials across updates

### DIFF
--- a/sky/serve/server/impl.py
+++ b/sky/serve/server/impl.py
@@ -630,6 +630,14 @@ def update(
                 raise ValueError(f'Failed to parse version: {version_string}; '
                                  f'Returncode: {returncode}') from e
 
+    if not pool:
+        # Recovery must use the installed files, not temporary API upload paths.
+        task.service.tls_credential = (serve_utils.TLSCredential(
+            serve_utils.generate_remote_tls_keyfile_name(service_name),
+            serve_utils.generate_remote_tls_certfile_name(service_name))
+                                       if service_record['tls_encrypted'] else
+                                       None)
+
     with tempfile.NamedTemporaryFile(
             prefix=f'{service_name}-v{current_version}',
             mode='w') as service_file:

--- a/tests/unit_tests/test_serve_update_tls.py
+++ b/tests/unit_tests/test_serve_update_tls.py
@@ -1,0 +1,84 @@
+"""Regression tests for persisted TLS configuration on service updates."""
+import contextlib
+from unittest import mock
+
+import pytest
+
+from sky import backends
+from sky import task as task_lib
+from sky.serve import serve_state
+from sky.serve import serve_utils
+from sky.serve.server import impl
+from sky.utils import yaml_utils
+
+
+@pytest.mark.parametrize('encrypted', [True, False])
+@pytest.mark.parametrize('submitted_tls', [True, False])
+def test_update_preserves_installed_tls(encrypted, submitted_tls):
+    service = {'readiness_probe': '/healthz', 'replicas': 1}
+    if submitted_tls:
+        service['tls'] = {
+            'keyfile': '/tmp/upload/key',
+            'certfile': '/tmp/upload/cert'
+        }
+    task = task_lib.Task.from_yaml_config({
+        'service': service,
+        'resources': {
+            'ports': 8080
+        },
+        'run': 'python app.py'
+    })
+    handle = mock.MagicMock(spec=backends.CloudVmRayResourceHandle)
+    handle.is_grpc_enabled_with_flag = True
+    backend = mock.MagicMock(spec=backends.CloudVmRayBackend)
+    persisted = []
+
+    def capture_yaml(_handle, mounts, storage_mounts):
+        del storage_mounts
+        persisted.append(yaml_utils.read_yaml(next(iter(mounts.values()))))
+
+    backend.sync_file_mounts.side_effect = capture_yaml
+    record = {
+        'status': serve_state.ServiceStatus.READY,
+        'tls_encrypted': encrypted,
+        'load_balancing_policy': task.service.load_balancing_policy
+    }
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(mock.patch.object(task, 'validate'))
+        stack.enter_context(
+            mock.patch.object(impl.serve_utils, 'validate_service_task'))
+        stack.enter_context(
+            mock.patch.object(impl.backend_utils,
+                              'is_controller_accessible',
+                              return_value=handle))
+        stack.enter_context(
+            mock.patch.object(impl.backend_utils,
+                              'get_backend_from_handle',
+                              return_value=backend))
+        stack.enter_context(
+            mock.patch.object(impl, '_get_service_record', return_value=record))
+        stack.enter_context(
+            mock.patch.object(impl.admin_policy_utils,
+                              'apply',
+                              return_value=(mock.Mock(tasks=[task]), None)))
+        stack.enter_context(
+            mock.patch.object(impl.controller_utils,
+                              'maybe_translate_local_file_mounts_and_sync_up'))
+        stack.enter_context(
+            mock.patch.object(impl.serve_rpc_utils.RpcRunner,
+                              'add_version',
+                              return_value=2))
+        stack.enter_context(
+            mock.patch.object(impl.serve_rpc_utils.RpcRunner, 'update_service'))
+        impl.update(task, 'test-service')
+
+    tls = persisted[0]['service'].get('tls')
+    if encrypted:
+        assert tls == {
+            'keyfile':
+                serve_utils.generate_remote_tls_keyfile_name('test-service'),
+            'certfile':
+                serve_utils.generate_remote_tls_certfile_name('test-service'),
+        }
+    else:
+        assert tls is None


### PR DESCRIPTION
## Summary

`serve up` installs TLS credentials at stable service paths, but `serve update` serializes the incoming task's TLS paths into the next version YAML. With API-uploaded files, those paths reference temporary blobs that can be garbage-collected; controller recovery then cannot reload TLS. Omitting TLS on update also removes the persisted TLS configuration despite the running load balancer retaining TLS.

Persist the installed service's stable TLS credential paths on update. Preserve the documented behavior that TLS changes are ignored: a TLS service keeps its installed identity, and a plaintext service stays plaintext even if an update submits credentials. Pool updates are unchanged.

## Tested

- Four serialization regression cases (installed TLS/plaintext × submitted TLS/omitted). Three fail before the fix; all pass afterward.
- New regression and existing `test_serve_impl.py`: 11 passed, using the available isolated runtime with `-o required_plugins='' -o addopts='' --confcutdir=tests/unit_tests`.
- Pinned YAPF 0.32.0 and isort 5.12.0 checks passed; scoped mypy 1.19.1 with skipped external imports passed.
- `format.sh --files` was attempted but its pylint-quotes version check failed because the required version resolved empty; pinned formatters were run directly.

Manual integration test (pending): deploy a TLS service through the API, record its certificate fingerprint, update using the same uploaded TLS files, and verify the new version YAML uses `~/.sky/serve/<service>/tls_keyfile` and `tls_certfile`. Remove expired upload blobs in an isolated test environment and recover its controller; HTTPS must retain the original fingerprint. Repeat with TLS omitted and with credentials submitted to an existing plaintext service; transport must remain unchanged. No image build or shared runtime mutation was performed for this PR.
