### PR TITLE
Don't let one unusable apt repository block a runtime install

### DIFF
--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -483,8 +483,13 @@ def get_az_mount_install_cmd() -> str:
         '  echo "blobfuse2 is not supported on $ARCH" && '
         f'  exit {exceptions.ARCH_NOT_SUPPORTED_EXIT_CODE}; '
         'fi && '
-        # Try to install fuse3 from default repos
-        'sudo apt-get update && '
+        # Try to install fuse3 from default repos. `apt-get update` fails as
+        # a whole when any one configured repository is unusable -- an
+        # expired release file on an end-of-life suite, say -- which would
+        # otherwise skip the install below and leave the mount to fail with
+        # a missing blobfuse2. The install is the gate instead.
+        '{ sudo apt-get update || echo "apt-get update failed; continuing '
+        'with the existing package index"; } && '
         'FUSE3_INSTALLED=0 && '
         # Detect which libfuse3 package is available. Debian 13+ (trixie) uses
         # libfuse3-4 instead of libfuse3-3 due to library soname bump.

--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -423,7 +423,14 @@ class DockerInitializer:
             'exec 200>/var/tmp/sky_apt.lock; '
             'flock -x -w 120 200 || exit 1; '
             'export DEBIAN_FRONTEND=noninteractive; '
-            'apt-get -yq update && '
+            # `apt-get update` fails as a whole when any one configured
+            # repository is unusable -- an expired release file on an
+            # end-of-life suite, say -- even though the packages below all
+            # resolve from the suites that did refresh. Keep going and let
+            # the install be what decides: it fails loudly, and with the
+            # name of the package it could not get.
+            '{ apt-get -yq update || echo "apt-get update failed; '
+            'continuing with the existing package index"; } && '
             # Our mount script will install gcsfuse without fuse package.
             # We need to install fuse package first to enable storage mount.
             # The dpkg option is to suppress the prompt for fuse installation.

--- a/tests/unit_tests/test_mounting_utils_apt.py
+++ b/tests/unit_tests/test_mounting_utils_apt.py
@@ -1,0 +1,93 @@
+"""Unit tests for the apt handling in sky.data.mounting_utils."""
+
+import os
+import pathlib
+import subprocess
+import tempfile
+import unittest
+
+from sky.data import mounting_utils
+
+# `apt-get update` exits non-zero when any single configured repository is
+# unusable, and prints why. An end-of-life suite whose release file has
+# expired is the case this stub reproduces: `update` fails, while `install`
+# would still succeed from the suites that did refresh.
+_APT_GET_STUB = """#!/bin/bash
+for arg in "$@"; do
+  case "$arg" in
+    update)
+      echo "E: Release file for http://example/dists/oldstable/InRelease \
+is expired"
+      exit 100
+      ;;
+    install)
+      echo "install called: $*" >> "$STUB_LOG"
+      exit 0
+      ;;
+  esac
+done
+exit 0
+"""
+
+_STUBS = {
+    'apt-get': _APT_GET_STUB,
+    'apt-cache': '#!/bin/bash\necho "libfuse3-3 - stub"\n',
+    # Report x86_64 so the command does not take its arm64 early exit.
+    'uname': '#!/bin/bash\n[ "$1" = "-m" ] && echo x86_64 || echo Linux\n',
+    'sudo': '#!/bin/bash\nexec "$@"\n',
+    # Downloading and unpacking blobfuse2 is not what is under test.
+    'wget': '#!/bin/bash\nexit 0\n',
+    'dpkg': '#!/bin/bash\nexit 0\n',
+    'find': '#!/bin/bash\nexit 0\n',
+}
+
+
+class TestAzMountInstallApt(unittest.TestCase):
+    """A repo the install does not need must not block the install."""
+
+    def _run_with_stubbed_apt(self, cmd: str, tmp: pathlib.Path):
+        """Runs `cmd` with apt stubbed to fail `update` and pass `install`."""
+        stub_dir = tmp / 'bin'
+        stub_dir.mkdir()
+        for name, body in _STUBS.items():
+            path = stub_dir / name
+            path.write_text(body)
+            path.chmod(0o755)
+        log = tmp / 'calls.log'
+        log.touch()
+        env = dict(os.environ)
+        env['PATH'] = os.pathsep.join([str(stub_dir), env.get('PATH', '')])
+        # The command writes a cache dir under $HOME; keep it in the tmp dir.
+        env['HOME'] = str(tmp)
+        env['STUB_LOG'] = str(log)
+        proc = subprocess.run(['bash', '-c', cmd],
+                              env=env,
+                              capture_output=True,
+                              text=True,
+                              timeout=120,
+                              check=False)
+        return proc, log.read_text()
+
+    def test_apt_update_failure_still_reaches_the_install(self):
+        """`apt-get update` failing must not skip installing fuse3.
+
+        The Azure mount installs fuse3 and then blobfuse2. Gating that
+        install on `apt-get update` meant one unusable repository -- an
+        end-of-life suite with an expired release file, say -- skipped the
+        install entirely, and the mount then failed on a blobfuse2 that was
+        never installed. `install` is what decides instead: it fails loudly,
+        naming the package it could not get.
+        """
+        with tempfile.TemporaryDirectory() as raw_tmp:
+            tmp = pathlib.Path(raw_tmp)
+            proc, calls = self._run_with_stubbed_apt(
+                mounting_utils.get_az_mount_install_cmd(), tmp)
+
+        self.assertIn(
+            'install called', calls,
+            f'the install never ran.\nstdout:\n{proc.stdout}\n'
+            f'stderr:\n{proc.stderr}')
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+        # The reason `update` failed still has to reach the log; tolerating
+        # the failure must not mean hiding it.
+        self.assertIn('is expired', proc.stdout)


### PR DESCRIPTION
Two runtime setup commands chain their install onto `apt-get update` with `&&`:

- `sky/provision/docker_utils.py` — the container runtime prerequisites (`rsync`, `curl`, `wget`, `patch`, `openssh-server`, `python3-pip`, `fuse`) for a `--image-id docker:...` launch
- `sky/data/mounting_utils.py` — `fuse3` and then `blobfuse2`, for an Azure bucket mount

`apt-get update` fails as a whole when any *single* configured repository is unusable, so a repository neither install needs is enough to skip the install entirely.

### The concrete trigger

Debian stopped refreshing `bullseye-security`; its final release file carried `Valid-Until: Mon, 07 Sep 2026 21:13:04 UTC` and has now lapsed. Any Debian 11 based image therefore gets

```
E: Release file for http://deb.debian.org/debian-security/dists/bullseye-security/InRelease is expired
```

and `apt-get update` exits 100. The packages themselves are fine — `fuse3`, `libfuse3-3` and `libfuse3-dev` are all in `bullseye/main` at `3.10.3-2`, and nothing in either install needs the security suite — but with `&&` the install never runs:

- a `--image-id docker:<Debian 11 image>` launch fails with `Failed to run docker setup commands` (`return code 100`);
- an Azure mount fails with `Mount failed with exit code 1`, on a `blobfuse2` that was never installed, because `FUSE3_INSTALLED` was never set.

`test_docker_storage_mounts` shows the split cleanly — of its four image params, only the Debian 11 one fails:

| image param | result |
| --- | --- |
| `ubuntu:18.04` | passes |
| `nvidia/cuda:11.8.0-devel-ubuntu18.04` | passes |
| `continuumio/miniconda3:latest` | passes |
| `continuumio/miniconda3:24.1.2-0` (Debian 11) | fails |

### The change

Let the install be what decides, since it is the step that actually needs the packages: it fails loudly and names the package it could not get. The `update` failure is still printed, so a genuinely broken mirror stays visible in the log rather than being silently swallowed. `sky/skylet/providers/command_runner.py` already sequences these two with `;` for the same reason.

Verified on a Debian 11 image with the security suite expired:

```
# before
apt-get -yq update && apt-get install -y ...   -> RC=100, install never ran

# after
{ apt-get -yq update || echo ...; } && apt-get install -y ...
   -> RC=0, 123 packages configured
   -> fuse3 installed from default repos
   -> Setting up blobfuse2 (2.2.0)
   -> blobfuse2 version 2.2.0
   -> public Azure container mounted, findmnt shows the fuse mount, contents list
```

### `Acquire::Check-Valid-Until=false` is not the fix

Worth recording, since it is the obvious first idea: accepting the stale index makes apt *trust* it and then fetch the security-pool versions it pins, which have been removed. That fails too, just later and less clearly:

```
E: Failed to fetch .../python3-setuptools_52.0.0-4+deb11u2_all.deb  404  Not Found
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

### Test

`tests/unit_tests/test_mounting_utils_apt.py` renders the Azure install command and runs it with `apt-get` stubbed to fail `update` and succeed `install`, then asserts the install was still reached and that the reason `update` failed still reaches stdout. No network, no root. Without this change it fails with:

```
AssertionError: 'install called' not found in '' : the install never ran.
```

### Deliberately not changed

The `apt-get update` in the Ubuntu-focal fallback further down `get_az_mount_install_cmd` keeps its `&&`: there the update is what makes the source just written into `sources.list.d` visible, so an install after a failed update could not work anyway.

Separately, `FUSE3_INSTALL_CMD` (used for the rclone mounts) has the same `apt-get update && apt-get install -y fuse3` shape. Its outer `|| true` means an update failure silently *skips* installing fuse3 rather than failing the launch, so the symptom surfaces later as a mount error instead. I have not reproduced that path, so I have left it alone — flagging it in case you would like the same treatment there.

### Tested

- `pytest tests/unit_tests/test_mounting_utils_apt.py` — passes with this change, fails without it
- `pytest tests/unit_tests/test_mounting_utils_arm64.py tests/unit_tests/test_instance_setup_docker.py` — unchanged
- both patched commands run end to end on a Debian 11 image, through `dpkg --install` of blobfuse2 and a real mount of a public Azure container

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018JekVSCumAMWgWMiXjqz9u

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10673" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->