### PR TITLE
[Server] Publish the API server's own local disk footprint on /metrics

### DIFF
--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -196,6 +196,21 @@ spec:
             resourceFieldRef:
               containerName: skypilot-api
               resource: requests.memory
+        {{- $apiResources := default dict .Values.apiService.resources }}
+        {{- if hasKey (default dict $apiResources.limits) "ephemeral-storage" }}
+        - name: SKYPILOT_POD_EPHEMERAL_STORAGE_BYTES_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              containerName: skypilot-api
+              resource: limits.ephemeral-storage
+        {{- end }}
+        {{- if hasKey (default dict $apiResources.requests) "ephemeral-storage" }}
+        - name: SKYPILOT_POD_EPHEMERAL_STORAGE_BYTES_REQUEST
+          valueFrom:
+            resourceFieldRef:
+              containerName: skypilot-api
+              resource: requests.ephemeral-storage
+        {{- end }}
         {{- if not $podIpInExtraEnvs }}
         - name: POD_IP
           valueFrom:

--- a/sky/server/blob/blob_storage.py
+++ b/sky/server/blob/blob_storage.py
@@ -6,7 +6,7 @@ import abc
 import contextlib
 import os
 import pathlib
-from typing import Generator, List, Optional, Tuple
+from typing import Dict, Generator, List, Optional, Tuple
 
 from sky import sky_logging
 from sky.skylet import constants
@@ -118,6 +118,15 @@ class BlobStorage(abc.ABC):
     def download_tmp_dir(self, user_hash: str) -> str:
         """Return a staging directory for log downloads for a user."""
         raise NotImplementedError
+
+    def local_disk_roots(self) -> Dict[str, str]:
+        """Returns {name: path} for directories this backend writes locally.
+
+        Consumed by the server's local-disk accounting, which needs to know
+        which trees on the node's own disk grow with file-mount traffic.
+        Backends that keep everything on shared storage return nothing.
+        """
+        return {}
 
     def download_tmp_base_dir(self) -> Optional[str]:
         """Return the base directory for download tmp cleanup.

--- a/sky/server/blob/local_blob_storage.py
+++ b/sky/server/blob/local_blob_storage.py
@@ -6,7 +6,7 @@ import os
 import pathlib
 import shutil
 import time
-from typing import List, Tuple
+from typing import Dict, List, Tuple
 
 import anyio
 import filelock
@@ -30,6 +30,14 @@ class LocalFilesystemBlobStorage(bs.BlobStorage):
     def download_tmp_base_dir(self):
         # Downloads share the persistent log directory; no separate cleanup.
         return None
+
+    def local_disk_roots(self) -> Dict[str, str]:
+        # Everything this backend writes lives under the clients dir:
+        # extracted file-mount blobs plus per-user download staging.
+        return {
+            'api_server_clients': str(
+                server_common.API_SERVER_CLIENT_DIR.expanduser())
+        }
 
     def blobs_dir(self, user_id: str) -> pathlib.Path:
 

--- a/sky/server/local_disk.py
+++ b/sky/server/local_disk.py
@@ -1,0 +1,291 @@
+"""Accounting for the API server's own local disk use.
+
+The server owns several trees on local disk that grow with traffic rather
+than with configuration: the per-request log files, the request debug logs,
+and whatever the configured blob storage extracts locally for file mounts.
+None of them has a size bound, and nothing inside the process knows how
+large they have grown or how much room is left. The first component to
+notice a filling disk is therefore the platform underneath -- on Kubernetes
+the kubelet, whose only response is to evict the pod, after which the
+evidence is gone.
+
+This module measures those trees and the space left on the filesystems
+holding them, so the growth is visible while there is still time to act.
+
+Measurement only: nothing here refuses, caps or sheds work.
+
+Two notes on matching what the platform sees:
+
+* Sizes are counted in allocated blocks, not apparent size, and hard links
+  are counted once, because that is what ``du`` reports and ``du`` is what
+  the kubelet's ephemeral-storage accounting runs.
+* A file that has been unlinked while a process still holds it open keeps
+  its blocks but is invisible to any directory walk, so a leaked descriptor
+  makes these numbers an undercount.
+"""
+import dataclasses
+import os
+import time
+from typing import Dict, List, Optional, Tuple
+
+from sky import sky_logging
+from sky.server import constants as server_constants
+from sky.server.blob import blob_storage
+from sky.skylet import runtime_utils
+
+logger = sky_logging.init_logger(__name__)
+
+# Downward-API environment variables carrying the container's own
+# ephemeral-storage resource fields, named after the existing
+# SKYPILOT_POD_{CPU_CORE,MEMORY_BYTES}_LIMIT pair. Unset outside
+# Kubernetes, and unset on Kubernetes unless the deployment declares the
+# corresponding resource field -- a resourceFieldRef for an undeclared
+# field resolves to the node's allocatable capacity, which would be
+# reported as a budget this container does not actually have.
+EPHEMERAL_STORAGE_LIMIT_ENV_VAR = 'SKYPILOT_POD_EPHEMERAL_STORAGE_BYTES_LIMIT'
+EPHEMERAL_STORAGE_REQUEST_ENV_VAR = (
+    'SKYPILOT_POD_EPHEMERAL_STORAGE_BYTES_REQUEST')
+
+# Work bounds for one scan of one root. The scan is on the metrics refresh
+# path, so it must finish in bounded time no matter how many files a root
+# has accumulated or how slow the filesystem under it is. Exceeding either
+# bound truncates that root's result and is reported, so a truncated scan
+# is never mistaken for a small one.
+DEFAULT_SCAN_TIMEOUT_SECONDS = 20.0
+DEFAULT_SCAN_MAX_ENTRIES = 2_000_000
+
+# How often the deadline is re-checked while draining a single directory.
+_DEADLINE_CHECK_EVERY = 4096
+
+# Bytes per st_blocks unit, fixed by POSIX regardless of the filesystem's
+# own block size.
+_BLOCK_SIZE = 512
+
+
+@dataclasses.dataclass
+class RootUsage:
+    """Disk used by one named tree the server writes to."""
+    path: str
+    used_bytes: int
+    files: int
+    truncated: bool
+
+
+@dataclasses.dataclass
+class FilesystemUsage:
+    """Space on one filesystem hosting at least one measured root."""
+    mountpoint: str
+    size_bytes: int
+    avail_bytes: int
+
+
+@dataclasses.dataclass
+class Snapshot:
+    """One pass over every root the server owns."""
+    roots: Dict[str, RootUsage]
+    filesystems: Dict[str, FilesystemUsage]
+    budget_bytes: Optional[int]
+    duration_seconds: float
+
+    @property
+    def used_bytes(self) -> int:
+        """Total across the measured roots.
+
+        A lower bound on what the platform attributes to this container:
+        the roots cover what the server writes, not the whole writable
+        layer.
+        """
+        return sum(r.used_bytes for r in self.roots.values())
+
+    @property
+    def headroom_bytes(self) -> Optional[int]:
+        """Room left against ``budget_bytes``, or None without a budget.
+
+        An upper bound, for the reason ``used_bytes`` is a lower one.
+        """
+        if self.budget_bytes is None:
+            return None
+        return max(self.budget_bytes - self.used_bytes, 0)
+
+
+def local_roots() -> Dict[str, str]:
+    """Returns {name: absolute path} for the trees the server writes locally.
+
+    Resolved on every call rather than at import time so SKY_RUNTIME_DIR /
+    HOME are honored the way the owning modules resolve their own paths,
+    and so a blob storage backend installed after import is included.
+
+    Deliberately excludes ``~/sky_logs``: in multi-replica deployments it
+    is on shared storage, where it does not count against this container's
+    local disk and where a directory walk is prohibitively slow. Its
+    filesystem is already reported by the sky_logs retention instruments.
+    """
+    roots = {
+        'request_logs': runtime_utils.expanduser(
+            server_constants.REQUEST_LOG_PATH_PREFIX),
+        'request_debug_logs': sky_logging.DEBUG_LOG_DIR,
+        'catalogs': runtime_utils.get_runtime_dir_path('.sky/catalogs'),
+        'wheels': runtime_utils.get_runtime_dir_path('.sky/wheels'),
+    }
+    # The blob backend knows its own local layout; an implementation that
+    # keeps blobs on shared storage reports nothing here.
+    try:
+        roots.update(blob_storage.get_blob_storage().local_disk_roots())
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f'Could not resolve blob storage local roots: {e}')
+    return roots
+
+
+def budget_bytes() -> Optional[int]:
+    """Returns this container's ephemeral-storage budget, if it has one.
+
+    Prefers the limit, which is the boundary that gets enforced, and falls
+    back to the request, which is what the deployment declared it needs.
+    Returns None when neither is exposed -- there is no way to read the
+    field from the kernel, since ephemeral-storage is not a cgroup
+    controller.
+    """
+    for env_var in (EPHEMERAL_STORAGE_LIMIT_ENV_VAR,
+                    EPHEMERAL_STORAGE_REQUEST_ENV_VAR):
+        raw = os.environ.get(env_var)
+        if not raw:
+            continue
+        try:
+            value = int(float(raw))
+        except ValueError:
+            logger.warning(f'Ignoring unparseable {env_var}={raw!r}')
+            continue
+        if value > 0:
+            return value
+    return None
+
+
+def _entry_bytes(stat_result) -> int:
+    blocks = getattr(stat_result, 'st_blocks', None)
+    if blocks is None:
+        # No block count on this platform; apparent size is the best
+        # available approximation.
+        return stat_result.st_size
+    return blocks * _BLOCK_SIZE
+
+
+def _scan_root(path: str, deadline: float, max_entries: int) -> RootUsage:
+    """Walks *path*, counting allocated blocks and regular files."""
+    used = 0
+    files = 0
+    entries = 0
+    truncated = False
+    # Only inodes with more than one link can be reached twice, so only
+    # those need to be remembered.
+    seen: set = set()
+    try:
+        used += _entry_bytes(os.stat(path))
+    except OSError:
+        return RootUsage(path=path, used_bytes=0, files=0, truncated=False)
+
+    stack: List[str] = [path]
+    while stack:
+        current = stack.pop()
+        try:
+            scandir = os.scandir(current)
+        except OSError as e:
+            logger.debug(f'Skipping {current} while measuring {path}: {e}')
+            continue
+        with scandir:
+            for entry in scandir:
+                entries += 1
+                if entries >= max_entries:
+                    truncated = True
+                    break
+                if (entries % _DEADLINE_CHECK_EVERY == 0 and
+                        time.monotonic() >= deadline):
+                    truncated = True
+                    break
+                try:
+                    stat_result = entry.stat(follow_symlinks=False)
+                    is_dir = entry.is_dir(follow_symlinks=False)
+                except OSError:
+                    # Raced with a GC or a rotation; the bytes are gone.
+                    continue
+                if stat_result.st_nlink > 1:
+                    key = (stat_result.st_dev, stat_result.st_ino)
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                used += _entry_bytes(stat_result)
+                if is_dir:
+                    stack.append(entry.path)
+                else:
+                    files += 1
+        if truncated:
+            break
+    if truncated:
+        logger.info(f'Local disk scan of {path} truncated after '
+                    f'{entries} entries; reported size is a lower bound')
+    return RootUsage(path=path,
+                     used_bytes=used,
+                     files=files,
+                     truncated=truncated)
+
+
+def _mountpoint(path: str) -> Optional[str]:
+    """Returns the mount point of the filesystem holding *path*."""
+    try:
+        device = os.stat(path).st_dev
+    except OSError:
+        return None
+    current = os.path.abspath(path)
+    while True:
+        parent = os.path.dirname(current)
+        if parent == current:
+            return current
+        try:
+            if os.stat(parent).st_dev != device:
+                return current
+        except OSError:
+            return current
+        current = parent
+
+
+def _filesystem_usage(paths: List[str]) -> Dict[str, FilesystemUsage]:
+    """Returns space stats for the distinct filesystems holding *paths*."""
+    out: Dict[str, FilesystemUsage] = {}
+    for path in paths:
+        mountpoint = _mountpoint(path)
+        if mountpoint is None or mountpoint in out:
+            continue
+        try:
+            stats = os.statvfs(mountpoint)
+        except OSError as e:
+            logger.debug(f'Could not statvfs {mountpoint}: {e}')
+            continue
+        out[mountpoint] = FilesystemUsage(
+            mountpoint=mountpoint,
+            size_bytes=stats.f_blocks * stats.f_frsize,
+            # f_bavail, not f_bfree: the space actually available to a
+            # non-root writer, which is what fills up first.
+            avail_bytes=stats.f_bavail * stats.f_frsize)
+    return out
+
+
+def scan(
+    timeout_seconds: float = DEFAULT_SCAN_TIMEOUT_SECONDS,
+    max_entries: int = DEFAULT_SCAN_MAX_ENTRIES,
+) -> Snapshot:
+    """Measures every local root, sharing one deadline across all of them."""
+    started = time.monotonic()
+    deadline = started + timeout_seconds
+    roots: Dict[str, RootUsage] = {}
+    measured: List[Tuple[str, str]] = []
+    for name, path in local_roots().items():
+        if not os.path.isdir(path):
+            # Not in use in this deployment; emitting a 0 would read as a
+            # measured emptiness.
+            continue
+        measured.append((name, path))
+        roots[name] = _scan_root(path, deadline, max_entries)
+    return Snapshot(roots=roots,
+                    filesystems=_filesystem_usage(
+                        [path for _, path in measured]),
+                    budget_bytes=budget_bytes(),
+                    duration_seconds=time.monotonic() - started)

--- a/sky/server/local_disk.py
+++ b/sky/server/local_disk.py
@@ -29,6 +29,7 @@ Three notes on matching what the platform sees:
   charged roots are compared against the budget.
 """
 import dataclasses
+import errno
 import os
 import time
 from typing import Dict, List, Optional, Tuple
@@ -50,6 +51,12 @@ logger = sky_logging.init_logger(__name__)
 EPHEMERAL_STORAGE_LIMIT_ENV_VAR = 'SKYPILOT_POD_EPHEMERAL_STORAGE_BYTES_LIMIT'
 EPHEMERAL_STORAGE_REQUEST_ENV_VAR = (
     'SKYPILOT_POD_EPHEMERAL_STORAGE_BYTES_REQUEST')
+
+# Which resource field a budget came from. Only a limit is enforced: a
+# platform is free to let a container exceed its request, so headroom
+# against a request would reach zero with room to spare.
+BUDGET_SOURCE_LIMIT = 'limit'
+BUDGET_SOURCE_REQUEST = 'request'
 
 # Work bounds for one scan of one root. The scan is on the metrics refresh
 # path, so it must finish in bounded time no matter how many files a root
@@ -77,6 +84,10 @@ class RootUsage:
     used_bytes: int
     files: int
     truncated: bool
+    # Entries the walk could not read for a reason other than the entry
+    # having gone away. Those bytes are missing from used_bytes, so a
+    # non-zero count means the size is a lower bound.
+    unreadable: int = 0
     # Mount point of the filesystem holding this root, so a root can be
     # joined to its entry in Snapshot.filesystems. None if it could not
     # be determined.
@@ -95,11 +106,23 @@ class FilesystemUsage:
 
 
 @dataclasses.dataclass
+class Budget:
+    """The container's declared ephemeral-storage allowance."""
+    total_bytes: int
+    # BUDGET_SOURCE_LIMIT or BUDGET_SOURCE_REQUEST.
+    source: str
+
+    @property
+    def enforced(self) -> bool:
+        return self.source == BUDGET_SOURCE_LIMIT
+
+
+@dataclasses.dataclass
 class Snapshot:
     """One pass over every root the server owns."""
     roots: Dict[str, RootUsage]
     filesystems: Dict[str, FilesystemUsage]
-    budget_bytes: Optional[int]
+    budget: Optional[Budget]
     duration_seconds: float
 
     @property
@@ -126,13 +149,20 @@ class Snapshot:
 
     @property
     def headroom_bytes(self) -> Optional[int]:
-        """Room left against ``budget_bytes``, or None without a budget.
+        """Room left before the budget stops the server writing.
+
+        None unless the budget is an enforced one. Room left against a
+        mere scheduling request is not headroom: the platform allows a
+        container past its request, so the number would reach zero while
+        the disk still has space, and read as imminent death. The exact
+        answer for the boundary that does stop writes is the available
+        space on the filesystem -- see ``filesystems``.
 
         An upper bound, for the reason ``used_bytes`` is a lower one.
         """
-        if self.budget_bytes is None:
+        if self.budget is None or not self.budget.enforced:
             return None
-        return max(self.budget_bytes - self.used_bytes, 0)
+        return max(self.budget.total_bytes - self.used_bytes, 0)
 
 
 def local_roots() -> Dict[str, str]:
@@ -160,20 +190,60 @@ def local_roots() -> Dict[str, str]:
         roots.update(blob_storage.get_blob_storage().local_disk_roots())
     except Exception as e:  # pylint: disable=broad-except
         logger.debug(f'Could not resolve blob storage local roots: {e}')
-    return roots
+    return _drop_nested(roots)
 
 
-def budget_bytes() -> Optional[int]:
-    """Returns this container's ephemeral-storage budget, if it has one.
+def _drop_nested(roots: Dict[str, str]) -> Dict[str, str]:
+    """Drops any root contained in another, keeping the outermost.
+
+    The roots must be disjoint trees. Walking a tree twice would count
+    every byte in it twice, and hard links are only deduplicated within a
+    single root, so an overlap corrupts the total rather than merely
+    duplicating a label. Enforced here so a backend that reports a
+    directory already covered by another root cannot silently inflate the
+    numbers.
+    """
+    normalized = {
+        name: os.path.normpath(os.path.abspath(path))
+        for name, path in roots.items()
+    }
+    kept: Dict[str, str] = {}
+    for name, path in normalized.items():
+        covered_by = None
+        for other_name, other in normalized.items():
+            if other_name == name:
+                continue
+            if path == other:
+                # The same tree under two names: keep whichever came
+                # first, so the choice does not depend on dict order.
+                if other_name in kept:
+                    covered_by = other_name
+                    break
+                continue
+            if path.startswith(other.rstrip(os.sep) + os.sep):
+                covered_by = other_name
+                break
+        if covered_by is not None:
+            logger.debug(f'Not measuring local root {name} at {path} '
+                         f'separately: already covered by {covered_by}')
+            continue
+        kept[name] = path
+    return kept
+
+
+def budget() -> Optional[Budget]:
+    """Returns this container's declared ephemeral-storage allowance.
 
     Prefers the limit, which is the boundary that gets enforced, and falls
-    back to the request, which is what the deployment declared it needs.
-    Returns None when neither is exposed -- there is no way to read the
-    field from the kernel, since ephemeral-storage is not a cgroup
+    back to the request, which is only what the deployment declared it
+    needs. Returns None when neither is exposed -- there is no way to read
+    the field from the kernel, since ephemeral-storage is not a cgroup
     controller.
     """
-    for env_var in (EPHEMERAL_STORAGE_LIMIT_ENV_VAR,
-                    EPHEMERAL_STORAGE_REQUEST_ENV_VAR):
+    for env_var, source in ((EPHEMERAL_STORAGE_LIMIT_ENV_VAR,
+                             BUDGET_SOURCE_LIMIT),
+                            (EPHEMERAL_STORAGE_REQUEST_ENV_VAR,
+                             BUDGET_SOURCE_REQUEST)):
         raw = os.environ.get(env_var)
         if not raw:
             continue
@@ -183,8 +253,13 @@ def budget_bytes() -> Optional[int]:
             logger.warning(f'Ignoring unparseable {env_var}={raw!r}')
             continue
         if value > 0:
-            return value
+            return Budget(total_bytes=value, source=source)
     return None
+
+
+def _count_unreadable(error: OSError) -> int:
+    """Returns 1 if *error* hides bytes from the walk, 0 if it does not."""
+    return 0 if error.errno == errno.ENOENT else 1
 
 
 def _entry_bytes(stat_result) -> int:
@@ -201,14 +276,19 @@ def _scan_root(path: str, deadline: float, max_entries: int) -> RootUsage:
     used = 0
     files = 0
     entries = 0
+    unreadable = 0
     truncated = False
     # Only inodes with more than one link can be reached twice, so only
     # those need to be remembered.
     seen: set = set()
     try:
         used += _entry_bytes(os.stat(path))
-    except OSError:
-        return RootUsage(path=path, used_bytes=0, files=0, truncated=False)
+    except OSError as e:
+        return RootUsage(path=path,
+                         used_bytes=0,
+                         files=0,
+                         truncated=False,
+                         unreadable=_count_unreadable(e))
 
     stack: List[str] = [path]
     while stack:
@@ -221,6 +301,9 @@ def _scan_root(path: str, deadline: float, max_entries: int) -> RootUsage:
         try:
             scandir = os.scandir(current)
         except OSError as e:
+            # A whole subtree missing from the total is worth reporting;
+            # a directory that was simply GC'd away is not.
+            unreadable += _count_unreadable(e)
             logger.debug(f'Skipping {current} while measuring {path}: {e}')
             continue
         with scandir:
@@ -235,8 +318,11 @@ def _scan_root(path: str, deadline: float, max_entries: int) -> RootUsage:
                 try:
                     stat_result = entry.stat(follow_symlinks=False)
                     is_dir = entry.is_dir(follow_symlinks=False)
-                except OSError:
-                    # Raced with a GC or a rotation; the bytes are gone.
+                except OSError as e:
+                    # ENOENT is the normal case here -- the request-log GC
+                    # unlinks constantly, and those bytes really are gone.
+                    # Anything else is a blind spot in the total.
+                    unreadable += _count_unreadable(e)
                     continue
                 if stat_result.st_nlink > 1:
                     key = (stat_result.st_dev, stat_result.st_ino)
@@ -253,10 +339,14 @@ def _scan_root(path: str, deadline: float, max_entries: int) -> RootUsage:
     if truncated:
         logger.info(f'Local disk scan of {path} truncated after '
                     f'{entries} entries; reported size is a lower bound')
+    if unreadable:
+        logger.info(f'Local disk scan of {path} could not read '
+                    f'{unreadable} entries; reported size is a lower bound')
     return RootUsage(path=path,
                      used_bytes=used,
                      files=files,
-                     truncated=truncated)
+                     truncated=truncated,
+                     unreadable=unreadable)
 
 
 def _mountpoint(path: str) -> Optional[str]:
@@ -381,5 +471,5 @@ def scan(
     return Snapshot(roots=roots,
                     filesystems=_filesystem_usage(
                         [path for _, path in measured]),
-                    budget_bytes=budget_bytes(),
+                    budget=budget(),
                     duration_seconds=time.monotonic() - started)

--- a/sky/server/local_disk.py
+++ b/sky/server/local_disk.py
@@ -14,7 +14,7 @@ holding them, so the growth is visible while there is still time to act.
 
 Measurement only: nothing here refuses, caps or sheds work.
 
-Two notes on matching what the platform sees:
+Three notes on matching what the platform sees:
 
 * Sizes are counted in allocated blocks, not apparent size, and hard links
   are counted once, because that is what ``du`` reports and ``du`` is what
@@ -22,6 +22,11 @@ Two notes on matching what the platform sees:
 * A file that has been unlinked while a process still holds it open keeps
   its blocks but is invisible to any directory walk, so a leaked descriptor
   makes these numbers an undercount.
+* Not every root is charged to the container. A deployment can mount a
+  persistent volume partway into the tree -- the same directory is local in
+  one layout and shared in another -- and those bytes belong to the volume's
+  budget, not this container's. Each filesystem is classified, and only the
+  charged roots are compared against the budget.
 """
 import dataclasses
 import os
@@ -54,12 +59,15 @@ EPHEMERAL_STORAGE_REQUEST_ENV_VAR = (
 DEFAULT_SCAN_TIMEOUT_SECONDS = 20.0
 DEFAULT_SCAN_MAX_ENTRIES = 2_000_000
 
-# How often the deadline is re-checked while draining a single directory.
-_DEADLINE_CHECK_EVERY = 4096
-
 # Bytes per st_blocks unit, fixed by POSIX regardless of the filesystem's
 # own block size.
 _BLOCK_SIZE = 512
+
+# Substring identifying a Kubernetes local scratch volume in the source
+# path a bind mount reports. Such a volume lives on the node's own disk
+# and is charged to the pod's ephemeral storage, unlike a persistent
+# volume mounted at the same kind of path.
+_EPHEMERAL_VOLUME_MARKER = 'kubernetes.io~empty-dir'
 
 
 @dataclasses.dataclass
@@ -69,6 +77,10 @@ class RootUsage:
     used_bytes: int
     files: int
     truncated: bool
+    # Mount point of the filesystem holding this root, so a root can be
+    # joined to its entry in Snapshot.filesystems. None if it could not
+    # be determined.
+    mountpoint: Optional[str] = None
 
 
 @dataclasses.dataclass
@@ -77,6 +89,9 @@ class FilesystemUsage:
     mountpoint: str
     size_bytes: int
     avail_bytes: int
+    # Whether bytes written here count against the container's own
+    # ephemeral-storage budget. See _charged_to_ephemeral().
+    charged_to_ephemeral: bool
 
 
 @dataclasses.dataclass
@@ -89,13 +104,25 @@ class Snapshot:
 
     @property
     def used_bytes(self) -> int:
-        """Total across the measured roots.
+        """Total across the roots charged to this container.
 
-        A lower bound on what the platform attributes to this container:
-        the roots cover what the server writes, not the whole writable
-        layer.
+        Roots on a filesystem the platform does not charge to this
+        container -- a persistent volume, a memory-backed tmpfs -- are
+        excluded, so this stays comparable to ``budget_bytes``. Still a
+        lower bound: the roots cover what the server writes, not the whole
+        writable layer.
         """
-        return sum(r.used_bytes for r in self.roots.values())
+        return sum(usage.used_bytes
+                   for name, usage in self.roots.items()
+                   if self.is_charged_to_ephemeral(name))
+
+    def is_charged_to_ephemeral(self, name: str) -> bool:
+        """Whether root *name* counts against ``budget_bytes``."""
+        root = self.roots.get(name)
+        if root is None or root.mountpoint is None:
+            return False
+        filesystem = self.filesystems.get(root.mountpoint)
+        return filesystem is not None and filesystem.charged_to_ephemeral
 
     @property
     def headroom_bytes(self) -> Optional[int]:
@@ -185,6 +212,11 @@ def _scan_root(path: str, deadline: float, max_entries: int) -> RootUsage:
 
     stack: List[str] = [path]
     while stack:
+        if time.monotonic() >= deadline:
+            # A tree of empty directories never reaches the per-entry check
+            # below, so the deadline is enforced here too.
+            truncated = True
+            break
         current = stack.pop()
         try:
             scandir = os.scandir(current)
@@ -197,8 +229,7 @@ def _scan_root(path: str, deadline: float, max_entries: int) -> RootUsage:
                 if entries >= max_entries:
                     truncated = True
                     break
-                if (entries % _DEADLINE_CHECK_EVERY == 0 and
-                        time.monotonic() >= deadline):
+                if time.monotonic() >= deadline:
                     truncated = True
                     break
                 try:
@@ -247,9 +278,68 @@ def _mountpoint(path: str) -> Optional[str]:
         current = parent
 
 
+def _mount_sources() -> Dict[str, str]:
+    """Returns {mount point: source path inside its device}, or {} if unknown.
+
+    The source path is mountinfo's fourth field, which for a bind mount is
+    the subtree of the backing device that was mounted -- the only place a
+    container can see what kind of volume it was handed.
+    """
+    sources: Dict[str, str] = {}
+    try:
+        with open('/proc/self/mountinfo', 'r', encoding='utf-8') as f:
+            for line in f:
+                fields = line.split()
+                if len(fields) < 5:
+                    continue
+                # id parent major:minor source mount-point ...; both paths
+                # octal-escape the characters that would break the split.
+                sources[_unescape_mount_path(fields[4])] = _unescape_mount_path(
+                    fields[3])
+    except OSError as e:
+        logger.debug(f'Could not read /proc/self/mountinfo: {e}')
+        return {}
+    return sources
+
+
+def _unescape_mount_path(path: str) -> str:
+    for escaped, literal in ((r'\040', ' '), (r'\011', '\t'), (r'\012', '\n'),
+                             (r'\134', '\\')):
+        path = path.replace(escaped, literal)
+    return path
+
+
+def _charged_to_ephemeral(mountpoint: str, sources: Dict[str, str],
+                          container_root_device: Optional[int]) -> bool:
+    """Whether writes under *mountpoint* count against the ephemeral budget.
+
+    A positive test, matching what a container runtime charges to a
+    container's ephemeral storage: its writable layer, and local
+    scratch volumes. Anything else -- a persistent volume, a
+    memory-backed tmpfs -- is not charged, and counting it would subtract
+    another volume's bytes from this container's budget.
+
+    Deliberately conservative in the direction that avoids false
+    exhaustion: an unrecognised mount is treated as not charged.
+    """
+    try:
+        if os.stat(mountpoint).st_dev == container_root_device:
+            # The container's own writable layer.
+            return True
+    except OSError:
+        return False
+    source = sources.get(mountpoint)
+    return source is not None and _EPHEMERAL_VOLUME_MARKER in source
+
+
 def _filesystem_usage(paths: List[str]) -> Dict[str, FilesystemUsage]:
     """Returns space stats for the distinct filesystems holding *paths*."""
     out: Dict[str, FilesystemUsage] = {}
+    sources = _mount_sources()
+    try:
+        container_root_device: Optional[int] = os.stat('/').st_dev
+    except OSError:
+        container_root_device = None
     for path in paths:
         mountpoint = _mountpoint(path)
         if mountpoint is None or mountpoint in out:
@@ -264,7 +354,9 @@ def _filesystem_usage(paths: List[str]) -> Dict[str, FilesystemUsage]:
             size_bytes=stats.f_blocks * stats.f_frsize,
             # f_bavail, not f_bfree: the space actually available to a
             # non-root writer, which is what fills up first.
-            avail_bytes=stats.f_bavail * stats.f_frsize)
+            avail_bytes=stats.f_bavail * stats.f_frsize,
+            charged_to_ephemeral=_charged_to_ephemeral(mountpoint, sources,
+                                                       container_root_device))
     return out
 
 
@@ -283,7 +375,9 @@ def scan(
             # measured emptiness.
             continue
         measured.append((name, path))
-        roots[name] = _scan_root(path, deadline, max_entries)
+        usage = _scan_root(path, deadline, max_entries)
+        usage.mountpoint = _mountpoint(path)
+        roots[name] = usage
     return Snapshot(roots=roots,
                     filesystems=_filesystem_usage(
                         [path for _, path in measured]),

--- a/sky/server/metrics.py
+++ b/sky/server/metrics.py
@@ -556,19 +556,33 @@ _LOCAL_DISK_FS_AVAIL_HELP = (
     'budget below, it is exact.')
 
 _LOCAL_DISK_BUDGET_HELP = (
-    'The container\'s own ephemeral-storage budget in bytes, from the limit '
-    'if one is declared and otherwise the request. No series is emitted when '
-    'neither is exposed to the container, which is the common case: the '
-    'field cannot be read from the kernel, since ephemeral-storage is not a '
-    'cgroup controller, so it has to be injected (Kubernetes: a '
-    'resourceFieldRef env var).')
+    'The container\'s own declared ephemeral-storage allowance in bytes, by '
+    'the resource field it came from. source="limit" is enforced -- exceed '
+    'it and the container is stopped. source="request" is not: a platform '
+    'may allow a container past its request, so exceeding it means only that '
+    'the container is over what it declared, and first in line to be stopped '
+    'when the node itself runs out. No series is emitted when neither field '
+    'is exposed, which is the common case: it cannot be read from the '
+    'kernel, since ephemeral-storage is not a cgroup controller, so it has '
+    'to be injected (Kubernetes: a resourceFieldRef env var).')
 
 _LOCAL_DISK_HEADROOM_HELP = (
-    'Bytes left against sky_apiserver_local_disk_budget_bytes, and absent '
-    'for the same reason that is. Counts only the roots whose '
-    'sky_apiserver_local_disk_root_charged_to_ephemeral is 1. An upper '
-    'bound: those roots cover what the server writes, not every byte the '
-    'platform charges to this container.')
+    'Bytes left before the budget stops the server writing. Emitted only '
+    'when the budget is an enforced limit: room left against a mere '
+    'scheduling request is not headroom, since the container is allowed '
+    'past it, and the number would reach zero with disk to spare. For the '
+    'boundary that does stop writes without a limit, use '
+    'sky_apiserver_local_disk_fs_avail_bytes. Counts only the roots whose '
+    'sky_apiserver_local_disk_root_charged_to_ephemeral is 1, and is an '
+    'upper bound: those roots cover what the server writes, not every byte '
+    'the platform charges to this container.')
+
+_LOCAL_DISK_UNREADABLE_HELP = (
+    'Entries the last walk of this root could not read, excluding entries '
+    'that had simply gone away -- the request-log GC unlinks constantly and '
+    'those bytes really are gone. Non-zero means a permission or I/O error '
+    'kept part of the tree out of the reported size, so treat it as a lower '
+    'bound.')
 
 
 class LocalDiskUsageCollector:
@@ -614,15 +628,21 @@ class LocalDiskUsageCollector:
             'sky_apiserver_local_disk_root_charged_to_ephemeral',
             _LOCAL_DISK_ROOT_CHARGED_HELP,
             labels=['root'])
+        unreadable = prom_core.GaugeMetricFamily(
+            'sky_apiserver_local_disk_scan_unreadable_entries',
+            _LOCAL_DISK_UNREADABLE_HELP,
+            labels=['root'])
         for root, usage in snapshot.roots.items():
             used.add_metric([root], usage.used_bytes)
             files.add_metric([root], usage.files)
             truncated.add_metric([root], 1 if usage.truncated else 0)
+            unreadable.add_metric([root], usage.unreadable)
             charged.add_metric(
                 [root], 1 if snapshot.is_charged_to_ephemeral(root) else 0)
         yield used
         yield files
         yield truncated
+        yield unreadable
         yield charged
 
         fs_size = prom_core.GaugeMetricFamily(
@@ -645,12 +665,16 @@ class LocalDiskUsageCollector:
             value=snapshot.duration_seconds)
 
         budget = prom_core.GaugeMetricFamily(
-            'sky_apiserver_local_disk_budget_bytes', _LOCAL_DISK_BUDGET_HELP)
+            'sky_apiserver_local_disk_budget_bytes',
+            _LOCAL_DISK_BUDGET_HELP,
+            labels=['source'])
         headroom = prom_core.GaugeMetricFamily(
             'sky_apiserver_local_disk_headroom_bytes',
             _LOCAL_DISK_HEADROOM_HELP)
-        if snapshot.budget_bytes is not None:
-            budget.add_metric([], snapshot.budget_bytes)
+        if snapshot.budget is not None:
+            budget.add_metric([snapshot.budget.source],
+                              snapshot.budget.total_bytes)
+        if snapshot.headroom_bytes is not None:
             headroom.add_metric([], snapshot.headroom_bytes)
         yield budget
         yield headroom

--- a/sky/server/metrics.py
+++ b/sky/server/metrics.py
@@ -531,6 +531,14 @@ _LOCAL_DISK_TRUNCATED_HELP = (
     'stopped early, making that root\'s reported size and file count lower '
     'bounds; 0 otherwise.')
 
+_LOCAL_DISK_ROOT_CHARGED_HELP = (
+    '1 when bytes written under this root count against the container\'s own '
+    'ephemeral-storage budget, 0 when the platform charges them elsewhere -- '
+    'a persistent volume or a memory-backed tmpfs mounted into the tree. '
+    'Only the roots marked 1 go into '
+    'sky_apiserver_local_disk_headroom_bytes, so this is what makes that '
+    'number reproducible from the per-root series.')
+
 _LOCAL_DISK_SCAN_DURATION_HELP = (
     'Wall-clock seconds the last walk of all local roots took. Runs off the '
     'scrape path, so this is a cost signal rather than scrape latency.')
@@ -542,9 +550,10 @@ _LOCAL_DISK_FS_SIZE_HELP = (
 _LOCAL_DISK_FS_AVAIL_HELP = (
     'Space available to a non-root writer on a filesystem hosting at least '
     'one of the API server\'s local roots, by mount point. On Kubernetes '
-    'this is the headroom to the kubelet\'s node-level eviction threshold, '
-    'which is what actually stops the server writing -- unlike the '
-    'per-container budget below, it is exact.')
+    'the value for the filesystem behind the container\'s writable layer is '
+    'the headroom to the kubelet\'s node-level eviction threshold, which is '
+    'what actually stops the server writing -- unlike the per-container '
+    'budget below, it is exact.')
 
 _LOCAL_DISK_BUDGET_HELP = (
     'The container\'s own ephemeral-storage budget in bytes, from the limit '
@@ -556,9 +565,10 @@ _LOCAL_DISK_BUDGET_HELP = (
 
 _LOCAL_DISK_HEADROOM_HELP = (
     'Bytes left against sky_apiserver_local_disk_budget_bytes, and absent '
-    'for the same reason that is. An upper bound: the measured roots cover '
-    'what the server writes, not every byte the platform charges to this '
-    'container.')
+    'for the same reason that is. Counts only the roots whose '
+    'sky_apiserver_local_disk_root_charged_to_ephemeral is 1. An upper '
+    'bound: those roots cover what the server writes, not every byte the '
+    'platform charges to this container.')
 
 
 class LocalDiskUsageCollector:
@@ -600,13 +610,20 @@ class LocalDiskUsageCollector:
             'sky_apiserver_local_disk_scan_truncated',
             _LOCAL_DISK_TRUNCATED_HELP,
             labels=['root'])
+        charged = prom_core.GaugeMetricFamily(
+            'sky_apiserver_local_disk_root_charged_to_ephemeral',
+            _LOCAL_DISK_ROOT_CHARGED_HELP,
+            labels=['root'])
         for root, usage in snapshot.roots.items():
             used.add_metric([root], usage.used_bytes)
             files.add_metric([root], usage.files)
             truncated.add_metric([root], 1 if usage.truncated else 0)
+            charged.add_metric(
+                [root], 1 if snapshot.is_charged_to_ephemeral(root) else 0)
         yield used
         yield files
         yield truncated
+        yield charged
 
         fs_size = prom_core.GaugeMetricFamily(
             'sky_apiserver_local_disk_fs_size_bytes',

--- a/sky/server/metrics.py
+++ b/sky/server/metrics.py
@@ -26,6 +26,7 @@ from sky import skypilot_config
 from sky.adaptors import kubernetes as kubernetes_adaptor
 from sky.metrics import utils as metrics_utils
 from sky.server import constants as server_constants
+from sky.server import local_disk
 from sky.skylet import runtime_utils
 from sky.utils import annotations
 from sky.utils import common
@@ -507,6 +508,141 @@ _SQLITE_DB_SIZE_COLLECTOR = _wrap_collector(SqliteDBSizeCollector())
 
 try:
     prom.REGISTRY.register(_SQLITE_DB_SIZE_COLLECTOR)  # for non-multiprocess
+except ValueError:
+    pass
+
+_LOCAL_DISK_USED_HELP = (
+    'Disk used by one of the trees the API server writes to its own local '
+    'disk, by root. Counted in allocated blocks with hard links counted '
+    'once, matching what du -- and therefore a container runtime\'s '
+    'ephemeral-storage accounting -- reports. A series appears only for a '
+    'root that exists on this host. Blocks held by a file that was unlinked '
+    'while still open are invisible to a directory walk and so are missing '
+    'from this value.')
+
+_LOCAL_DISK_FILES_HELP = (
+    'Distinct regular files under one of the API server\'s local roots, '
+    'hard links counted once. Worth watching alongside bytes: the cost of '
+    'the periodic du a container runtime runs to account for ephemeral '
+    'storage scales with file count, not with size.')
+
+_LOCAL_DISK_TRUNCATED_HELP = (
+    '1 when the last walk of this root hit its entry or time bound and '
+    'stopped early, making that root\'s reported size and file count lower '
+    'bounds; 0 otherwise.')
+
+_LOCAL_DISK_SCAN_DURATION_HELP = (
+    'Wall-clock seconds the last walk of all local roots took. Runs off the '
+    'scrape path, so this is a cost signal rather than scrape latency.')
+
+_LOCAL_DISK_FS_SIZE_HELP = (
+    'Total size of a filesystem hosting at least one of the API server\'s '
+    'local roots, by mount point.')
+
+_LOCAL_DISK_FS_AVAIL_HELP = (
+    'Space available to a non-root writer on a filesystem hosting at least '
+    'one of the API server\'s local roots, by mount point. On Kubernetes '
+    'this is the headroom to the kubelet\'s node-level eviction threshold, '
+    'which is what actually stops the server writing -- unlike the '
+    'per-container budget below, it is exact.')
+
+_LOCAL_DISK_BUDGET_HELP = (
+    'The container\'s own ephemeral-storage budget in bytes, from the limit '
+    'if one is declared and otherwise the request. No series is emitted when '
+    'neither is exposed to the container, which is the common case: the '
+    'field cannot be read from the kernel, since ephemeral-storage is not a '
+    'cgroup controller, so it has to be injected (Kubernetes: a '
+    'resourceFieldRef env var).')
+
+_LOCAL_DISK_HEADROOM_HELP = (
+    'Bytes left against sky_apiserver_local_disk_budget_bytes, and absent '
+    'for the same reason that is. An upper bound: the measured roots cover '
+    'what the server writes, not every byte the platform charges to this '
+    'container.')
+
+
+class LocalDiskUsageCollector:
+    """Collector for the API server's own local disk footprint.
+
+    The trees behind these series grow with traffic and have no size bound
+    of their own, so on a node with finite local disk the server can fill
+    it. Without this, the earliest available signal is a node-level
+    filesystem alert, which cannot say which pod is responsible and has
+    only the gap between its own threshold and the eviction threshold as
+    lead time -- a few percentage points, which at multi-GB-per-minute fill
+    rates is under a minute. Per-root series make the growth attributable
+    and let an alert trigger on rate rather than on level.
+
+    Measurement only: nothing here bounds or refuses writes.
+
+    A walk of a few hundred thousand files costs well under a second on
+    local disk, but the roots are on whatever the deployment mounted, so
+    ResilientCollector keeps it off the scrape path and each root's walk
+    carries its own entry and time bound.
+    """
+
+    def describe(self):
+        yield prom_core.GaugeMetricFamily('sky_apiserver_local_disk_used_bytes',
+                                          _LOCAL_DISK_USED_HELP,
+                                          labels=['root'])
+
+    def collect(self):
+        snapshot = local_disk.scan()
+
+        used = prom_core.GaugeMetricFamily(
+            'sky_apiserver_local_disk_used_bytes',
+            _LOCAL_DISK_USED_HELP,
+            labels=['root'])
+        files = prom_core.GaugeMetricFamily('sky_apiserver_local_disk_files',
+                                            _LOCAL_DISK_FILES_HELP,
+                                            labels=['root'])
+        truncated = prom_core.GaugeMetricFamily(
+            'sky_apiserver_local_disk_scan_truncated',
+            _LOCAL_DISK_TRUNCATED_HELP,
+            labels=['root'])
+        for root, usage in snapshot.roots.items():
+            used.add_metric([root], usage.used_bytes)
+            files.add_metric([root], usage.files)
+            truncated.add_metric([root], 1 if usage.truncated else 0)
+        yield used
+        yield files
+        yield truncated
+
+        fs_size = prom_core.GaugeMetricFamily(
+            'sky_apiserver_local_disk_fs_size_bytes',
+            _LOCAL_DISK_FS_SIZE_HELP,
+            labels=['mountpoint'])
+        fs_avail = prom_core.GaugeMetricFamily(
+            'sky_apiserver_local_disk_fs_avail_bytes',
+            _LOCAL_DISK_FS_AVAIL_HELP,
+            labels=['mountpoint'])
+        for mountpoint, fs in snapshot.filesystems.items():
+            fs_size.add_metric([mountpoint], fs.size_bytes)
+            fs_avail.add_metric([mountpoint], fs.avail_bytes)
+        yield fs_size
+        yield fs_avail
+
+        yield prom_core.GaugeMetricFamily(
+            'sky_apiserver_local_disk_scan_duration_seconds',
+            _LOCAL_DISK_SCAN_DURATION_HELP,
+            value=snapshot.duration_seconds)
+
+        budget = prom_core.GaugeMetricFamily(
+            'sky_apiserver_local_disk_budget_bytes', _LOCAL_DISK_BUDGET_HELP)
+        headroom = prom_core.GaugeMetricFamily(
+            'sky_apiserver_local_disk_headroom_bytes',
+            _LOCAL_DISK_HEADROOM_HELP)
+        if snapshot.budget_bytes is not None:
+            budget.add_metric([], snapshot.budget_bytes)
+            headroom.add_metric([], snapshot.headroom_bytes)
+        yield budget
+        yield headroom
+
+
+_LOCAL_DISK_USAGE_COLLECTOR = _wrap_collector(LocalDiskUsageCollector())
+
+try:
+    prom.REGISTRY.register(_LOCAL_DISK_USAGE_COLLECTOR)  # non-multiprocess
 except ValueError:
     pass
 
@@ -1045,6 +1181,7 @@ def metrics() -> fastapi.Response:
         registry.register(_BURN_RATE_COLLECTOR)
         registry.register(_SQLITE_DB_SIZE_COLLECTOR)
         registry.register(_WORKSPACE_USAGE_COLLECTOR)
+        registry.register(_LOCAL_DISK_USAGE_COLLECTOR)
         registry.register(_COLLECTOR_HEALTH_COLLECTOR)
         registry.register(_SERVER_START_TIME_COLLECTOR)
         if _MANAGED_JOBS_COLLECTOR is not None:

--- a/tests/unit_tests/test_local_disk_accounting.py
+++ b/tests/unit_tests/test_local_disk_accounting.py
@@ -1,0 +1,179 @@
+"""Tests for the API server's local-disk accounting and its metrics.
+
+The collector is exercised unwrapped: ResilientCollector refreshes on a
+background thread, so a test that went through it would assert against
+whichever snapshot happened to be current.
+"""
+import os
+
+import pytest
+
+from sky.server import local_disk
+from sky.server import metrics
+
+
+def _write(path, size):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, 'wb') as f:
+        f.write(b'x' * size)
+
+
+@pytest.fixture
+def roots(tmp_path, monkeypatch):
+    """Two real roots plus one that does not exist."""
+    present = tmp_path / 'present'
+    other = tmp_path / 'other'
+    present.mkdir()
+    other.mkdir()
+    mapping = {
+        'present': str(present),
+        'other': str(other),
+        'absent': str(tmp_path / 'absent'),
+    }
+    monkeypatch.setattr(local_disk, 'local_roots', lambda: mapping)
+    return present, other
+
+
+@pytest.fixture(autouse=True)
+def _no_budget(monkeypatch):
+    monkeypatch.delenv(local_disk.EPHEMERAL_STORAGE_LIMIT_ENV_VAR,
+                       raising=False)
+    monkeypatch.delenv(local_disk.EPHEMERAL_STORAGE_REQUEST_ENV_VAR,
+                       raising=False)
+
+
+def test_scan_counts_files_and_skips_absent_roots(roots):
+    present, _ = roots
+    _write(str(present / 'a.log'), 128 * 1024)
+    _write(str(present / 'nested' / 'b.log'), 64 * 1024)
+
+    snapshot = local_disk.scan()
+
+    # An absent root emits nothing rather than a measured zero.
+    assert set(snapshot.roots) == {'present', 'other'}
+    assert snapshot.roots['present'].files == 2
+    assert snapshot.roots['other'].files == 0
+    # Allocated blocks, so at least the bytes written plus directory inodes.
+    assert snapshot.roots['present'].used_bytes >= 192 * 1024
+    assert not snapshot.roots['present'].truncated
+    assert snapshot.used_bytes == sum(
+        r.used_bytes for r in snapshot.roots.values())
+
+
+def test_scan_counts_a_hard_link_once(roots):
+    present, _ = roots
+    target = str(present / 'a.log')
+    _write(target, 1024 * 1024)
+    before = local_disk.scan().roots['present']
+
+    os.link(target, str(present / 'link.log'))
+    after = local_disk.scan().roots['present']
+
+    assert after.files == before.files
+    # The extra dirent may enlarge the directory inode, but the file's
+    # megabyte must not be counted twice.
+    assert after.used_bytes - before.used_bytes < 1024 * 1024
+
+
+def test_scan_reports_truncation_instead_of_undercounting_silently(roots):
+    present, _ = roots
+    for i in range(20):
+        _write(str(present / f'{i}.log'), 1024)
+
+    snapshot = local_disk.scan(max_entries=5)
+
+    assert snapshot.roots['present'].truncated is True
+    assert snapshot.roots['present'].files < 20
+
+
+def test_scan_reports_the_filesystem_behind_each_root(roots):
+    present, _ = roots
+    _write(str(present / 'a.log'), 1024)
+
+    snapshot = local_disk.scan()
+
+    # Both roots are under tmp_path, so they share one mount point.
+    assert len(snapshot.filesystems) == 1
+    fs = next(iter(snapshot.filesystems.values()))
+    assert fs.size_bytes > 0
+    assert fs.avail_bytes > 0
+    assert fs.avail_bytes <= fs.size_bytes
+
+
+def test_budget_prefers_the_limit_over_the_request(monkeypatch):
+    monkeypatch.setenv(local_disk.EPHEMERAL_STORAGE_REQUEST_ENV_VAR, '100')
+    assert local_disk.budget_bytes() == 100
+    monkeypatch.setenv(local_disk.EPHEMERAL_STORAGE_LIMIT_ENV_VAR, '250')
+    assert local_disk.budget_bytes() == 250
+
+
+@pytest.mark.parametrize('raw', ['', 'not-a-number', '0', '-1'])
+def test_budget_absent_when_unusable(monkeypatch, raw):
+    monkeypatch.setenv(local_disk.EPHEMERAL_STORAGE_LIMIT_ENV_VAR, raw)
+    assert local_disk.budget_bytes() is None
+
+
+def test_headroom_needs_a_budget_and_never_goes_negative(roots):
+    present, _ = roots
+    _write(str(present / 'a.log'), 64 * 1024)
+
+    assert local_disk.scan().headroom_bytes is None
+
+    os.environ[local_disk.EPHEMERAL_STORAGE_LIMIT_ENV_VAR] = str(1024**3)
+    try:
+        snapshot = local_disk.scan()
+        assert snapshot.headroom_bytes == 1024**3 - snapshot.used_bytes
+        os.environ[local_disk.EPHEMERAL_STORAGE_LIMIT_ENV_VAR] = '1'
+        assert local_disk.scan().headroom_bytes == 0
+    finally:
+        del os.environ[local_disk.EPHEMERAL_STORAGE_LIMIT_ENV_VAR]
+
+
+def _families(collector):
+    return {m.name: m for m in collector.collect()}
+
+
+def test_collector_omits_budget_series_when_the_container_has_no_budget(roots):
+    present, _ = roots
+    _write(str(present / 'a.log'), 4096)
+
+    families = _families(metrics.LocalDiskUsageCollector())
+
+    assert families['sky_apiserver_local_disk_budget_bytes'].samples == []
+    assert families['sky_apiserver_local_disk_headroom_bytes'].samples == []
+    used = {
+        s.labels['root']: s.value
+        for s in families['sky_apiserver_local_disk_used_bytes'].samples
+    }
+    assert set(used) == {'present', 'other'}
+    assert used['present'] >= 4096
+    truncated = families['sky_apiserver_local_disk_scan_truncated'].samples
+    assert all(s.value == 0 for s in truncated)
+    duration, = families[
+        'sky_apiserver_local_disk_scan_duration_seconds'].samples
+    assert duration.value >= 0
+
+
+def test_collector_emits_budget_and_headroom_when_exposed(roots, monkeypatch):
+    present, _ = roots
+    _write(str(present / 'a.log'), 4096)
+    monkeypatch.setenv(local_disk.EPHEMERAL_STORAGE_LIMIT_ENV_VAR,
+                       str(8 * 1024**3))
+
+    families = _families(metrics.LocalDiskUsageCollector())
+
+    budget, = families['sky_apiserver_local_disk_budget_bytes'].samples
+    headroom, = families['sky_apiserver_local_disk_headroom_bytes'].samples
+    assert budget.value == 8 * 1024**3
+    assert 0 < headroom.value <= budget.value
+
+
+def test_local_roots_includes_the_blob_backend_and_not_shared_sky_logs():
+    roots = local_disk.local_roots()
+
+    assert 'request_logs' in roots
+    assert 'request_debug_logs' in roots
+    # Provided by BlobStorage.local_disk_roots(); the default backend keeps
+    # extracted file mounts under the clients dir.
+    assert 'api_server_clients' in roots
+    assert not any('sky_logs' in name for name in roots)

--- a/tests/unit_tests/test_local_disk_accounting.py
+++ b/tests/unit_tests/test_local_disk_accounting.py
@@ -192,8 +192,8 @@ def test_only_charged_roots_count_against_the_budget(roots, monkeypatch):
     _write(str(present / 'a.log'), 256 * 1024)
     _write(str(other / 'b.log'), 8 * 1024 * 1024)
 
-    def fake_charged(mountpoint, sources):
-        del sources
+    def fake_charged(mountpoint, sources, container_root_device):
+        del sources, container_root_device
         return mountpoint == str(present)
 
     # One mount point per root, so each can be classified on its own.

--- a/tests/unit_tests/test_local_disk_accounting.py
+++ b/tests/unit_tests/test_local_disk_accounting.py
@@ -4,6 +4,7 @@ The collector is exercised unwrapped: ResilientCollector refreshes on a
 background thread, so a test that went through it would assert against
 whichever snapshot happened to be current.
 """
+import errno
 import os
 
 import pytest
@@ -102,31 +103,54 @@ def test_scan_reports_the_filesystem_behind_each_root(roots):
 
 def test_budget_prefers_the_limit_over_the_request(monkeypatch):
     monkeypatch.setenv(local_disk.EPHEMERAL_STORAGE_REQUEST_ENV_VAR, '100')
-    assert local_disk.budget_bytes() == 100
+    request = local_disk.budget()
+    assert request.total_bytes == 100
+    assert request.source == local_disk.BUDGET_SOURCE_REQUEST
+    assert request.enforced is False
+
     monkeypatch.setenv(local_disk.EPHEMERAL_STORAGE_LIMIT_ENV_VAR, '250')
-    assert local_disk.budget_bytes() == 250
+    limit = local_disk.budget()
+    assert limit.total_bytes == 250
+    assert limit.source == local_disk.BUDGET_SOURCE_LIMIT
+    assert limit.enforced is True
 
 
 @pytest.mark.parametrize('raw', ['', 'not-a-number', '0', '-1'])
 def test_budget_absent_when_unusable(monkeypatch, raw):
     monkeypatch.setenv(local_disk.EPHEMERAL_STORAGE_LIMIT_ENV_VAR, raw)
-    assert local_disk.budget_bytes() is None
+    assert local_disk.budget() is None
 
 
-def test_headroom_needs_a_budget_and_never_goes_negative(roots):
+def test_a_request_is_not_headroom(roots, monkeypatch):
+    """A request does not stop the container, so it cannot bound headroom.
+
+    Reporting room left against a scheduling request would reach zero
+    while the disk still has space, and read as imminent death.
+    """
+    present, _ = roots
+    _write(str(present / 'a.log'), 64 * 1024)
+    monkeypatch.setenv(local_disk.EPHEMERAL_STORAGE_REQUEST_ENV_VAR, '4096')
+
+    snapshot = local_disk.scan()
+
+    assert snapshot.budget.source == local_disk.BUDGET_SOURCE_REQUEST
+    # Already over the request, and still no headroom claim either way.
+    assert snapshot.used_bytes > 4096
+    assert snapshot.headroom_bytes is None
+
+
+def test_headroom_needs_a_limit_and_never_goes_negative(roots, monkeypatch):
     present, _ = roots
     _write(str(present / 'a.log'), 64 * 1024)
 
     assert local_disk.scan().headroom_bytes is None
 
-    os.environ[local_disk.EPHEMERAL_STORAGE_LIMIT_ENV_VAR] = str(1024**3)
-    try:
-        snapshot = local_disk.scan()
-        assert snapshot.headroom_bytes == 1024**3 - snapshot.used_bytes
-        os.environ[local_disk.EPHEMERAL_STORAGE_LIMIT_ENV_VAR] = '1'
-        assert local_disk.scan().headroom_bytes == 0
-    finally:
-        del os.environ[local_disk.EPHEMERAL_STORAGE_LIMIT_ENV_VAR]
+    monkeypatch.setenv(local_disk.EPHEMERAL_STORAGE_LIMIT_ENV_VAR, str(1024**3))
+    snapshot = local_disk.scan()
+    assert snapshot.headroom_bytes == 1024**3 - snapshot.used_bytes
+
+    monkeypatch.setenv(local_disk.EPHEMERAL_STORAGE_LIMIT_ENV_VAR, '1')
+    assert local_disk.scan().headroom_bytes == 0
 
 
 def _families(collector):
@@ -141,6 +165,9 @@ def test_collector_omits_budget_series_when_the_container_has_no_budget(roots):
 
     assert families['sky_apiserver_local_disk_budget_bytes'].samples == []
     assert families['sky_apiserver_local_disk_headroom_bytes'].samples == []
+    unreadable = families[
+        'sky_apiserver_local_disk_scan_unreadable_entries'].samples
+    assert all(s.value == 0 for s in unreadable)
     used = {
         s.labels['root']: s.value
         for s in families['sky_apiserver_local_disk_used_bytes'].samples
@@ -165,6 +192,7 @@ def test_collector_emits_budget_and_headroom_when_exposed(roots, monkeypatch):
     budget, = families['sky_apiserver_local_disk_budget_bytes'].samples
     headroom, = families['sky_apiserver_local_disk_headroom_bytes'].samples
     assert budget.value == 8 * 1024**3
+    assert budget.labels == {'source': local_disk.BUDGET_SOURCE_LIMIT}
     assert 0 < headroom.value <= budget.value
 
 
@@ -263,3 +291,57 @@ def test_deadline_is_enforced_on_a_small_tree(roots):
     snapshot = local_disk.scan(timeout_seconds=-1.0)
 
     assert snapshot.roots['present'].truncated is True
+
+
+def test_an_unreadable_subtree_is_reported_not_hidden(roots):
+    """A permission error must not publish a partial size as a whole one."""
+    present, _ = roots
+    _write(str(present / 'readable.log'), 4096)
+    locked = present / 'locked'
+    locked.mkdir()
+    _write(str(locked / 'big.log'), 1024 * 1024)
+    os.chmod(locked, 0o000)
+    try:
+        usage = local_disk.scan().roots['present']
+    finally:
+        os.chmod(locked, 0o755)
+
+    assert usage.unreadable == 1
+    # The megabyte inside the unreadable directory is missing, which is
+    # exactly why the count has to be published alongside the size.
+    assert usage.used_bytes < 1024 * 1024
+    assert usage.truncated is False
+
+
+def test_a_vanished_entry_is_not_an_unreadable_one(roots):
+    """The request-log GC unlinks constantly; those bytes really are gone."""
+    present, _ = roots
+    _write(str(present / 'a.log'), 4096)
+
+    assert local_disk.scan().roots['present'].unreadable == 0
+    assert local_disk._count_unreadable(OSError(errno.ENOENT, 'gone')) == 0
+    assert local_disk._count_unreadable(OSError(errno.EACCES, 'denied')) == 1
+
+
+def test_a_root_inside_another_root_is_measured_once(tmp_path, monkeypatch):
+    """Overlapping roots would count every byte in the overlap twice.
+
+    Hard links are only deduplicated within one root, so an overlap
+    corrupts the total rather than merely duplicating a label.
+    """
+    outer = tmp_path / 'outer'
+    inner = outer / 'nested' / 'inner'
+    inner.mkdir(parents=True)
+    _write(str(inner / 'a.log'), 512 * 1024)
+
+    monkeypatch.setattr(
+        local_disk, 'local_roots', lambda: local_disk._drop_nested({
+            'outer': str(outer),
+            'inner': str(inner),
+            'same_as_outer': str(outer),
+        }))
+
+    snapshot = local_disk.scan()
+
+    assert list(snapshot.roots) == ['outer']
+    assert snapshot.roots['outer'].files == 1

--- a/tests/unit_tests/test_local_disk_accounting.py
+++ b/tests/unit_tests/test_local_disk_accounting.py
@@ -177,3 +177,89 @@ def test_local_roots_includes_the_blob_backend_and_not_shared_sky_logs():
     # extracted file mounts under the clients dir.
     assert 'api_server_clients' in roots
     assert not any('sky_logs' in name for name in roots)
+
+
+def test_only_charged_roots_count_against_the_budget(roots, monkeypatch):
+    """A persistent volume mounted into the tree is not this pod's problem.
+
+    The chart mounts a PVC at ~/.sky/api_server/clients under one upgrade
+    strategy and over all of ~/.sky under another, so the same root is
+    local in one layout and shared in the next. Counting the shared bytes
+    would subtract another volume's usage from this container's budget and
+    report exhaustion that is not there.
+    """
+    present, other = roots
+    _write(str(present / 'a.log'), 256 * 1024)
+    _write(str(other / 'b.log'), 8 * 1024 * 1024)
+
+    def fake_charged(mountpoint, sources):
+        del sources
+        return mountpoint == str(present)
+
+    # One mount point per root, so each can be classified on its own.
+    monkeypatch.setattr(local_disk, '_mountpoint', lambda path: path)
+    monkeypatch.setattr(local_disk, '_charged_to_ephemeral', fake_charged)
+    monkeypatch.setenv(local_disk.EPHEMERAL_STORAGE_LIMIT_ENV_VAR, str(1024**3))
+
+    snapshot = local_disk.scan()
+
+    assert snapshot.is_charged_to_ephemeral('present') is True
+    assert snapshot.is_charged_to_ephemeral('other') is False
+    # 'other' holds 8 MB and must not appear in the total.
+    assert snapshot.used_bytes == snapshot.roots['present'].used_bytes
+    assert snapshot.used_bytes < 8 * 1024 * 1024
+    assert snapshot.headroom_bytes == 1024**3 - snapshot.used_bytes
+    # Both roots still report their own size; only the aggregate is scoped.
+    assert snapshot.roots['other'].used_bytes >= 8 * 1024 * 1024
+
+    charged = {
+        s.labels['root']: s.value
+        for s in _families(metrics.LocalDiskUsageCollector())
+        ['sky_apiserver_local_disk_root_charged_to_ephemeral'].samples
+    }
+    assert charged == {'present': 1.0, 'other': 0.0}
+
+
+def test_charging_follows_the_device_then_the_mount_source(tmp_path):
+    mountpoint = str(tmp_path)
+    device = os.stat(mountpoint).st_dev
+
+    # Same device as the container's writable layer.
+    assert local_disk._charged_to_ephemeral(mountpoint, {}, device) is True
+
+    # A different device, but a local scratch volume by its mount source.
+    scratch = {
+        mountpoint: ('/var/lib/kubelet/pods/abc/volumes/'
+                     f'{local_disk._EPHEMERAL_VOLUME_MARKER}/sky-ephemeral')
+    }
+    assert local_disk._charged_to_ephemeral(mountpoint, scratch,
+                                            device + 1) is True
+
+    # A different device and an unrecognised source: a persistent volume as
+    # far as this container can tell, so not charged. Erring this way misses
+    # a warning rather than raising a false one.
+    pvc = {mountpoint: '/nfs-export/tenant/api_server/clients'}
+    assert local_disk._charged_to_ephemeral(mountpoint, pvc,
+                                            device + 1) is False
+    assert local_disk._charged_to_ephemeral(mountpoint, {}, device + 1) is False
+
+
+def test_charging_a_path_that_is_not_there(tmp_path):
+    assert local_disk._charged_to_ephemeral(str(tmp_path / 'gone'), {},
+                                            None) is False
+
+
+def test_deadline_is_enforced_on_a_small_tree(roots):
+    """A slow filesystem must not outrun the timeout on a small tree.
+
+    Before this, the deadline was only re-checked every few thousand
+    entries, so a handful of files on a filesystem with millisecond stat
+    latency ran to completion and reported an untruncated result.
+    """
+    present, _ = roots
+    for i in range(4):
+        _write(str(present / f'{i}.log'), 1024)
+
+    snapshot = local_disk.scan(timeout_seconds=-1.0)
+
+    assert snapshot.roots['present'].truncated is True


### PR DESCRIPTION
Publishes the API server's own local disk footprint on `/metrics`.

The server owns several trees on local disk that grow with traffic and have no size bound of their own: the per-request log files, the request debug logs, and whatever the configured blob storage extracts locally for file mounts. Nothing in the process knows how large they have grown or how much room is left, so on a node with finite local disk the first component to notice a filling disk is the platform underneath — on Kubernetes the kubelet, whose only response is to evict the pod, after which the evidence is gone.

A node-level filesystem alert is not a substitute. It cannot say which pod is responsible, and its lead time is the gap between its own threshold and the eviction threshold — a few percentage points, which a multi-GB-per-minute writer crosses in well under a minute, shorter than any sane alert `for:`.

New series, all gauges:

| metric | labels | notes |
| --- | --- | --- |
| `sky_apiserver_local_disk_used_bytes` | `root` | allocated blocks, hard links counted once |
| `sky_apiserver_local_disk_files` | `root` | du cost scales with file count, not with size |
| `sky_apiserver_local_disk_scan_truncated` | `root` | 1 when the walk hit its bound |
| `sky_apiserver_local_disk_scan_duration_seconds` | — | |
| `sky_apiserver_local_disk_fs_size_bytes` | `mountpoint` | |
| `sky_apiserver_local_disk_fs_avail_bytes` | `mountpoint` | exact headroom to the node's eviction threshold |
| `sky_apiserver_local_disk_budget_bytes` | — | absent unless the container's own limit/request is exposed |
| `sky_apiserver_local_disk_headroom_bytes` | — | absent for the same reason |

Measurement only: nothing here refuses, caps or sheds work.

Notes:

- The walk runs off the scrape path via `ResilientCollector`, and each root carries an entry and a time bound. Exceeding either truncates that root and raises `sky_apiserver_local_disk_scan_truncated`, so a bounded scan is never mistaken for a small one.
- `~/sky_logs` is deliberately excluded: it may be on shared storage, where it is not charged to this container's local disk and where a directory walk is prohibitively slow. Its filesystem is already covered by the existing sky_logs retention instruments.
- `BlobStorage` gains `local_disk_roots()`, so each backend reports its own local layout and a backend keeping blobs on shared storage reports nothing.
- `ephemeral-storage` is not a cgroup controller, so a container cannot read its own budget from the kernel. The chart projects `limits.ephemeral-storage` and `requests.ephemeral-storage` as env vars, but only when the values declare them — a `resourceFieldRef` for an undeclared field resolves to the node's *allocatable* capacity, which would be reported as a budget the container does not have. With neither exposed the budget and headroom series are absent rather than wrong.
- Blocks held by a file that was unlinked while a process still has it open are invisible to any directory walk, so these numbers undercount in the presence of a leaked descriptor. Stated in the metric help text.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

New unit tests in `tests/unit_tests/test_local_disk_accounting.py`: absent roots emit no series, hard links are counted once, truncation is reported rather than silently undercounting, filesystem stats are per mount point, the limit is preferred over the request, unusable budget values are ignored, headroom is clamped at zero and absent without a budget, and the collector's series shape with and without a budget.

Also ran the collector against real paths on a dev box, and rendered the chart with and without `ephemeral-storage` declared to confirm the env vars appear only when the values set them (`helm lint` clean).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10674" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->