### PR TITLE
[Server] Reclaim request logs that outlived their request row

### DIFF
--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -10,6 +10,7 @@ import pathlib
 import shutil
 import signal
 import sqlite3
+import stat
 import threading
 import time
 import traceback
@@ -675,15 +676,19 @@ def init_db_async(func):
     return wrapper
 
 
+def request_log_dirs() -> Tuple[pathlib.Path, ...]:
+    """Local directories holding per-request log files."""
+    return (pathlib.Path(server_constants.REQUEST_LOG_PATH_PREFIX).expanduser(),
+            pathlib.Path(sky_logging.DEBUG_LOG_DIR))
+
+
 def reset_db_and_logs():
     """Clear local state and re-initialize the request storage backend."""
     logger.debug('clearing local API server database')
     server_common.clear_local_api_server_database()
-    logger.debug('clearing local API server logs directory at '
-                 f'{server_constants.REQUEST_LOG_PATH_PREFIX}')
-    shutil.rmtree(pathlib.Path(
-        server_constants.REQUEST_LOG_PATH_PREFIX).expanduser(),
-                  ignore_errors=True)
+    for log_dir in request_log_dirs():
+        logger.debug(f'clearing API server logs directory at {log_dir}')
+        shutil.rmtree(log_dir, ignore_errors=True)
     # Also clear legacy path for backward compatibility cleanup
     logger.debug('clearing legacy API server logs directory at '
                  f'{LEGACY_REQUEST_LOG_PATH_PREFIX}')
@@ -1030,6 +1035,8 @@ class RequestTaskFilter:
 
     Args:
         status: a list of statuses of the requests to filter on.
+        request_ids: a list of request IDs to filter requests on. An empty
+            list matches nothing.
         cluster_names: a list of cluster names to filter requests on.
         exclude_request_names: a list of request names to exclude from results.
             Mutually exclusive with include_request_names.
@@ -1049,6 +1056,7 @@ class RequestTaskFilter:
             provided.
     """
     status: Optional[List[RequestStatus]] = None
+    request_ids: Optional[List[str]] = None
     cluster_names: Optional[List[str]] = None
     user_id: Optional[str] = None
     exclude_request_names: Optional[List[str]] = None
@@ -1082,6 +1090,15 @@ class RequestTaskFilter:
             status_placeholders = ','.join(['?'] * len(self.status))
             filters.append(f'status IN ({status_placeholders})')
             filter_params.extend(status.value for status in self.status)
+        if self.request_ids is not None:
+            if len(self.request_ids) == 0:
+                # Empty IN () is invalid SQL in PostgreSQL.
+                # An empty list means "match nothing".
+                filters.append('1=0')
+            else:
+                id_placeholders = ','.join(['?'] * len(self.request_ids))
+                filters.append(f'request_id IN ({id_placeholders})')
+                filter_params.extend(self.request_ids)
         if self.include_request_names is not None:
             name_placeholders = ','.join(['?'] *
                                          len(self.include_request_names))
@@ -1316,12 +1333,109 @@ async def _cleanup_legacy_directory_if_empty():
         logger.debug(f'Failed to cleanup legacy directory: {e}')
 
 
+# Number of request IDs per `request_id IN (...)` existence query, to stay
+# under SQLite's 999-parameter cap.
+_ORPHAN_LOG_QUERY_CHUNK_SIZE = 500
+
+
+def _list_stale_log_files(log_dir: pathlib.Path,
+                          cutoff: float) -> List[Tuple[str, str, int]]:
+    """List (request_id, path, size) of logs written before cutoff."""
+    if not log_dir.is_dir():
+        return []
+    stale = []
+    with os.scandir(log_dir) as entries:
+        for entry in entries:
+            if not entry.name.endswith('.log'):
+                continue
+            request_id = entry.name[:-len('.log')]
+            # A live daemon holds its log file open for the lifetime of the
+            # server process; never unlink it.
+            if daemons.is_daemon_request_id(request_id):
+                continue
+            try:
+                # os.stat, not DirEntry.stat: see _prune_sky_logs in
+                # sky/server/server.py for why.
+                st = os.stat(entry.path, follow_symlinks=False)
+            except OSError:
+                continue
+            if not stat.S_ISREG(st.st_mode) or st.st_mtime >= cutoff:
+                continue
+            stale.append((request_id, entry.path, st.st_size))
+    return stale
+
+
+def _unlink_log_files(files: List[Tuple[str, int]]) -> Tuple[int, int]:
+    """Unlink (path, size) pairs; returns (files removed, bytes removed)."""
+    removed_files = 0
+    removed_bytes = 0
+    for path, size in files:
+        try:
+            os.unlink(path)
+        except OSError:
+            continue
+        removed_files += 1
+        removed_bytes += size
+    return removed_files, removed_bytes
+
+
+async def _clean_orphan_request_logs() -> None:
+    """Delete request log files whose request row is already gone.
+
+    When the API server runs with more than one replica, the replicas share
+    one database but each writes its request logs to local disk, so the
+    row-driven cleanup above only reaches the files that sit on the replica
+    running it. A file left behind on another replica outlives the row that
+    names it, after which nothing on the database side can enumerate it.
+
+    A file with no row is already garbage — it cannot be read back through
+    the API — so the age cutoff is a grace period against reading a
+    directory while a request is being recorded, not a retention period.
+    """
+    cutoff = time.time() - bs.GC_GRACE_SECONDS
+    listings = await asyncio.gather(*[
+        asyncio.to_thread(_list_stale_log_files, log_dir, cutoff)
+        for log_dir in request_log_dirs()
+    ])
+    # A request writes one file per log directory, so group by request ID to
+    # ask the database about each one once.
+    stale: Dict[str, List[Tuple[str, int]]] = {}
+    for listing in listings:
+        for request_id, path, size in listing:
+            stale.setdefault(request_id, []).append((path, size))
+
+    request_ids = list(stale)
+    removed_files = 0
+    removed_bytes = 0
+    for start in range(0, len(request_ids), _ORPHAN_LOG_QUERY_CHUNK_SIZE):
+        batch = request_ids[start:start + _ORPHAN_LOG_QUERY_CHUNK_SIZE]
+        live = {
+            req.request_id for req in await get_request_tasks_async(
+                req_filter=RequestTaskFilter(request_ids=batch,
+                                             fields=['request_id']))
+        }
+        orphans = [
+            log_file for request_id in batch if request_id not in live
+            for log_file in stale[request_id]
+        ]
+        if not orphans:
+            continue
+        batch_files, batch_bytes = await asyncio.to_thread(
+            _unlink_log_files, orphans)
+        removed_files += batch_files
+        removed_bytes += batch_bytes
+    if removed_files:
+        logger.info(f'Cleaned up {removed_files} orphan request log file(s), '
+                    f'{removed_bytes} bytes freed')
+
+
 async def clean_finished_requests_with_retention(retention_seconds: int,
                                                  batch_size: int = 1000):
     """Clean up finished requests older than the retention period.
 
     This function removes old finished requests (SUCCEEDED, FAILED, CANCELLED)
-    from the database and cleans up their associated log files.
+    from the database and cleans up their associated log files. It then sweeps
+    the log directories for files that no longer have a request row at all.
 
     For backward compatibility, it also cleans up log files from the legacy
     path (~/sky_logs/api_server/requests/) to handle server upgrades.
@@ -1382,6 +1496,8 @@ async def clean_finished_requests_with_retention(retention_seconds: int,
     # request task in the database.
     logger.info(f'Cleaned up {total_deleted} finished requests '
                 f'older than {retention_seconds} seconds')
+
+    await _clean_orphan_request_logs()
 
 
 async def requests_gc_daemon():

--- a/tests/unit_tests/test_sky/server/requests/test_requests.py
+++ b/tests/unit_tests/test_sky/server/requests/test_requests.py
@@ -2,6 +2,7 @@
 import asyncio
 import json
 import logging
+import os
 import pathlib
 import time
 from typing import List, Optional
@@ -11,7 +12,10 @@ import filelock
 import pytest
 
 from sky import core
+from sky import sky_logging
 from sky.server import constants as server_constants
+from sky.server import daemons
+from sky.server.blob import blob_storage as requests_bs
 from sky.server.requests import payloads
 from sky.server.requests import requests
 from sky.server.requests.requests import RequestStatus
@@ -31,17 +35,22 @@ def isolated_database(tmp_path):
     temp_db_path = tmp_path / "requests.db"
     temp_log_path = tmp_path / "logs"
     temp_log_path.mkdir()
+    temp_debug_log_path = tmp_path / "debug_logs"
+    temp_debug_log_path.mkdir()
 
     # Patch the database path and log path constants
     with mock.patch('sky.server.constants.API_SERVER_REQUEST_DB_PATH',
                     str(temp_db_path)):
         with mock.patch('sky.server.constants.REQUEST_LOG_PATH_PREFIX',
                         str(temp_log_path)):
-            # Reset the global database variable to force re-initialization
-            requests._DB = None
-            yield
-            # Clean up after the test
-            requests._DB = None
+            with mock.patch('sky.sky_logging.DEBUG_LOG_DIR',
+                            str(temp_debug_log_path)):
+                # Reset the global database variable to force
+                # re-initialization
+                requests._DB = None
+                yield
+                # Clean up after the test
+                requests._DB = None
 
 
 @pytest.mark.asyncio
@@ -680,6 +689,125 @@ async def test_clean_finished_requests_cleans_both_paths(
 
     # Verify the request was deleted
     assert requests.get_request('legacy-test-req-1') is None
+
+
+@pytest.mark.asyncio
+async def test_clean_orphan_request_logs(isolated_database):
+    """Test that log files whose request row is gone are reclaimed."""
+    current_time = time.time()
+    # Older than the grace period the sweep applies to the age cutoff.
+    stale_mtime = current_time - 10 * requests_bs.GC_GRACE_SECONDS
+
+    live_request = requests.Request(request_id='live-req',
+                                    name='test-request',
+                                    entrypoint=dummy,
+                                    request_body=payloads.RequestBody(),
+                                    status=RequestStatus.RUNNING,
+                                    created_at=stale_mtime,
+                                    user_id='test-user')
+    await requests.create_if_not_exists_async(live_request)
+
+    request_log_dir, debug_log_dir = requests.request_log_dirs()
+
+    # No request row: the files to reclaim. The same request ID in both
+    # directories exercises the grouping of a request's files.
+    orphans = [
+        request_log_dir / 'orphan-req.log', debug_log_dir / 'orphan-req.log'
+    ]
+    for orphan in orphans:
+        orphan.write_text('orphan')
+        os.utime(orphan, (stale_mtime, stale_mtime))
+
+    # Stale, but the request is still in the database.
+    live = request_log_dir / 'live-req.log'
+    live.write_text('live')
+    os.utime(live, (stale_mtime, stale_mtime))
+    # No request row, but written within the grace period.
+    fresh = request_log_dir / 'fresh-req.log'
+    fresh.write_text('fresh')
+    # A running internal daemon's log, which can go a long time without a
+    # write and has no row of its own on a replica that skips it.
+    daemon_log = (request_log_dir /
+                  f'{daemons.INTERNAL_REQUEST_DAEMONS[0].id}.log')
+    daemon_log.write_text('daemon')
+    os.utime(daemon_log, (stale_mtime, stale_mtime))
+    # Not a log file.
+    lock = request_log_dir / '.orphan-req.lock'
+    lock.write_text('')
+    os.utime(lock, (stale_mtime, stale_mtime))
+    kept = [live, fresh, daemon_log, lock]
+
+    with mock.patch('sky.server.requests.requests.logger') as mock_logger:
+        await requests.clean_finished_requests_with_retention(60)
+
+    for path in orphans:
+        assert not path.exists(), f'{path} should have been reclaimed'
+    for path in kept:
+        assert path.exists(), f'{path} should have been kept'
+
+    messages = [call[0][0] for call in mock_logger.info.call_args_list]
+    assert any('Cleaned up 2 orphan request log file(s)' in message
+               for message in messages), messages
+
+
+@pytest.mark.asyncio
+async def test_clean_orphan_request_logs_many_files(isolated_database):
+    """Test reclaiming more orphans than fit in one existence query."""
+    stale_mtime = time.time() - 10 * requests_bs.GC_GRACE_SECONDS
+    count = 2 * requests._ORPHAN_LOG_QUERY_CHUNK_SIZE + 1
+    log_dir = requests.request_log_dirs()[0]
+    for i in range(count):
+        path = log_dir / f'orphan-{i}.log'
+        path.write_text('x')
+        os.utime(path, (stale_mtime, stale_mtime))
+
+    await requests.clean_finished_requests_with_retention(60)
+
+    assert not list(log_dir.glob('orphan-*.log'))
+
+
+def test_list_stale_log_files_missing_dir(tmp_path):
+    """Test that a missing log directory yields nothing, not an error."""
+    assert requests._list_stale_log_files(tmp_path / 'gone', time.time()) == []
+
+
+@pytest.mark.asyncio
+async def test_request_task_filter_request_ids(isolated_database):
+    """Test filtering requests by request ID."""
+    for request_id in ['req-a', 'req-b', 'req-c']:
+        await requests.create_if_not_exists_async(
+            requests.Request(request_id=request_id,
+                             name='test-request',
+                             entrypoint=dummy,
+                             request_body=payloads.RequestBody(),
+                             status=RequestStatus.RUNNING,
+                             created_at=time.time(),
+                             user_id='test-user'))
+
+    found = await requests.get_request_tasks_async(
+        req_filter=requests.RequestTaskFilter(request_ids=['req-a', 'req-c'],
+                                              fields=['request_id']))
+    assert {req.request_id for req in found} == {'req-a', 'req-c'}
+
+    found = await requests.get_request_tasks_async(
+        req_filter=requests.RequestTaskFilter(request_ids=[]))
+    assert not found
+
+
+def test_reset_db_and_logs_clears_debug_log_dir(isolated_database, tmp_path):
+    """Test that startup clears the request debug log directory."""
+    debug_log = pathlib.Path(sky_logging.DEBUG_LOG_DIR) / 'stale-req.log'
+    debug_log.write_text('stale')
+
+    with mock.patch('sky.server.common.clear_local_api_server_database'), \
+         mock.patch('sky.server.blob.blob_storage.get_blob_storage'), \
+         mock.patch('sky.server.requests.storage.get_request_backend'), \
+         mock.patch(
+             'sky.server.requests.requests.LEGACY_REQUEST_LOG_PATH_PREFIX',
+             str(tmp_path / 'legacy_logs')):
+        requests.reset_db_and_logs()
+
+    assert not debug_log.exists()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The requests GC unlinks log files by iterating the rows past retention, so a file is only reclaimed on the replica that happens to run the sweep. When the API server runs with more than one replica, the replicas share one database but each writes its request logs to local disk (`~/.sky/api_server/request_logs/`, `~/.sky/api_server/request_debug_logs/`). A file left on another replica outlives the row that names it — the row is deleted, the local `unlink` is a silent no-op, and no later pass can enumerate the file from the database side. `request_debug_logs` is the worse of the two because nothing clears it at startup, so its leak survives restarts.

- Sweep both request log directories at the end of each GC pass: take the `*.log` files, group them by request id, batch-query which ids still have a row, and delete the files of those that do not. A file with no row is already garbage, so the age cutoff is only a grace period against reading a directory while a request is being recorded — it uses the same `GC_GRACE_SECONDS` floor as the blob GC rather than the retention window.
- Live internal-daemon logs are skipped by id: they sit in the same directory, their writer holds them open for the life of the process, and a daemon can go a whole window without a write. A daemon no longer in `INTERNAL_REQUEST_DAEMONS` is still reclaimed.
- Clear `request_debug_logs` on startup, the way `request_logs` already is.
- Add a `request_ids` filter to `RequestTaskFilter` for the existence lookup, chunked to stay under SQLite's parameter cap.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

New unit tests in `tests/unit_tests/test_sky/server/requests/test_requests.py`:

- `test_clean_orphan_request_logs` — a file past the grace period with no request row is reclaimed from both log directories, while a file whose request is still in the database, a file written within the grace period, a live daemon's log, and a non-`.log` file are all kept.
- `test_clean_orphan_request_logs_many_files` — reclaims more orphans than fit in one existence query.
- `test_list_stale_log_files_missing_dir` — a missing log directory yields nothing rather than raising.
- `test_request_task_filter_request_ids` — the new filter selects the named requests, and an empty list matches nothing.
- `test_reset_db_and_logs_clears_debug_log_dir` — startup clears the request debug log directory.

Manual verification on a two-replica deployment backed by one Postgres:

- A request that ran on replica B, with its row past retention: replica A's pass deleted the row and its local unlink was a no-op, leaving the row absent from the database while both of B's log files were still on disk. B's own next pass then reclaimed exactly those two files while finding no rows to collect — the case the row-driven cleanup cannot reach.
- Before those files aged past the grace period, a pass on B left them alone and logged nothing, despite their row already being gone.
- A file past the grace period with no row, planted in both directories, was reclaimed; the pass reported the file count and bytes freed.
- The same pass kept a file with no row but a recent mtime, a non-`.log` file, a live daemon's log, an idle daemon's log whose row is absent, and a stale-mtime file whose request row still exists.
- A pass with nothing to reclaim logged no additional line.
- Restarting the server process with the log volume intact left both log directories empty, verified against a marker file outside them that survived the restart.
- The GC daemon's own scheduled pass ran the sweep in the server process, not just under direct invocation.
