### PR TITLE
[Core] Redact docker password when it lives in provider_config

### DIFF
--- a/sky/provision/common.py
+++ b/sky/provision/common.py
@@ -41,6 +41,7 @@ class StopFailoverError(Exception):
 # purposes.
 SENSITIVE_FIELDS: List[Tuple[str, ...]] = [
     ('docker_config', 'docker_login_config', 'password'),
+    ('provider_config', 'docker_login_config', 'password'),
     ('provider_config', 'create_instance_kwargs', 'login'),
     ('provider_config', 'create_instance_kwargs', 'api_key'),
 ]

--- a/tests/unit_tests/test_sky/provision/test_provision_config.py
+++ b/tests/unit_tests/test_sky/provision/test_provision_config.py
@@ -60,3 +60,99 @@ class TestProvisionConfigRedaction:
         assert redacted['docker_config']['image'] == 'ubuntu:latest'
         # Should not create docker_login_config.password if it doesn't exist.
         assert 'docker_login_config' not in redacted['docker_config']
+
+    def test_redact_provider_config_docker_password(self):
+        """Test that a docker password under provider_config is redacted.
+
+        Docker-native clouds (yotta, runpod) put the login in provider_config
+        rather than docker_config, since docker_config is promised not to exist
+        for clouds that hand out containers instead of VMs.
+        """
+        config = common.ProvisionConfig(
+            provider_config={
+                'docker_login_config': {
+                    'username': 'testuser',
+                    'password': 'secret-password-123',
+                    'server': 'docker.io'
+                }
+            },
+            authentication_config={},
+            docker_config={},
+            node_config={},
+            count=1,
+            tags={},
+            resume_stopped_nodes=False,
+            ports_to_open_on_launch=None,
+        )
+
+        redacted = config.get_redacted_config()
+
+        # Verify password is redacted
+        assert redacted['provider_config']['docker_login_config'][
+            'password'] == '<redacted>'
+
+        # Verify other fields are preserved
+        assert redacted['provider_config']['docker_login_config'][
+            'username'] == 'testuser'
+        assert redacted['provider_config']['docker_login_config'][
+            'server'] == 'docker.io'
+
+    def test_redact_docker_password_in_both_locations(self):
+        """Both docker_config and provider_config logins are redacted."""
+        config = common.ProvisionConfig(
+            provider_config={
+                'docker_login_config': {
+                    'username': 'provideruser',
+                    'password': 'provider-secret',
+                    'server': 'docker.io'
+                }
+            },
+            authentication_config={},
+            docker_config={
+                'docker_login_config': {
+                    'username': 'dockeruser',
+                    'password': 'docker-secret',
+                    'server': 'docker.io'
+                }
+            },
+            node_config={},
+            count=1,
+            tags={},
+            resume_stopped_nodes=False,
+            ports_to_open_on_launch=None,
+        )
+
+        redacted = config.get_redacted_config()
+
+        # Both locations are redacted, so adding one entry cannot silently
+        # replace the other.
+        assert redacted['docker_config']['docker_login_config'][
+            'password'] == '<redacted>'
+        assert redacted['provider_config']['docker_login_config'][
+            'password'] == '<redacted>'
+
+        # Verify other fields are preserved
+        assert redacted['docker_config']['docker_login_config'][
+            'username'] == 'dockeruser'
+        assert redacted['provider_config']['docker_login_config'][
+            'username'] == 'provideruser'
+
+    def test_redact_without_provider_docker_config(self):
+        """Test redaction when provider_config has no docker login."""
+        config = common.ProvisionConfig(
+            provider_config={'region': 'us-east-1'},
+            authentication_config={},
+            docker_config={},
+            node_config={},
+            count=1,
+            tags={},
+            resume_stopped_nodes=False,
+            ports_to_open_on_launch=None,
+        )
+
+        redacted = config.get_redacted_config()
+
+        # Should not raise an error even if docker_login_config doesn't exist
+        assert redacted['provider_config']['region'] == 'us-east-1'
+        # Should not create docker_login_config.password if it doesn't exist.
+        assert 'docker_login_config' not in redacted['provider_config']


### PR DESCRIPTION
`get_redacted_config()` masks secrets before the provision config is written to the provisioning log, driven by the static `SENSITIVE_FIELDS` list in `sky/provision/common.py`. It covers `docker_config.docker_login_config.password` but not the same field under `provider_config`:

```python
SENSITIVE_FIELDS: List[Tuple[str, ...]] = [
    ('docker_config', 'docker_login_config', 'password'),
    ('provider_config', 'create_instance_kwargs', 'login'),
    ('provider_config', 'create_instance_kwargs', 'api_key'),
]
```

Docker-native clouds put the login in `provider_config` rather than `docker_config` — `sky/provision/provisioner.py` notes that `docker_config` is promised not to exist for clouds that hand out containers instead of full VMs. Two shipped clouds read it from there:

- `sky/provision/yotta/instance.py:151` — `config.provider_config.get('docker_login_config')`
- `sky/provision/runpod/instance.py:114` — same

So a yotta or runpod launch against a private registry writes the password in cleartext into the file produced by `setup_provision_logging()` — not just a console line.

## Fix

One entry added, next to the existing `docker_config` path. `get_redacted_config` already skips absent fields (`get_nested` returns `None` and the write is guarded), so it is inert for clouds that do not set it and cannot create the key where it was absent.

## Tests

Extends `TestProvisionConfigRedaction` in `tests/unit_tests/test_sky/provision/test_provision_config.py`:

- the `provider_config` location — **fails on master**, passes here;
- both locations set at once — also fails on master — so a future edit cannot replace one entry with the other rather than adding it;
- `provider_config` present with no docker login — no error, and the key is not created.

Before, on master:

```
FAILED tests/unit_tests/test_sky/provision/test_provision_config.py::TestProvisionConfigRedaction::test_redact_provider_config_docker_password - AssertionError: assert 'secret-password-123' == '<redacted>'
FAILED tests/unit_tests/test_sky/provision/test_provision_config.py::TestProvisionConfigRedaction::test_redact_docker_password_in_both_locations - AssertionError: assert 'provider-secret' == '<redacted>'
2 failed, 3 passed, 136 warnings in 2.78s
```

After, on this branch:

```
5 passed, 136 warnings in 2.76s
```

## Notes

Severity is low — it needs debug logging enabled and the log stays on the local machine — and there is no `SECURITY.md` or private disclosure process in the repo, so I've filed it publicly. Happy to move it if you'd prefer otherwise.

Noticed while working on #9632 — I've opened williamsnell/skypilot#1 against that branch with the missing binding. That PR moves Vast's login to `provider_config` and would make it a third affected cloud. This is worth fixing independently of what happens to that PR.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10669" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->