### PR TITLE
[Metrics] Add managed-job startup wait metrics and Grafana dashboard

### DIFF
--- a/charts/skypilot/manifests/job-startup.json
+++ b/charts/skypilot/manifests/job-startup.json
@@ -1,0 +1,861 @@
+{
+  "uid": "skypilot-job-startup",
+  "title": "SkyPilot Job Startup & Demand",
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "tags": [
+    "skypilot",
+    "managed-jobs"
+  ],
+  "timezone": "browser",
+  "refresh": "30s",
+  "time": {
+    "from": "now-7d",
+    "to": "now"
+  },
+  "timepicker": {
+    "hidden": true
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "workspace",
+        "label": "Workspace",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "query": "label_values({__name__=~\"sky_managed_job_wait_7d_tasks|sky_managed_job_waiting_tasks\"}, workspace)",
+        "definition": "label_values({__name__=~\"sky_managed_job_wait_7d_tasks|sky_managed_job_waiting_tasks\"}, workspace)",
+        "refresh": 1,
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "sort": 1
+      },
+      {
+        "name": "user",
+        "label": "User",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "query": "label_values({__name__=~\"sky_managed_job_wait_7d_tasks|sky_managed_job_waiting_tasks\"}, user)",
+        "definition": "label_values({__name__=~\"sky_managed_job_wait_7d_tasks|sky_managed_job_waiting_tasks\"}, user)",
+        "refresh": 1,
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "sort": 1
+      },
+      {
+        "name": "cloud",
+        "label": "Cloud",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "query": "label_values({__name__=~\"sky_managed_job_wait_7d_tasks|sky_managed_job_waiting_tasks\"}, cloud)",
+        "definition": "label_values({__name__=~\"sky_managed_job_wait_7d_tasks|sky_managed_job_waiting_tasks\"}, cloud)",
+        "refresh": 1,
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "sort": 1
+      },
+      {
+        "name": "gpu",
+        "label": "Requested GPU",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "query": "label_values({__name__=~\"sky_managed_job_wait_7d_tasks|sky_managed_job_waiting_tasks\"}, gpu)",
+        "definition": "label_values({__name__=~\"sky_managed_job_wait_7d_tasks|sky_managed_job_waiting_tasks\"}, gpu)",
+        "refresh": 1,
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "sort": 1
+      },
+      {
+        "name": "team",
+        "label": "Team",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "query": "label_values({__name__=~\"sky_managed_job_wait_7d_tasks|sky_managed_job_waiting_tasks\"}, team)",
+        "definition": "label_values({__name__=~\"sky_managed_job_wait_7d_tasks|sky_managed_job_waiting_tasks\"}, team)",
+        "refresh": 1,
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "sort": 1
+      },
+      {
+        "name": "project",
+        "label": "Project",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "query": "label_values({__name__=~\"sky_managed_job_wait_7d_tasks|sky_managed_job_waiting_tasks\"}, project)",
+        "definition": "label_values({__name__=~\"sky_managed_job_wait_7d_tasks|sky_managed_job_waiting_tasks\"}, project)",
+        "refresh": 1,
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "sort": 1
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Submission \u2192 first run \u00b7 p50",
+      "type": "stat",
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 6,
+        "h": 5
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "",
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.5, sum by (le) (max by (workspace,user,cloud,gpu,team,project,outcome,phase,le) (sky_managed_job_wait_7d_seconds_bucket{workspace=~\"$workspace\",user=~\"$user\",cloud=~\"$cloud\",gpu=~\"$gpu\",team=~\"$team\",project=~\"$project\",outcome=\"started\",phase=\"total\"} and on(job,instance) (time() - sky_managed_job_wait_snapshot_timestamp_seconds < 120))))",
+          "instant": true,
+          "range": false,
+          "format": "time_series",
+          "legendFormat": "__auto"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "decimals": 1,
+          "noValue": "No data"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 2,
+      "title": "Submission \u2192 first run \u00b7 p95",
+      "type": "stat",
+      "gridPos": {
+        "x": 6,
+        "y": 0,
+        "w": 6,
+        "h": 5
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "",
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum by (le) (max by (workspace,user,cloud,gpu,team,project,outcome,phase,le) (sky_managed_job_wait_7d_seconds_bucket{workspace=~\"$workspace\",user=~\"$user\",cloud=~\"$cloud\",gpu=~\"$gpu\",team=~\"$team\",project=~\"$project\",outcome=\"started\",phase=\"total\"} and on(job,instance) (time() - sky_managed_job_wait_snapshot_timestamp_seconds < 120))))",
+          "instant": true,
+          "range": false,
+          "format": "time_series",
+          "legendFormat": "__auto"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "decimals": 1,
+          "noValue": "No data"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 3,
+      "title": "Currently waiting to first run",
+      "type": "stat",
+      "gridPos": {
+        "x": 12,
+        "y": 0,
+        "w": 6,
+        "h": 5
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "",
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "(sum(max by (workspace,user,cloud,gpu,team,project) (sky_managed_job_waiting_tasks{workspace=~\"$workspace\",user=~\"$user\",cloud=~\"$cloud\",gpu=~\"$gpu\",team=~\"$team\",project=~\"$project\"} and on(job,instance) (time() - sky_managed_job_wait_snapshot_timestamp_seconds < 120))) or vector(0)) and on() (max(sky_managed_job_wait_snapshot_timestamp_seconds) > time() - 120)",
+          "instant": true,
+          "range": false,
+          "format": "time_series",
+          "legendFormat": "__auto"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 1,
+          "noValue": "No data"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 4,
+      "title": "Oldest known current wait",
+      "type": "stat",
+      "gridPos": {
+        "x": 18,
+        "y": 0,
+        "w": 6,
+        "h": 5
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "",
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "max(max by (workspace,user,cloud,gpu,team,project) (sky_managed_job_oldest_wait_seconds{workspace=~\"$workspace\",user=~\"$user\",cloud=~\"$cloud\",gpu=~\"$gpu\",team=~\"$team\",project=~\"$project\"} and on(job,instance) (time() - sky_managed_job_wait_snapshot_timestamp_seconds < 120)))",
+          "instant": true,
+          "range": false,
+          "format": "time_series",
+          "legendFormat": "__auto"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "decimals": 1,
+          "noValue": "No data"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 5,
+      "title": "Started tasks \u00b7 7d submissions",
+      "type": "stat",
+      "gridPos": {
+        "x": 0,
+        "y": 5,
+        "w": 6,
+        "h": 5
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "",
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "(sum(max by (workspace,user,cloud,gpu,team,project,outcome) (sky_managed_job_wait_7d_tasks{workspace=~\"$workspace\",user=~\"$user\",cloud=~\"$cloud\",gpu=~\"$gpu\",team=~\"$team\",project=~\"$project\",outcome=\"started\"} and on(job,instance) (time() - sky_managed_job_wait_snapshot_timestamp_seconds < 120))) or vector(0)) and on() (max(sky_managed_job_wait_snapshot_timestamp_seconds) > time() - 120)",
+          "instant": true,
+          "range": false,
+          "format": "time_series",
+          "legendFormat": "__auto"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 1,
+          "noValue": "No data"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 6,
+      "title": "Cancelled before first run \u00b7 7d",
+      "type": "stat",
+      "gridPos": {
+        "x": 6,
+        "y": 5,
+        "w": 6,
+        "h": 5
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "",
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "(sum(max by (workspace,user,cloud,gpu,team,project,outcome) (sky_managed_job_wait_7d_tasks{workspace=~\"$workspace\",user=~\"$user\",cloud=~\"$cloud\",gpu=~\"$gpu\",team=~\"$team\",project=~\"$project\",outcome=\"cancelled_before_start\"} and on(job,instance) (time() - sky_managed_job_wait_snapshot_timestamp_seconds < 120))) or vector(0)) and on() (max(sky_managed_job_wait_snapshot_timestamp_seconds) > time() - 120)",
+          "instant": true,
+          "range": false,
+          "format": "time_series",
+          "legendFormat": "__auto"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 1,
+          "noValue": "No data"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 7,
+      "title": "Failed before first run \u00b7 7d",
+      "type": "stat",
+      "gridPos": {
+        "x": 12,
+        "y": 5,
+        "w": 6,
+        "h": 5
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "",
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "(sum(max by (workspace,user,cloud,gpu,team,project,outcome) (sky_managed_job_wait_7d_tasks{workspace=~\"$workspace\",user=~\"$user\",cloud=~\"$cloud\",gpu=~\"$gpu\",team=~\"$team\",project=~\"$project\",outcome=\"failed_before_start\"} and on(job,instance) (time() - sky_managed_job_wait_snapshot_timestamp_seconds < 120))) or vector(0)) and on() (max(sky_managed_job_wait_snapshot_timestamp_seconds) > time() - 120)",
+          "instant": true,
+          "range": false,
+          "format": "time_series",
+          "legendFormat": "__auto"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 1,
+          "noValue": "No data"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 8,
+      "title": "Snapshot age \u00b7 must be < 2 minutes",
+      "type": "stat",
+      "gridPos": {
+        "x": 18,
+        "y": 5,
+        "w": 6,
+        "h": 5
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "A stale or missing snapshot makes the other panels show no data. Zero waiting is only shown with a fresh snapshot.",
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "time() - max(sky_managed_job_wait_snapshot_timestamp_seconds)",
+          "instant": true,
+          "range": false,
+          "format": "time_series",
+          "legendFormat": "__auto"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "decimals": 1,
+          "noValue": "No data",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 120
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 9,
+      "title": "p95 startup by requested GPU",
+      "type": "bargauge",
+      "gridPos": {
+        "x": 0,
+        "y": 10,
+        "w": 12,
+        "h": 7
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "",
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum by (le,gpu) (max by (workspace,user,cloud,gpu,team,project,outcome,phase,le) (sky_managed_job_wait_7d_seconds_bucket{workspace=~\"$workspace\",user=~\"$user\",cloud=~\"$cloud\",gpu=~\"$gpu\",team=~\"$team\",project=~\"$project\",outcome=\"started\",phase=\"total\"} and on(job,instance) (time() - sky_managed_job_wait_snapshot_timestamp_seconds < 120))))",
+          "instant": true,
+          "range": false,
+          "format": "time_series",
+          "legendFormat": "{{gpu}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "decimals": 1,
+          "noValue": "No data"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 10,
+      "title": "p95 by startup phase",
+      "type": "bargauge",
+      "gridPos": {
+        "x": 12,
+        "y": 10,
+        "w": 12,
+        "h": 7
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Controller: submission to first STARTING. Launch: first STARTING to first RUNNING, including capacity acquisition, provisioning, image pulls, setup and retries. Phase percentiles are not additive.",
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum by (le,phase) (max by (workspace,user,cloud,gpu,team,project,outcome,phase,le) (sky_managed_job_wait_7d_seconds_bucket{workspace=~\"$workspace\",user=~\"$user\",cloud=~\"$cloud\",gpu=~\"$gpu\",team=~\"$team\",project=~\"$project\",outcome=\"started\",phase=~\"controller|launch\"} and on(job,instance) (time() - sky_managed_job_wait_snapshot_timestamp_seconds < 120))))",
+          "instant": true,
+          "range": false,
+          "format": "time_series",
+          "legendFormat": "{{phase}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "decimals": 1,
+          "noValue": "No data"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 11,
+      "title": "Submission outcomes by user \u00b7 7d",
+      "type": "bargauge",
+      "gridPos": {
+        "x": 0,
+        "y": 17,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "",
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (user,outcome) (max by (workspace,user,cloud,gpu,team,project,outcome) (sky_managed_job_wait_7d_tasks{workspace=~\"$workspace\",user=~\"$user\",cloud=~\"$cloud\",gpu=~\"$gpu\",team=~\"$team\",project=~\"$project\"} and on(job,instance) (time() - sky_managed_job_wait_snapshot_timestamp_seconds < 120)))",
+          "instant": true,
+          "range": false,
+          "format": "time_series",
+          "legendFormat": "{{user}} \u00b7 {{outcome}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 1,
+          "noValue": "No data"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 12,
+      "title": "p95 startup by team / project",
+      "type": "bargauge",
+      "gridPos": {
+        "x": 12,
+        "y": 17,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Only persisted resource labels are used. Unknown means attribution is unavailable; job names and log contents are not used to guess.",
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum by (le,team,project) (max by (workspace,user,cloud,gpu,team,project,outcome,phase,le) (sky_managed_job_wait_7d_seconds_bucket{workspace=~\"$workspace\",user=~\"$user\",cloud=~\"$cloud\",gpu=~\"$gpu\",team=~\"$team\",project=~\"$project\",outcome=\"started\",phase=\"total\"} and on(job,instance) (time() - sky_managed_job_wait_snapshot_timestamp_seconds < 120))))",
+          "instant": true,
+          "range": false,
+          "format": "time_series",
+          "legendFormat": "{{team}} / {{project}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "decimals": 1,
+          "noValue": "No data"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 13,
+      "title": "Longest waits \u00b7 up to 20 tasks",
+      "type": "table",
+      "gridPos": {
+        "x": 0,
+        "y": 25,
+        "w": 24,
+        "h": 9
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Global top 20 emitted per snapshot, then dashboard filters apply. Includes started/cancelled/failed tasks from the seven-day submission cohort and current waiting tasks of any age. Open the job to inspect logs.",
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "topk(20, max by (workspace,user,cloud,gpu,team,project,job_id,task_id,outcome) (sky_managed_job_wait_outlier_seconds{workspace=~\"$workspace\",user=~\"$user\",cloud=~\"$cloud\",gpu=~\"$gpu\",team=~\"$team\",project=~\"$project\"} and on(job,instance) (time() - sky_managed_job_wait_snapshot_timestamp_seconds < 120)))",
+          "instant": true,
+          "range": false,
+          "format": "table",
+          "legendFormat": "__auto"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "decimals": 1,
+          "noValue": "No data"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "job_id"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "Inspect job",
+                    "url": "/dashboard/jobs/${__data.fields.job_id}",
+                    "targetBlank": true
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "displayName": "Value",
+            "desc": true
+          }
+        ]
+      },
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true
+            },
+            "renameByName": {
+              "Value": "Wait (seconds)"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": 14,
+      "title": "Timing gaps \u00b7 recent or active tasks",
+      "type": "bargauge",
+      "gridPos": {
+        "x": 0,
+        "y": 34,
+        "w": 12,
+        "h": 7
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Missing submission/start/end/acceptance events or invalid chronology. These observations are excluded from the affected duration calculation.",
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (reason) (max by (workspace,user,cloud,gpu,team,project,reason) (sky_managed_job_wait_missing_tasks{workspace=~\"$workspace\",user=~\"$user\",cloud=~\"$cloud\",gpu=~\"$gpu\",team=~\"$team\",project=~\"$project\"} and on(job,instance) (time() - sky_managed_job_wait_snapshot_timestamp_seconds < 120)))",
+          "instant": true,
+          "range": false,
+          "format": "time_series",
+          "legendFormat": "{{reason}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 1,
+          "noValue": "No data"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 15,
+      "title": "How to read this dashboard",
+      "type": "text",
+      "gridPos": {
+        "x": 12,
+        "y": 34,
+        "w": 12,
+        "h": 7
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "**Fixed rolling seven-day submission cohort.** The time picker does not change it. Retries retain the first submission time. Counts are tasks, not GPUs. CPU tasks are included unless filtered out.\n\nStartup measures **time until user code first runs**, not pure GPU scheduling delay. Current waiting includes older tasks. Cancelled/failed-before-start tasks are reported separately from successful starts.\n\nBuckets are rolling gauges: use `histogram_quantile` directly, never `rate` or `increase`. Retain job events for at least seven days. Missing data is explicit. Historical project attribution cannot be reconstructed reliably. User is the SkyPilot user hash."
+      }
+    }
+  ]
+}

--- a/charts/skypilot/manifests/job-startup.json
+++ b/charts/skypilot/manifests/job-startup.json
@@ -160,7 +160,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "histogram_quantile(0.5, sum by (le) (max by (workspace,user,cloud,gpu,team,project,outcome,phase,le) (sky_managed_job_wait_7d_seconds_bucket{workspace=~\"$workspace\",user=~\"$user\",cloud=~\"$cloud\",gpu=~\"$gpu\",team=~\"$team\",project=~\"$project\",outcome=\"started\",phase=\"total\"} and on(job,instance) (time() - sky_managed_job_wait_snapshot_timestamp_seconds < 120))))",
+          "expr": "histogram_quantile(0.5, sum by (le) (max by (workspace,user,cloud,gpu,team,project,outcome,phase,le) (sky_managed_job_wait_7d_seconds_bucket{workspace=~\"$workspace\",user=~\"$user\",cloud=~\"$cloud\",gpu=~\"$gpu\",team=~\"$team\",project=~\"$project\",outcome=\"started\",phase=\"total\"} and on(job,instance) (time() - sky_managed_job_wait_snapshot_timestamp_seconds < 180))))",
           "instant": true,
           "range": false,
           "format": "time_series",
@@ -207,7 +207,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "histogram_quantile(0.95, sum by (le) (max by (workspace,user,cloud,gpu,team,project,outcome,phase,le) (sky_managed_job_wait_7d_seconds_bucket{workspace=~\"$workspace\",user=~\"$user\",cloud=~\"$cloud\",gpu=~\"$gpu\",team=~\"$team\",project=~\"$project\",outcome=\"started\",phase=\"total\"} and on(job,instance) (time() - sky_managed_job_wait_snapshot_timestamp_seconds < 120))))",
+          "expr": "histogram_quantile(0.95, sum by (le) (max by (workspace,user,cloud,gpu,team,project,outcome,phase,le) (sky_managed_job_wait_7d_seconds_bucket{workspace=~\"$workspace\",user=~\"$user\",cloud=~\"$cloud\",gpu=~\"$gpu\",team=~\"$team\",project=~\"$project\",outcome=\"started\",phase=\"total\"} and on(job,instance) (time() - sky_managed_job_wait_snapshot_timestamp_seconds < 180))))",
           "instant": true,
           "range": false,
           "format": "time_series",
@@ -254,7 +254,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "(sum(max by (workspace,user,cloud,gpu,team,project) (sky_managed_job_waiting_tasks{workspace=~\"$workspace\",user=~\"$user\",cloud=~\"$cloud\",gpu=~\"$gpu\",team=~\"$team\",project=~\"$project\"} and on(job,instance) (time() - sky_managed_job_wait_snapshot_timestamp_seconds < 120))) or vector(0)) and on() (max(sky_managed_job_wait_snapshot_timestamp_seconds) > time() - 120)",
+          "expr": "(sum(max by (workspace,user,cloud,gpu,team,project) (sky_managed_job_waiting_tasks{workspace=~\"$workspace\",user=~\"$user\",cloud=~\"$cloud\",gpu=~\"$gpu\",team=~\"$team\",project=~\"$project\"} and on(job,instance) (time() - sky_managed_job_wait_snapshot_timestamp_seconds < 180))) or vector(0)) and on() (max(sky_managed_job_wait_snapshot_timestamp_seconds) > time() - 180)",
           "instant": true,
           "range": false,
           "format": "time_series",
@@ -301,7 +301,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "max(max by (workspace,user,cloud,gpu,team,project) (sky_managed_job_oldest_wait_seconds{workspace=~\"$workspace\",user=~\"$user\",cloud=~\"$cloud\",gpu=~\"$gpu\",team=~\"$team\",project=~\"$project\"} and on(job,instance) (time() - sky_managed_job_wait_snapshot_timestamp_seconds < 120)))",
+          "expr": "max(max by (workspace,user,cloud,gpu,team,project) (sky_managed_job_oldest_wait_seconds{workspace=~\"$workspace\",user=~\"$user\",cloud=~\"$cloud\",gpu=~\"$gpu\",team=~\"$team\",project=~\"$project\"} and on(job,instance) (time() - sky_managed_job_wait_snapshot_timestamp_seconds < 180)))",
           "instant": true,
           "range": false,
           "format": "time_series",
@@ -348,7 +348,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "(sum(max by (workspace,user,cloud,gpu,team,project,outcome) (sky_managed_job_wait_7d_tasks{workspace=~\"$workspace\",user=~\"$user\",cloud=~\"$cloud\",gpu=~\"$gpu\",team=~\"$team\",project=~\"$project\",outcome=\"started\"} and on(job,instance) (time() - sky_managed_job_wait_snapshot_timestamp_seconds < 120))) or vector(0)) and on() (max(sky_managed_job_wait_snapshot_timestamp_seconds) > time() - 120)",
+          "expr": "(sum(max by (workspace,user,cloud,gpu,team,project,outcome) (sky_managed_job_wait_7d_tasks{workspace=~\"$workspace\",user=~\"$user\",cloud=~\"$cloud\",gpu=~\"$gpu\",team=~\"$team\",project=~\"$project\",outcome=\"started\"} and on(job,instance) (time() - sky_managed_job_wait_snapshot_timestamp_seconds < 180))) or vector(0)) and on() (max(sky_managed_job_wait_snapshot_timestamp_seconds) > time() - 180)",
           "instant": true,
           "range": false,
           "format": "time_series",
@@ -395,7 +395,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "(sum(max by (workspace,user,cloud,gpu,team,project,outcome) (sky_managed_job_wait_7d_tasks{workspace=~\"$workspace\",user=~\"$user\",cloud=~\"$cloud\",gpu=~\"$gpu\",team=~\"$team\",project=~\"$project\",outcome=\"cancelled_before_start\"} and on(job,instance) (time() - sky_managed_job_wait_snapshot_timestamp_seconds < 120))) or vector(0)) and on() (max(sky_managed_job_wait_snapshot_timestamp_seconds) > time() - 120)",
+          "expr": "(sum(max by (workspace,user,cloud,gpu,team,project,outcome) (sky_managed_job_wait_7d_tasks{workspace=~\"$workspace\",user=~\"$user\",cloud=~\"$cloud\",gpu=~\"$gpu\",team=~\"$team\",project=~\"$project\",outcome=\"cancelled_before_start\"} and on(job,instance) (time() - sky_managed_job_wait_snapshot_timestamp_seconds < 180))) or vector(0)) and on() (max(sky_managed_job_wait_snapshot_timestamp_seconds) > time() - 180)",
           "instant": true,
           "range": false,
           "format": "time_series",
@@ -442,7 +442,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "(sum(max by (workspace,user,cloud,gpu,team,project,outcome) (sky_managed_job_wait_7d_tasks{workspace=~\"$workspace\",user=~\"$user\",cloud=~\"$cloud\",gpu=~\"$gpu\",team=~\"$team\",project=~\"$project\",outcome=\"failed_before_start\"} and on(job,instance) (time() - sky_managed_job_wait_snapshot_timestamp_seconds < 120))) or vector(0)) and on() (max(sky_managed_job_wait_snapshot_timestamp_seconds) > time() - 120)",
+          "expr": "(sum(max by (workspace,user,cloud,gpu,team,project,outcome) (sky_managed_job_wait_7d_tasks{workspace=~\"$workspace\",user=~\"$user\",cloud=~\"$cloud\",gpu=~\"$gpu\",team=~\"$team\",project=~\"$project\",outcome=\"failed_before_start\"} and on(job,instance) (time() - sky_managed_job_wait_snapshot_timestamp_seconds < 180))) or vector(0)) and on() (max(sky_managed_job_wait_snapshot_timestamp_seconds) > time() - 180)",
           "instant": true,
           "range": false,
           "format": "time_series",
@@ -473,7 +473,7 @@
     },
     {
       "id": 8,
-      "title": "Snapshot age \u00b7 must be < 2 minutes",
+      "title": "Snapshot age \u00b7 must be < 3 minutes",
       "type": "stat",
       "gridPos": {
         "x": 18,
@@ -510,7 +510,7 @@
               },
               {
                 "color": "red",
-                "value": 120
+                "value": 180
               }
             ]
           }
@@ -549,7 +549,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "histogram_quantile(0.95, sum by (le,gpu) (max by (workspace,user,cloud,gpu,team,project,outcome,phase,le) (sky_managed_job_wait_7d_seconds_bucket{workspace=~\"$workspace\",user=~\"$user\",cloud=~\"$cloud\",gpu=~\"$gpu\",team=~\"$team\",project=~\"$project\",outcome=\"started\",phase=\"total\"} and on(job,instance) (time() - sky_managed_job_wait_snapshot_timestamp_seconds < 120))))",
+          "expr": "histogram_quantile(0.95, sum by (le,gpu) (max by (workspace,user,cloud,gpu,team,project,outcome,phase,le) (sky_managed_job_wait_7d_seconds_bucket{workspace=~\"$workspace\",user=~\"$user\",cloud=~\"$cloud\",gpu=~\"$gpu\",team=~\"$team\",project=~\"$project\",outcome=\"started\",phase=\"total\"} and on(job,instance) (time() - sky_managed_job_wait_snapshot_timestamp_seconds < 180))))",
           "instant": true,
           "range": false,
           "format": "time_series",
@@ -596,7 +596,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "histogram_quantile(0.95, sum by (le,phase) (max by (workspace,user,cloud,gpu,team,project,outcome,phase,le) (sky_managed_job_wait_7d_seconds_bucket{workspace=~\"$workspace\",user=~\"$user\",cloud=~\"$cloud\",gpu=~\"$gpu\",team=~\"$team\",project=~\"$project\",outcome=\"started\",phase=~\"controller|launch\"} and on(job,instance) (time() - sky_managed_job_wait_snapshot_timestamp_seconds < 120))))",
+          "expr": "histogram_quantile(0.95, sum by (le,phase) (max by (workspace,user,cloud,gpu,team,project,outcome,phase,le) (sky_managed_job_wait_7d_seconds_bucket{workspace=~\"$workspace\",user=~\"$user\",cloud=~\"$cloud\",gpu=~\"$gpu\",team=~\"$team\",project=~\"$project\",outcome=\"started\",phase=~\"controller|launch\"} and on(job,instance) (time() - sky_managed_job_wait_snapshot_timestamp_seconds < 180))))",
           "instant": true,
           "range": false,
           "format": "time_series",
@@ -643,7 +643,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "sum by (user,outcome) (max by (workspace,user,cloud,gpu,team,project,outcome) (sky_managed_job_wait_7d_tasks{workspace=~\"$workspace\",user=~\"$user\",cloud=~\"$cloud\",gpu=~\"$gpu\",team=~\"$team\",project=~\"$project\"} and on(job,instance) (time() - sky_managed_job_wait_snapshot_timestamp_seconds < 120)))",
+          "expr": "sum by (user,outcome) (max by (workspace,user,cloud,gpu,team,project,outcome) (sky_managed_job_wait_7d_tasks{workspace=~\"$workspace\",user=~\"$user\",cloud=~\"$cloud\",gpu=~\"$gpu\",team=~\"$team\",project=~\"$project\"} and on(job,instance) (time() - sky_managed_job_wait_snapshot_timestamp_seconds < 180)))",
           "instant": true,
           "range": false,
           "format": "time_series",
@@ -690,7 +690,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "histogram_quantile(0.95, sum by (le,team,project) (max by (workspace,user,cloud,gpu,team,project,outcome,phase,le) (sky_managed_job_wait_7d_seconds_bucket{workspace=~\"$workspace\",user=~\"$user\",cloud=~\"$cloud\",gpu=~\"$gpu\",team=~\"$team\",project=~\"$project\",outcome=\"started\",phase=\"total\"} and on(job,instance) (time() - sky_managed_job_wait_snapshot_timestamp_seconds < 120))))",
+          "expr": "histogram_quantile(0.95, sum by (le,team,project) (max by (workspace,user,cloud,gpu,team,project,outcome,phase,le) (sky_managed_job_wait_7d_seconds_bucket{workspace=~\"$workspace\",user=~\"$user\",cloud=~\"$cloud\",gpu=~\"$gpu\",team=~\"$team\",project=~\"$project\",outcome=\"started\",phase=\"total\"} and on(job,instance) (time() - sky_managed_job_wait_snapshot_timestamp_seconds < 180))))",
           "instant": true,
           "range": false,
           "format": "time_series",
@@ -737,7 +737,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "topk(20, max by (workspace,user,cloud,gpu,team,project,job_id,task_id,outcome) (sky_managed_job_wait_outlier_seconds{workspace=~\"$workspace\",user=~\"$user\",cloud=~\"$cloud\",gpu=~\"$gpu\",team=~\"$team\",project=~\"$project\"} and on(job,instance) (time() - sky_managed_job_wait_snapshot_timestamp_seconds < 120)))",
+          "expr": "topk(20, max by (workspace,user,cloud,gpu,team,project,job_id,task_id,outcome) (sky_managed_job_wait_outlier_seconds{workspace=~\"$workspace\",user=~\"$user\",cloud=~\"$cloud\",gpu=~\"$gpu\",team=~\"$team\",project=~\"$project\"} and on(job,instance) (time() - sky_managed_job_wait_snapshot_timestamp_seconds < 180)))",
           "instant": true,
           "range": false,
           "format": "table",
@@ -813,7 +813,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "sum by (reason) (max by (workspace,user,cloud,gpu,team,project,reason) (sky_managed_job_wait_missing_tasks{workspace=~\"$workspace\",user=~\"$user\",cloud=~\"$cloud\",gpu=~\"$gpu\",team=~\"$team\",project=~\"$project\"} and on(job,instance) (time() - sky_managed_job_wait_snapshot_timestamp_seconds < 120)))",
+          "expr": "sum by (reason) (max by (workspace,user,cloud,gpu,team,project,reason) (sky_managed_job_wait_missing_tasks{workspace=~\"$workspace\",user=~\"$user\",cloud=~\"$cloud\",gpu=~\"$gpu\",team=~\"$team\",project=~\"$project\"} and on(job,instance) (time() - sky_managed_job_wait_snapshot_timestamp_seconds < 180)))",
           "instant": true,
           "range": false,
           "format": "time_series",

--- a/charts/skypilot/manifests/job-startup.md
+++ b/charts/skypilot/manifests/job-startup.md
@@ -1,0 +1,43 @@
+# Job Startup & Demand
+
+The chart provisions `skypilot-job-startup` in the existing Grafana instance when
+`grafana.enabled` and `grafana.sidecar.dashboards.enabled` are true. It uses the
+existing `prometheus` datasource and API server `/metrics` scrape. The collector
+requires managed jobs consolidation mode and the server's resilient collector
+wrapper; updating the dashboard alone does not install the metrics.
+
+## Semantics
+
+- The fixed rolling cohort is tasks first submitted in the last seven days,
+  independent of the Grafana time picker. The first task-level `PENDING` event
+  with reason `Job submitted to queue` defines submission; retry timestamps and
+  job-level cleanup events do not redefine it.
+- Startup is submission to the first task-level `RUNNING` event. `controller` is
+  submission to first `STARTING`; `launch` is first `STARTING` to first `RUNNING`,
+  including acquisition, provisioning, image pulls, setup and retries. This is
+  not a measurement of pure GPU scheduling delay. Phase percentiles do not add.
+- Tasks cancelled or failed before first run are separate outcomes. Their total
+  wait ends at the task's terminal timestamp. Cancellation after a run remains
+  in the started cohort. Current waiting gauges include tasks older than seven
+  days, and exclude recovery after a run.
+- Missing retained events and invalid chronology are reported by reason, not
+  reconstructed from mutable summary fields. Keep job events for at least seven
+  days; waiting tasks older than retention can have unknown duration.
+- All metrics are gauges. For `sky_managed_job_wait_7d_seconds_bucket`, use
+  `histogram_quantile` directly on aggregated cumulative buckets. Never apply
+  `rate` or `increase`. Counts are tasks, not GPU counts or GPU hours.
+- Dimensions are workspace, user hash, cloud, requested GPU, and persisted
+  resource labels `team` / `project`. Missing attribution is `unknown`; resource
+  alternatives can produce a comma-separated GPU label. Historical task names
+  or logs are not used to infer project membership.
+- Per-task series are limited to the global 20 longest known waits, before
+  dashboard filters. Aggregates contain no task IDs, names or commands.
+
+Snapshots refresh through the existing background collector wrapper. A failing
+or hung query retains its original snapshot timestamp. Panels discard snapshots
+older than two minutes and deduplicate API replicas before aggregation. A fresh
+empty cohort can display zero; missing/stale collection cannot.
+
+After deploying both server code and chart, verify the snapshot age is below two
+minutes and compare sampled outliers with task events in the jobs dashboard.
+Check a retried task, a cancelled-before-start task and a currently waiting task.

--- a/charts/skypilot/manifests/job-startup.md
+++ b/charts/skypilot/manifests/job-startup.md
@@ -35,9 +35,9 @@ wrapper; updating the dashboard alone does not install the metrics.
 
 Snapshots refresh through the existing background collector wrapper. A failing
 or hung query retains its original snapshot timestamp. Panels discard snapshots
-older than two minutes and deduplicate API replicas before aggregation. A fresh
+older than three minutes and deduplicate API replicas before aggregation. A fresh
 empty cohort can display zero; missing/stale collection cannot.
 
-After deploying both server code and chart, verify the snapshot age is below two
+After deploying both server code and chart, verify the snapshot age is below three
 minutes and compare sampled outliers with task events in the jobs dashboard.
 Check a retried task, a cancelled-before-start task and a currently waiting task.

--- a/charts/skypilot/templates/job-startup-grafana-configmap.yaml
+++ b/charts/skypilot/templates/job-startup-grafana-configmap.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.grafana.enabled .Values.grafana.sidecar.dashboards.enabled }}
+{{- $fullName := include "skypilot.fullname" . -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $fullName }}-job-startup-dashboard
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ $fullName }}-api
+    grafana_dashboard: "true"
+data:
+  job-startup.json: |
+{{ .Files.Get "manifests/job-startup.json" | indent 4 }}
+{{- end }}

--- a/sky/server/job_wait_metrics.py
+++ b/sky/server/job_wait_metrics.py
@@ -137,7 +137,7 @@ class JobWaitCollector:
             terminal = state.ManagedJobStatus(row['status']).is_terminal()
             previously_started = (running is not None or
                                   row['start_at'] is not None or row['status']
-                                  in ('RUNNING', 'RECOVERING', 'SUCCEEDED'))
+                                  in ('RUNNING', 'SUCCEEDED'))
             if not terminal and not previously_started:
                 waiting[key] += 1
             if queued is None:

--- a/sky/server/job_wait_metrics.py
+++ b/sky/server/job_wait_metrics.py
@@ -1,0 +1,214 @@
+"""Seven-day task startup snapshots from retained managed-job events."""
+
+import collections
+import datetime
+import re
+import time
+from typing import Any, Dict, Iterator, List, Mapping, Tuple
+
+from prometheus_client.core import GaugeMetricFamily
+import sqlalchemy as sa
+
+from sky.jobs import state
+
+_WINDOW = 7 * 86400
+_BUCKETS = (10, 30, 60, 120, 300, 600, 900, 1800, 3600, 7200, 14400, 28800,
+            86400, float('inf'))
+_LABELS = ['workspace', 'user', 'cloud', 'gpu', 'team', 'project']
+_PREFIX = 'sky_managed_job_'
+
+
+def _rows(now: float) -> List[Any]:
+    e, t, j = state.job_events_table.c, state.spot_table.c, state.job_info_table.c
+    events = sa.select(
+        e.spot_job_id,
+        e.task_id,
+        sa.func.min(
+            sa.case((sa.and_(e.new_status == 'PENDING',
+                             e.reason == 'Job submitted to queue'),
+                     e.timestamp))).label('queued'),
+        sa.func.min(sa.case(
+            (e.new_status == 'STARTING', e.timestamp))).label('accepted'),
+        sa.func.min(sa.case(
+            (e.new_status == 'RUNNING', e.timestamp))).label('running'),
+        sa.func.max(e.timestamp).label('last_event'),
+    ).where(e.task_id.is_not(None)).group_by(e.spot_job_id,
+                                             e.task_id).subquery()
+    cutoff = now - _WINDOW
+    query = sa.select(
+        t.spot_job_id,
+        t.task_id,
+        t.status,
+        t.start_at,
+        t.end_at,
+        t.full_resources,
+        t.resources,
+        j.workspace,
+        j.user_hash,
+        j.cloud,
+        events.c.queued,
+        events.c.accepted,
+        events.c.running,
+    ).select_from(
+        state.spot_table.outerjoin(
+            state.job_info_table, t.spot_job_id == j.spot_job_id).outerjoin(
+                events,
+                sa.and_(t.spot_job_id == events.c.spot_job_id,
+                        t.task_id == events.c.task_id))
+    ).where(
+        sa.or_(
+            t.submitted_at >= cutoff, t.end_at >= cutoff,
+            t.status.not_in(
+                [s.value for s in state.ManagedJobStatus.terminal_statuses()]),
+            events.c.last_event >= datetime.datetime.fromtimestamp(
+                cutoff, datetime.timezone.utc)))
+    with state._db_manager.get_engine().connect() as conn:
+        return list(conn.execute(query).mappings())
+
+
+def _timestamp(value: datetime.datetime) -> float:
+    # SQLite returns naive UTC datetimes; the exporter host need not use UTC.
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=datetime.timezone.utc)
+    return value.timestamp()
+
+
+class JobWaitCollector:
+    """Expose rolling gauges, not counters; never apply rate() to the buckets.
+
+    The cohort is tasks first submitted within seven days. Current waiting
+    gauges include older tasks. Missing retained events are reported separately.
+    Register through the server's resilient collector wrapper to bound DB work.
+    """
+
+    def describe(self) -> Iterator[GaugeMetricFamily]:
+        for name, help_text, extra in [
+            ('wait_7d_tasks', 'Tasks first submitted in the last seven days.',
+             ['outcome']),
+            ('wait_7d_seconds_bucket',
+             'Cumulative buckets of seven-day waits; rolling gauges, not counters.',
+             ['outcome', 'phase', 'le']),
+            ('wait_7d_seconds_count', 'Seven-day wait observations.',
+             ['outcome', 'phase']),
+            ('wait_7d_seconds_sum',
+             'Sum of seven-day wait observations in seconds.',
+             ['outcome', 'phase']),
+            ('waiting_tasks', 'Current tasks that have never started.', []),
+            ('oldest_wait_seconds',
+             'Oldest known current wait, including older tasks.', []),
+            ('wait_missing_tasks',
+             'Recent or active tasks with missing or invalid timing data.',
+             ['reason']),
+            ('wait_outlier_seconds',
+             'Twenty longest known waits, from the seven-day cohort or active tasks.',
+             ['job_id', 'task_id', 'outcome']),
+        ]:
+            yield GaugeMetricFamily(_PREFIX + name,
+                                    help_text,
+                                    labels=_LABELS + extra)
+        yield GaugeMetricFamily(_PREFIX + 'wait_snapshot_timestamp_seconds',
+                                'Time of the last successful wait snapshot.')
+
+    def collect(self) -> Iterator[GaugeMetricFamily]:
+        now = time.time()
+        families = {m.name: m for m in self.describe()}
+        counts: Dict[Tuple[str, ...], int] = collections.Counter()
+        waiting: Dict[Tuple[str, ...], int] = collections.Counter()
+        missing: Dict[Tuple[str, ...], int] = collections.Counter()
+        oldest: Dict[Tuple[str, ...], float] = {}
+        durations: Dict[Tuple[str, ...],
+                        List[float]] = collections.defaultdict(list)
+        outliers = []
+        for row in _rows(now):
+            resources = row['full_resources'] or {}
+            labels = resources.get('labels') or {}
+            accelerators = resources.get('accelerators')
+            gpu = ','.join(sorted(accelerators)) if accelerators else ','.join(
+                sorted(
+                    set(re.findall(r'([\w.-]+):[\d.]+', row['resources'] or
+                                   '')))) or 'unknown'
+            key: Tuple[str, ...] = (row['workspace'] or
+                                    'default', row['user_hash'] or
+                                    'unknown', row['cloud'] or 'unknown', gpu,
+                                    labels.get('team', 'unknown'),
+                                    labels.get('project', 'unknown'))
+            queued = _timestamp(row['queued']) if row['queued'] else None
+            running = _timestamp(row['running']) if row['running'] else None
+            terminal = state.ManagedJobStatus(row['status']).is_terminal()
+            previously_started = (running is not None or
+                                  row['start_at'] is not None or row['status']
+                                  in ('RUNNING', 'RECOVERING', 'SUCCEEDED'))
+            if not terminal and not previously_started:
+                waiting[key] += 1
+            if queued is None:
+                missing[key + ('submission',)] += 1
+                continue
+            recent = queued >= now - _WINDOW
+            if not recent and (terminal or previously_started):
+                continue
+            if queued > now or (running is not None and
+                                (running < queued or running > now)):
+                missing[key + ('invalid_timestamps',)] += 1
+                continue
+            if running is not None:
+                outcome, end = 'started', running
+            elif previously_started:
+                missing[key + ('start',)] += 1
+                continue
+            elif terminal:
+                outcome = ('cancelled_before_start' if row['status']
+                           == 'CANCELLED' else 'failed_before_start')
+                end = row['end_at']
+            else:
+                outcome, end = 'waiting', now
+                oldest[key] = max(oldest.get(key, 0), now - queued)
+            if recent:
+                counts[key + (outcome,)] += 1
+            if end is None:
+                missing[key + ('end',)] += 1
+                continue
+            if end < queued or end > now:
+                missing[key + ('invalid_timestamps',)] += 1
+                continue
+            elapsed = end - queued
+            outliers.append(
+                (elapsed, row['spot_job_id'], row['task_id'], key, outcome))
+            if outcome == 'waiting':
+                continue
+            durations[key + (outcome, 'total')].append(elapsed)
+            if running is not None:
+                accepted = _timestamp(
+                    row['accepted']) if row['accepted'] else None
+                if accepted is not None and queued <= accepted <= running:
+                    durations[key + (outcome, 'controller')].append(accepted -
+                                                                    queued)
+                    durations[key + (outcome, 'launch')].append(running -
+                                                                accepted)
+                else:
+                    missing[key + ('acceptance',)] += 1
+
+        grouped: List[Tuple[str,
+                            Mapping[Tuple[str, ...],
+                                    float]]] = [('wait_7d_tasks', counts),
+                                                ('waiting_tasks', waiting),
+                                                ('oldest_wait_seconds', oldest),
+                                                ('wait_missing_tasks', missing)]
+        for name, data in grouped:
+            for key, value in data.items():
+                families[_PREFIX + name].add_metric(list(key), value)
+        for key, observations in durations.items():
+            for bound in _BUCKETS:
+                le = '+Inf' if bound == float('inf') else str(bound)
+                families[_PREFIX + 'wait_7d_seconds_bucket'].add_metric(
+                    list(key) + [le], sum(v <= bound for v in observations))
+            families[_PREFIX + 'wait_7d_seconds_count'].add_metric(
+                list(key), len(observations))
+            families[_PREFIX + 'wait_7d_seconds_sum'].add_metric(
+                list(key), sum(observations))
+        for elapsed, job_id, task_id, key, outcome in sorted(outliers,
+                                                             reverse=True)[:20]:
+            families[_PREFIX + 'wait_outlier_seconds'].add_metric(
+                list(key) + [str(job_id), str(task_id), outcome], elapsed)
+        families[_PREFIX + 'wait_snapshot_timestamp_seconds'].add_metric([],
+                                                                         now)
+        yield from families.values()

--- a/sky/server/job_wait_metrics.py
+++ b/sky/server/job_wait_metrics.py
@@ -136,8 +136,8 @@ class JobWaitCollector:
             running = _timestamp(row['running']) if row['running'] else None
             terminal = state.ManagedJobStatus(row['status']).is_terminal()
             previously_started = (running is not None or
-                                  row['start_at'] is not None or row['status']
-                                  in ('RUNNING', 'SUCCEEDED'))
+                                  row['start_at'] is not None or
+                                  row['status'] in ('RUNNING', 'SUCCEEDED'))
             if not terminal and not previously_started:
                 waiting[key] += 1
             if queued is None:

--- a/sky/server/job_wait_metrics.py
+++ b/sky/server/job_wait_metrics.py
@@ -19,7 +19,8 @@ _PREFIX = 'sky_managed_job_'
 
 
 def _rows(now: float) -> List[Any]:
-    e, t, j = state.job_events_table.c, state.spot_table.c, state.job_info_table.c
+    e = state.job_events_table.c
+    t, j = state.spot_table.c, state.job_info_table.c
     events = sa.select(
         e.spot_job_id,
         e.task_id,
@@ -62,6 +63,7 @@ def _rows(now: float) -> List[Any]:
                 [s.value for s in state.ManagedJobStatus.terminal_statuses()]),
             events.c.last_event >= datetime.datetime.fromtimestamp(
                 cutoff, datetime.timezone.utc)))
+    # pylint: disable=protected-access
     with state._db_manager.get_engine().connect() as conn:
         return list(conn.execute(query).mappings())
 
@@ -86,7 +88,7 @@ class JobWaitCollector:
             ('wait_7d_tasks', 'Tasks first submitted in the last seven days.',
              ['outcome']),
             ('wait_7d_seconds_bucket',
-             'Cumulative buckets of seven-day waits; rolling gauges, not counters.',
+             'Seven-day cumulative wait buckets; gauges, not counters.',
              ['outcome', 'phase', 'le']),
             ('wait_7d_seconds_count', 'Seven-day wait observations.',
              ['outcome', 'phase']),
@@ -100,7 +102,7 @@ class JobWaitCollector:
              'Recent or active tasks with missing or invalid timing data.',
              ['reason']),
             ('wait_outlier_seconds',
-             'Twenty longest known waits, from the seven-day cohort or active tasks.',
+             'Twenty longest known waits: seven-day cohort or current waiters.',
              ['job_id', 'task_id', 'outcome']),
         ]:
             yield GaugeMetricFamily(_PREFIX + name,

--- a/sky/server/metrics.py
+++ b/sky/server/metrics.py
@@ -26,6 +26,7 @@ from sky import skypilot_config
 from sky.adaptors import kubernetes as kubernetes_adaptor
 from sky.metrics import utils as metrics_utils
 from sky.server import constants as server_constants
+from sky.server import job_wait_metrics
 from sky.skylet import runtime_utils
 from sky.utils import annotations
 from sky.utils import common
@@ -1021,6 +1022,7 @@ def maybe_register_managed_jobs_collector():
     if not managed_job_utils.is_consolidation_mode():
         return
     _MANAGED_JOBS_COLLECTOR = _wrap_collector(ManagedJobsCollector())
+    register_plugin_collector(job_wait_metrics.JobWaitCollector())
     try:
         prom.REGISTRY.register(_MANAGED_JOBS_COLLECTOR)
     except ValueError:

--- a/tests/unit_tests/test_sky/server/test_job_wait_metrics.py
+++ b/tests/unit_tests/test_sky/server/test_job_wait_metrics.py
@@ -1,0 +1,278 @@
+import datetime
+from unittest import mock
+
+import pytest
+import sqlalchemy
+
+from sky.jobs import state
+from sky.server import job_wait_metrics
+
+NOW = 1800000000.0
+
+
+@pytest.fixture
+def db(tmp_path, monkeypatch):
+    engine = sqlalchemy.create_engine(f'sqlite:///{tmp_path}/jobs.db')
+    state.Base.metadata.create_all(engine)
+    monkeypatch.setattr(state._db_manager, 'get_engine', lambda: engine)
+    yield engine
+    engine.dispose()
+
+
+def seed(db,
+         job_id,
+         status='SUCCEEDED',
+         submitted=None,
+         started=None,
+         ended=None,
+         events=(),
+         task_id=0):
+    with db.begin() as conn:
+        if task_id == 0:
+            conn.execute(state.job_info_table.insert().values(
+                spot_job_id=job_id,
+                name=f'job-{job_id}',
+                workspace='research',
+                user_hash='user-1',
+                cloud='Kubernetes'))
+        conn.execute(state.spot_table.insert().values(
+            spot_job_id=job_id,
+            task_id=task_id,
+            status=status,
+            submitted_at=submitted,
+            start_at=started,
+            end_at=ended,
+            resources='1x[L40S:1]',
+            full_resources={
+                'accelerators': {
+                    'L40S': 1
+                },
+                'labels': {
+                    'team': 'vision',
+                    'project': 'enhancement'
+                }
+            }))
+        for event_task, event_status, reason, timestamp in events:
+            conn.execute(state.job_events_table.insert().values(
+                spot_job_id=job_id,
+                task_id=event_task,
+                new_status=event_status,
+                reason=reason,
+                timestamp=datetime.datetime.fromtimestamp(
+                    timestamp, datetime.timezone.utc)))
+
+
+def samples():
+    with mock.patch.object(job_wait_metrics.time, 'time', return_value=NOW):
+        return [
+            sample for metric in job_wait_metrics.JobWaitCollector().collect()
+            for sample in metric.samples
+        ]
+
+
+def values(data, name, **labels):
+    return [
+        s.value for s in data if s.name == name and all(
+            s.labels.get(k) == v for k, v in labels.items())
+    ]
+
+
+def test_first_submission_survives_retries_and_cleanup(db):
+    seed(db,
+         1,
+         submitted=NOW - 100,
+         started=NOW - 50,
+         ended=NOW - 10,
+         events=[
+             (0, 'PENDING', 'Job submitted to queue', NOW - 1000),
+             (0, 'STARTING', 'Job is starting', NOW - 990),
+             (0, 'PENDING', 'Job is in backoff', NOW - 500),
+             (0, 'STARTING', 'Job is starting', NOW - 100),
+             (0, 'RUNNING', 'Job has started', NOW - 50),
+             (None, 'CANCELLED', 'Job has been cancelled', NOW - 5),
+         ])
+    data = samples()
+    assert values(data,
+                  'sky_managed_job_wait_7d_seconds_sum',
+                  phase='total',
+                  outcome='started') == [950]
+    assert values(data,
+                  'sky_managed_job_wait_7d_seconds_sum',
+                  phase='controller',
+                  outcome='started') == [10]
+    assert values(data,
+                  'sky_managed_job_wait_7d_seconds_sum',
+                  phase='launch',
+                  outcome='started') == [940]
+    assert values(data, 'sky_managed_job_wait_7d_tasks',
+                  outcome='started') == [1]
+
+
+def test_cancellation_failure_and_active_waits_are_separate(db):
+    for job_id, status, end in [(1, 'CANCELLED', NOW - 10),
+                                (2, 'FAILED_SETUP', NOW - 10),
+                                (3, 'STARTING', None)]:
+        seed(db,
+             job_id,
+             status=status,
+             submitted=NOW - 100,
+             ended=end,
+             events=[
+                 (0, 'PENDING', 'Job submitted to queue', NOW - 600),
+                 (0, 'STARTING', 'Job is starting', NOW - 590),
+             ])
+    data = samples()
+    assert values(data,
+                  'sky_managed_job_wait_7d_seconds_sum',
+                  outcome='cancelled_before_start') == [590]
+    assert values(data,
+                  'sky_managed_job_wait_7d_seconds_sum',
+                  outcome='failed_before_start') == [590]
+    assert values(data, 'sky_managed_job_waiting_tasks') == [1]
+    assert values(data, 'sky_managed_job_oldest_wait_seconds') == [600]
+    assert values(data,
+                  'sky_managed_job_wait_7d_seconds_count',
+                  outcome='started') == []
+
+
+def test_missing_events_are_reported_not_reconstructed_from_mutable_fields(db):
+    seed(db, 1, submitted=NOW - 100, started=NOW - 50, ended=NOW - 10)
+    seed(db,
+         2,
+         submitted=NOW - 100,
+         ended=NOW - 10,
+         events=[
+             (0, 'PENDING', 'Job submitted to queue', NOW - 100),
+         ])
+    data = samples()
+    assert values(data,
+                  'sky_managed_job_wait_missing_tasks',
+                  reason='submission') == [1]
+    assert values(data, 'sky_managed_job_wait_missing_tasks',
+                  reason='start') == [1]
+    assert values(data, 'sky_managed_job_wait_7d_seconds_count') == []
+
+
+def test_window_uses_original_submission_and_keeps_old_active_waits(db):
+    for job_id, status in [(1, 'SUCCEEDED'), (2, 'STARTING')]:
+        seed(db,
+             job_id,
+             status=status,
+             submitted=NOW - 100,
+             ended=NOW - 10 if job_id == 1 else None,
+             events=[
+                 (0, 'PENDING', 'Job submitted to queue', NOW - 8 * 86400),
+             ])
+    data = samples()
+    assert values(data, 'sky_managed_job_wait_7d_tasks') == []
+    assert values(data, 'sky_managed_job_waiting_tasks') == [1]
+    assert values(data, 'sky_managed_job_oldest_wait_seconds') == [8 * 86400]
+
+
+def test_task_events_do_not_leak_between_pipeline_tasks(db):
+    seed(db,
+         1,
+         submitted=NOW - 300,
+         started=NOW - 200,
+         ended=NOW - 190,
+         events=[
+             (0, 'PENDING', 'Job submitted to queue', NOW - 300),
+             (0, 'STARTING', 'Job is starting', NOW - 290),
+             (0, 'RUNNING', 'Job has started', NOW - 200),
+         ])
+    seed(db,
+         1,
+         task_id=1,
+         status='CANCELLED',
+         submitted=NOW - 180,
+         ended=NOW - 10,
+         events=[
+             (1, 'PENDING', 'Job submitted to queue', NOW - 180),
+             (1, 'STARTING', 'Job is starting', NOW - 170),
+         ])
+    data = samples()
+    assert values(data,
+                  'sky_managed_job_wait_7d_seconds_sum',
+                  phase='total',
+                  outcome='started') == [100]
+    assert values(data,
+                  'sky_managed_job_wait_7d_seconds_sum',
+                  outcome='cancelled_before_start') == [170]
+
+
+def test_cumulative_buckets_and_labels(db):
+    for job_id, duration in [(1, 60), (2, 600)]:
+        seed(db,
+             job_id,
+             submitted=NOW - 1000,
+             started=NOW - 1000 + duration,
+             ended=NOW - 1,
+             events=[
+                 (0, 'PENDING', 'Job submitted to queue', NOW - 1000),
+                 (0, 'RUNNING', 'Job has started', NOW - 1000 + duration),
+             ])
+    data = samples()
+    assert values(data,
+                  'sky_managed_job_wait_7d_seconds_bucket',
+                  phase='total',
+                  le='60') == [1]
+    assert values(data,
+                  'sky_managed_job_wait_7d_seconds_bucket',
+                  phase='total',
+                  le='600') == [2]
+    assert values(data,
+                  'sky_managed_job_wait_7d_seconds_bucket',
+                  phase='total',
+                  le='+Inf') == [2]
+    assert values(data,
+                  'sky_managed_job_wait_7d_tasks',
+                  team='vision',
+                  project='enhancement',
+                  gpu='L40S',
+                  workspace='research',
+                  user='user-1') == [2]
+
+
+def test_invalid_chronology_does_not_emit_negative_duration(db):
+    seed(db,
+         1,
+         submitted=NOW - 100,
+         started=NOW - 200,
+         ended=NOW - 1,
+         events=[
+             (0, 'PENDING', 'Job submitted to queue', NOW - 100),
+             (0, 'RUNNING', 'Job has started', NOW - 200),
+         ])
+    data = samples()
+    assert values(data,
+                  'sky_managed_job_wait_missing_tasks',
+                  reason='invalid_timestamps') == [1]
+    assert values(data, 'sky_managed_job_wait_7d_seconds_count') == []
+
+
+@pytest.mark.parametrize('status', ['RUNNING', 'RECOVERING'])
+def test_started_status_with_missing_history_is_not_waiting(db, status):
+    seed(db,
+         1,
+         status=status,
+         submitted=NOW - 100,
+         events=[
+             (0, 'PENDING', 'Job submitted to queue', NOW - 100),
+         ])
+    data = samples()
+    assert values(data, 'sky_managed_job_waiting_tasks') == []
+    assert values(data, 'sky_managed_job_wait_missing_tasks',
+                  reason='start') == [1]
+
+
+def test_legacy_resources_preserve_requested_gpu_type(db):
+    seed(db,
+         1,
+         status='STARTING',
+         submitted=NOW - 100,
+         events=[
+             (0, 'PENDING', 'Job submitted to queue', NOW - 100),
+         ])
+    with db.begin() as conn:
+        conn.execute(state.spot_table.update().values(full_resources=None))
+    assert values(samples(), 'sky_managed_job_waiting_tasks', gpu='L40S') == [1]

--- a/tests/unit_tests/test_sky/server/test_job_wait_metrics.py
+++ b/tests/unit_tests/test_sky/server/test_job_wait_metrics.py
@@ -250,11 +250,10 @@ def test_invalid_chronology_does_not_emit_negative_duration(db):
     assert values(data, 'sky_managed_job_wait_7d_seconds_count') == []
 
 
-@pytest.mark.parametrize('status', ['RUNNING', 'RECOVERING'])
-def test_started_status_with_missing_history_is_not_waiting(db, status):
+def test_started_status_with_missing_history_is_not_waiting(db):
     seed(db,
          1,
-         status=status,
+         status='RUNNING',
          submitted=NOW - 100,
          events=[
              (0, 'PENDING', 'Job submitted to queue', NOW - 100),
@@ -276,3 +275,26 @@ def test_legacy_resources_preserve_requested_gpu_type(db):
     with db.begin() as conn:
         conn.execute(state.spot_table.update().values(full_resources=None))
     assert values(samples(), 'sky_managed_job_waiting_tasks', gpu='L40S') == [1]
+
+
+@pytest.mark.parametrize('started', [None, NOW - 200])
+def test_recovery_only_excludes_tasks_that_previously_started(db, started):
+    seed(db,
+         1,
+         status='RECOVERING',
+         submitted=NOW - 100,
+         started=started,
+         events=[
+             (0, 'PENDING', 'Job submitted to queue', NOW - 600),
+             (0, 'STARTING', 'Job is starting', NOW - 590),
+             (0, 'RECOVERING', 'Job is recovering', NOW - 100),
+         ])
+    data = samples()
+    if started is None:
+        assert values(data, 'sky_managed_job_waiting_tasks') == [1]
+        assert values(data, 'sky_managed_job_oldest_wait_seconds') == [600]
+    else:
+        assert values(data, 'sky_managed_job_waiting_tasks') == []
+        assert values(data,
+                      'sky_managed_job_wait_missing_tasks',
+                      reason='start') == [1]


### PR DESCRIPTION
Managed-job retry timestamps can understate time from submission to the first run, while jobs cancelled during startup disappear from started-only latency summaries. Add a seven-day task cohort based on the first retained submission and RUNNING events, with separate cancelled/failed-before-start outcomes, current waiters, timing gaps, and capped per-task outliers.

The collector uses the existing background metrics wrapper in consolidation mode. A chart-provisioned **Job Startup & Demand** Grafana dashboard shows p50/p95, controller/launch phases, requested-GPU and user breakdowns, and persisted team/project labels. Queries deduplicate API replicas and exclude stale snapshots. Buckets are rolling gauges, not counters. Missing attribution stays `unknown`; startup includes provisioning/image/setup/retries and is not labelled pure GPU queue time.

Validation:
- 75 tests pass across the new collector, server metrics, managed-job metrics, and recovery-state suites. Regressions cover rewritten retry timestamps, task-vs-job cleanup, pre-start recovery, cancellations, missing history, and invalid chronology.
- Promtool query tests pass for all dashboard expressions, replica deduplication, histogram quantiles, healthy-empty results, and stale snapshots.
- Helm renders the new ConfigMap with matching dashboard JSON; YAPF/isort checks and scoped mypy (Python 3.12) pass.
- Full `format.sh` stops at the existing Python-3.9 mypy target versus installed NumPy 3.12 stubs. Repository-wide mypy also encounters duplicate example modules; unit collection has four missing-dependency errors. Repository-wide Ruff does not match this repository's YAPF/import conventions. These checks are not reported as passing.

Both server code and chart must be deployed; this PR does not update an existing server image or install the dashboard into a running cluster. The deployed server must include the resilient collector wrapper. No cloud smoke tests or infrastructure changes were run.
