### PR TITLE
[Server] Keep the hook-logs request log that its client reads back

### DIFF
--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -2561,11 +2561,16 @@ async def hook_logs(
     )
     task = executor.execute_request_in_coroutine(request_task)
     background_tasks.add_task(task.cancel)
+    # Keep this request's log. Unlike the other log-tail endpoints, the
+    # client of this one (``sdk.tail_hook_logs``) does not read the body
+    # streamed here -- it re-reads the same log through /api/stream. A log
+    # discarded when this response ends would leave that read with nothing.
     return stream_utils.stream_response_for_long_request(
         request_id=request.state.request_id,
         logs_path=request_task.log_path,
         background_tasks=background_tasks,
         kill_request_on_disconnect=False,
+        discard_log_after_stream=False,
     )
 
 

--- a/tests/unit_tests/test_sky/server/test_server.py
+++ b/tests/unit_tests/test_sky/server/test_server.py
@@ -406,6 +406,76 @@ async def test_prepare_request_passes_auth_user():
 
 
 @pytest.mark.asyncio
+async def test_hook_logs_keeps_its_request_log(tmp_path, monkeypatch):
+    """`/hook_logs` must not discard the request log it streams.
+
+    Its client, ``sky.client.sdk.tail_hook_logs``, does not read the body
+    this endpoint streams -- it re-reads the same log through
+    ``/api/stream``. So a log discarded when the first response ends leaves
+    that second read with nothing, and the hook output never reaches the
+    user.
+
+    ``stream_response_for_long_request`` is deliberately not mocked here: the
+    default it applies is the whole point of the test, so the real streaming
+    and log-discard path has to run. The log is placed where
+    ``log_provider.discard_log`` would look for it (it resolves the path from
+    the request id, not from ``log_path``), otherwise a discard would delete
+    some other file and the assertion below could not fail.
+    """
+    from sky.server.requests import log_provider
+    from sky.server.requests import payloads
+
+    request_id = 'hook-logs-request-id'
+    monkeypatch.setattr(server_constants, 'REQUEST_LOG_PATH_PREFIX',
+                        str(tmp_path))
+    log_path = log_provider.local_log_path(request_id,
+                                           log_provider.RequestLogType.REQUEST)
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.write_text('hook-marker\nEVENT=stop\n')
+
+    request = mock.MagicMock()
+    request.state = mock.MagicMock()
+    request.state.request_id = request_id
+    request.state.auth_user = None
+
+    request_task = mock.MagicMock()
+    request_task.request_id = request_id
+    request_task.log_path = log_path
+
+    hook_logs_body = payloads.HookLogsBody(cluster_name='test-cluster',
+                                           event='stop')
+    background_tasks = fastapi.BackgroundTasks()
+
+    async def _already_started(*args, **kwargs):
+        """The request has left PENDING; yield nothing and return."""
+        return
+        yield ''  # pragma: no cover -- makes this an async generator
+
+    with mock.patch('sky.server.requests.executor.prepare_request_async',
+                    new_callable=mock.AsyncMock,
+                    return_value=request_task), \
+         mock.patch('sky.server.requests.executor.execute_request_in_coroutine'
+                   ) as mock_execute, \
+         mock.patch('sky.server.stream_utils.wait_for_request_to_start',
+                    _already_started), \
+         mock.patch('sky.server.requests.requests.get_request_status_async',
+                    new_callable=mock.AsyncMock, return_value=None):
+        mock_execute.return_value = executor.CoroutineTask(
+            asyncio.create_task(asyncio.sleep(0)))
+
+        response = await server.hook_logs(request, hook_logs_body,
+                                          background_tasks)
+        streamed = ''.join([chunk async for chunk in response.body_iterator])
+
+    # The stream really ran -- without this the check below is vacuous.
+    assert 'hook-marker' in streamed, streamed
+    assert log_path.exists(), (
+        'the /hook_logs request log was discarded when its response ended; '
+        'sky.client.sdk.tail_hook_logs re-reads that log through /api/stream '
+        'and would show the user nothing')
+
+
+@pytest.mark.asyncio
 async def test_launch_endpoint_passes_auth_user():
     """Test that launch endpoint passes auth_user to schedule_request_async."""
     from sky.server.requests import payloads


### PR DESCRIPTION
**Regression introduced by #10657** (`c99a31663`, "[Server] Delete a log tail's request log once its stream ends").

`sky logs --hook <event>` now prints no hook output at all — just:

```
Log <request-id>.log is no longer available on the API server.
```

That line is itself from #10657: it is the `FileNotFoundError` branch that PR added to `_stream_log_file`.

The attribution is a clean bisect — `34c8f09e` is green, `c99a31663` is red, and it is the only commit between them. Every test that reads a hook log through `sky logs --hook` fails at that commit; the hook tests that read the log off the pod directly (`kubectl exec ... cat ~/.sky/hooks/<event>.log`) still pass, which is what narrows it to the log-streaming path rather than to hooks themselves.

### Why it regressed

`/hook_logs` is the one log-tail endpoint whose client does not read the body it streams. `sky.client.sdk.tail_hook_logs` POSTs the endpoint *without* `stream=True`, keeps only the request id, and then reads the same log again through `/api/stream`:

```python
response = server_common.make_authenticated_request(
    'POST', '/hook_logs', json=json.loads(body.model_dump_json()))
request_id = server_common.get_request_id(response)
return stream_and_get(request_id)          # <- second read of the same log
```

Every other client in this family — `sdk.tail_logs`, the managed-jobs and pool log tails, `serve.tail_logs` — passes `stream=True` and consumes the streamed response directly, so for them the discard is correct and is exactly the point of #10657.

Since #10657, `stream_response_for_long_request` defaults `discard_log_after_stream=True`. For `/hook_logs` that deletes the log when the first (unread) response ends, before the client's real read, so `stream_and_get` finds the file gone.

Worth noting that #10657's own docstring states the invariant it relies on — "A request whose own log is the artifact … is not streamed through here: its client reads /api/stream, which never discards." `tail_hook_logs` does *both*, which is the case that was not accounted for.

### Why fix the endpoint and not the client

The client has read the log this way since the endpoint was introduced (added as `/autostop_logs` in `ebedc74ad`, renamed to `/hook_logs` in `4a5de4027`), including in released versions. A released CLI therefore hits the same gap against a newer server and cannot be changed retroactively — so the endpoint has to keep its log. Making `tail_hook_logs` consume the streamed response like its siblings is a worthwhile follow-up that would also drop a duplicated server-side tail, but it cannot replace this fix while older clients are supported.

### Repro

```
pytest tests/smoke_tests/test_lifecycle_hooks.py::test_hook_sky_stop_fires_stop_event_with_env_var --aws
```

Fails at the final step before this change, passes after. `test_hook_lifecycle_combined`, `test_hook_down_and_race` and the backward-compat `test_autostop_hook_compatibility` fail the same way, all on their `sky logs --hook ... --no-follow` assertion.

Verified end to end on one cluster: with the endpoint unchanged, `sky logs <cluster> --hook stop --no-follow` returned only the "no longer available" line; re-reading the same cluster's same hook log with only this change applied returned the hook's marker and `EVENT=stop`. All four tests above now pass on this branch.

### Test

The existing endpoint test mocks `stream_response_for_long_request` outright, so no test below the smoke tier can catch the default changing. The new test drives the real streaming and discard path instead. Two details make it meaningful rather than decorative:

- the request log is written where `log_provider.discard_log` resolves it **from the request id** (not from the `log_path` argument), so a discard really would delete that file and the assertion can fail;
- it also asserts the body actually streamed, so it cannot pass vacuously if the stream stops running.

Removing `discard_log_after_stream=False` from the endpoint makes it fail with:

```
AssertionError: the /hook_logs request log was discarded when its response ended;
sky.client.sdk.tail_hook_logs re-reads that log through /api/stream and would show
the user nothing
```

### Note for reviewers

`discard_log_after_stream` defaults to `True`, so *forgetting* it costs correctness (the user gets nothing) while setting it the other way costs only disk. Inverting that default and opting in at the four call sites whose clients do consume the response would make this class of bug impossible. Happy to do that here or separately — it is a wider change, so this PR keeps to the endpoint that is currently broken.

### Tested

- `pytest tests/unit_tests/test_sky/server/test_server.py::test_hook_logs_keeps_its_request_log` — passes with this change, fails without it
- `pytest tests/smoke_tests/test_lifecycle_hooks.py::test_hook_sky_stop_fires_stop_event_with_env_var --aws`
- `pytest tests/smoke_tests/test_lifecycle_hooks.py::test_hook_lifecycle_combined --aws`
- `pytest tests/smoke_tests/test_lifecycle_hooks.py::test_hook_down_and_race --aws`
- `pytest tests/smoke_tests/backward_compat/test_backward_compat.py::TestBackwardCompatibility::test_autostop_hook_compatibility --aws`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018JekVSCumAMWgWMiXjqz9u
