### PR TITLE
[Slurm] Explain a pending job, and merge its queue history into `sky jobs events`

### DIFF
--- a/agent/skills/skypilot/references/cli-reference.md
+++ b/agent/skills/skypilot/references/cli-reference.md
@@ -327,7 +327,7 @@ Show the status-transition events of a managed job.
 - `JOB_ID` — integer
 - `TASK` — text
 - `--limit`, `-l` (default: `50`) — Number of most recent events to show, after merging every source; default 50, 0 shows all. Neither the job's own transitions nor the cluster's launch progress can be crowded out entirely.
-- `--cluster-events`, `--no-cluster-events` — Include launch-progress events from the job's cluster, e.g. why the cluster is still pending on Slurm or Kubernetes. Requires an API server on version 54 or newer.
+- `--cluster-events`, `--no-cluster-events` — Include what the infrastructure did while the job waited: the cluster's launch progress, and on Slurm the allocation's queue history and wait times. Requires an API server on version 54 or newer.
 - `--output`, `-o` (default: `table`) — Output format. Choices: table, json. Default: table.
 
 ### `sky jobs launch`

--- a/sky/adaptors/slurm.py
+++ b/sky/adaptors/slurm.py
@@ -49,14 +49,22 @@ _INVENTORY_TIMEOUT_SECONDS = 60
 # through as text rather than guessing an offset for.
 _EPOCH_TIME_ENV = 'SLURM_TIME_FORMAT=%s'
 
-# Wall-clock bound for the per-job reads that explain or reconstruct one
+# Wall-clock bounds for the per-job reads that explain or reconstruct one
 # job's history. Unlike the inventory sweep these run on request paths
 # (`sky jobs events`), where an unanswered read must not hold the caller: on
 # expiry the SSH process is killed and subprocess.TimeoutExpired is raised,
 # and every caller degrades to saying what it could not read. Public because
 # a caller that composes several of these reads bounds its own work against
-# the same figure.
+# the same figures.
+#
+# Accounting keeps a longer budget than the queue reads: it is answered by
+# slurmdbd rather than by slurmctld's in-memory queue, and on a busy one a
+# read that would have succeeded in 15s is worth more than a timeline
+# abandoned at 10. A caller that composes several reads bounds the total
+# itself, so the longer budget costs latency only on the slow clusters that
+# need it.
 JOB_READ_TIMEOUT_SECONDS = 10
+ACCOUNTING_READ_TIMEOUT_SECONDS = 20
 
 # Regex pattern to extract partition names from scontrol output
 # Matches PartitionName=<name> and captures until the next field
@@ -495,6 +503,7 @@ class SlurmClient:
         self,
         job_name: Optional[str] = None,
         state_filters: Optional[List[str]] = None,
+        timeout: Optional[int] = None,
     ) -> List[str]:
         """Query Slurm jobs by state and optional name.
 
@@ -502,6 +511,9 @@ class SlurmClient:
             job_name: Optional job name to filter by.
             state_filters: List of job states to filter by
                 (e.g., ['running', 'pending']). If None, returns all jobs.
+            timeout: Bounds the read, for a caller on a request path. The
+                default leaves the runner's own behaviour untouched, which is
+                what the provisioner has while it waits for an allocation.
 
         Returns:
             List of job IDs matching the filters.
@@ -513,7 +525,7 @@ class SlurmClient:
         if job_name is not None:
             cmd += f' --name {job_name}'
 
-        rc, stdout, stderr = self._run_slurm_cmd(cmd)
+        rc, stdout, stderr = self._run_slurm_cmd(cmd, timeout=timeout)
         subprocess_utils.handle_returncode(rc,
                                            cmd,
                                            'Failed to query Slurm jobs.',

--- a/sky/adaptors/slurm.py
+++ b/sky/adaptors/slurm.py
@@ -980,6 +980,57 @@ class SlurmClient:
             })
         return rows
 
+    def get_job_accounting(self, job_id: str) -> List[Dict[str, str]]:
+        """Accounting records for ``job_id``: what happened, and when.
+
+        This is the only source for a job Slurm has already forgotten --
+        squeue drops it MinJobAge after it finishes (5 minutes by default) --
+        and the only one that carries the exit code and the original submit
+        line.
+
+        One row per record, and there can be several:
+
+        - a **job array** id returns one row per element, each with its own
+          eligible/start time, so a caller passing a base id groups by the
+          returned JobID rather than expecting one record;
+        - a **requeued** job returns one row per attempt, which is what ``-D``
+          is for. Without it only the latest survives, and since a requeue
+          *resets* Submit, the job would appear to have been submitted at the
+          moment of its last attempt. SkyPilot passes --no-requeue for its
+          own allocations precisely because requeue is expected on jobs it
+          does not control, which is the population this read serves.
+
+        Empty when accounting is not configured (no slurmdbd), which is a
+        cluster shape rather than an error: the caller says the history is
+        unavailable instead of reporting that nothing happened.
+        """
+        fields = ('job_id', 'state', 'reason', 'submit', 'eligible', 'start',
+                  'end', 'exit_code', 'derived_exit_code', 'restarts',
+                  'submit_line')
+        fmt = ('JobID,State,Reason,Submit,Eligible,Start,End,ExitCode,'
+               'DerivedExitCode,Restarts,SubmitLine')
+        # -X: the job, not its steps. -D: every attempt, see above. -P with
+        # -n: pipe-separated and unheadered, so the parse needs no column
+        # arithmetic.
+        cmd = f'sacct -j {job_id} -X -D -P -n --format={fmt}'
+        rc, stdout, stderr = self._run_slurm_cmd(cmd)
+        if rc != 0:
+            logger.debug(f'sacct for job {job_id} failed: '
+                         f'{(stderr or stdout).strip()[:200]}')
+            return []
+        rows = []
+        for line in stdout.strip().splitlines():
+            # SubmitLine is the last field and can itself contain anything,
+            # pipes included, so the split is bounded and the remainder is
+            # the command line.
+            parts = line.split('|', len(fields) - 1)
+            if len(parts) != len(fields):
+                continue
+            row = dict(zip(fields, (p.strip() for p in parts)))
+            if row['job_id']:
+                rows.append(row)
+        return rows
+
     def get_pending_job_count(self,
                               partition: str,
                               exclude_job_id: Optional[str] = None) -> int:

--- a/sky/adaptors/slurm.py
+++ b/sky/adaptors/slurm.py
@@ -893,6 +893,93 @@ class SlurmClient:
 
         return output if output != 'None' else None
 
+    def get_pending_job_details(self, job_id: str) -> Dict[str, str]:
+        """The fields that explain why a job is not running, in one call.
+
+        ``get_job_reason`` answers with the reason alone, which is all the
+        launch spinner needs. Explaining the reason needs more: the partition
+        it is queued in, the dependency expression Slurm has not satisfied
+        yet, and its scheduling priority relative to the queue. One squeue
+        invocation returns all of them, so asking costs the same round trip as
+        asking for the reason did.
+
+        Empty dict when the job is unknown -- Slurm forgets a finished job
+        after MinJobAge, which is a normal outcome rather than an error.
+        """
+        fields = ('state', 'reason', 'partition', 'dependency', 'priority',
+                  'gres', 'num_nodes', 'qos', 'start_time')
+        # %E is the *unsatisfied* dependency list, annotated per entry
+        # ('afterok:5122(unfulfilled)'); Slurm drops an entry once it is met,
+        # so this shrinks as the job unblocks. %Q is the integer priority,
+        # not the normalized float %p.
+        fmt = SEP.join(('%T', '%R', '%P', '%E', '%Q', '%b', '%D', '%q', '%S'))
+        cmd = f'squeue -h --jobs {job_id} --states all -o "{fmt}"'
+        rc, stdout, _ = self._run_slurm_cmd(cmd)
+        if rc != 0:
+            return {}
+        line = stdout.strip().splitlines()
+        if not line:
+            return {}
+        # SEP is the literal four characters '\x1f': squeue passes the format
+        # through and the shell does not expand it either, so the separator
+        # arrives verbatim -- same as every other split in this file.
+        parts = line[0].split(SEP)
+        if len(parts) != len(fields):
+            logger.debug(f'Unexpected squeue field count for job {job_id}: '
+                         f'{len(parts)} != {len(fields)}')
+            return {}
+        details = dict(zip(fields, (p.strip() for p in parts)))
+        return {k: v for k, v in details.items() if v and v != 'N/A'}
+
+    def get_job_states(self, job_ids: Sequence[str]) -> Dict[str, str]:
+        """State of each of ``job_ids``, in one call.
+
+        For explaining a dependency: the ids come from the job's own
+        dependency expression, and what a caller wants to know is whether each
+        one is still queued, running, or gone. An id Slurm has forgotten is
+        absent from the result rather than reported as unknown -- the caller
+        can tell those apart and says so differently.
+        """
+        if not job_ids:
+            return {}
+        joined = ','.join(job_ids)
+        cmd = f'squeue -h --jobs {joined} --states all -o "%i{SEP}%T"'
+        rc, stdout, _ = self._run_slurm_cmd(cmd)
+        if rc != 0:
+            return {}
+        states = {}
+        for line in stdout.strip().splitlines():
+            parts = line.split(SEP)
+            if len(parts) == 2 and parts[0].strip():
+                states[parts[0].strip()] = parts[1].strip()
+        return states
+
+    def get_pending_queue(self) -> List[Dict[str, str]]:
+        """Every pending job with its partition and scheduling priority.
+
+        This is what "how many jobs are ahead of mine" needs: the count of
+        *pending* jobs in a partition says nothing on its own, since Slurm
+        runs the queue by priority rather than by arrival. One row per pending
+        job, and the caller compares priorities.
+        """
+        cmd = ('squeue -h --states=pending '
+               f'-o "%i{SEP}%P{SEP}%Q{SEP}%T"')
+        rc, stdout, _ = self._run_slurm_cmd(cmd)
+        if rc != 0:
+            return []
+        rows = []
+        for line in stdout.strip().splitlines():
+            parts = line.split(SEP)
+            if len(parts) != 4:
+                continue
+            rows.append({
+                'job_id': parts[0].strip(),
+                'partition': parts[1].strip(),
+                'priority': parts[2].strip(),
+                'state': parts[3].strip(),
+            })
+        return rows
+
     def get_pending_job_count(self,
                               partition: str,
                               exclude_job_id: Optional[str] = None) -> int:

--- a/sky/adaptors/slurm.py
+++ b/sky/adaptors/slurm.py
@@ -4,8 +4,10 @@ import base64
 import binascii
 import ipaddress
 import logging
+import math
 import re
 import shlex
+import time
 from typing import Dict, List, NamedTuple, Optional, Sequence, Tuple
 
 from sky.adaptors import common
@@ -38,6 +40,23 @@ _JOB_STEP_NOT_FOUND_REGEX = re.compile(
 # expiry the SSH process is killed and subprocess.TimeoutExpired is raised,
 # which the aggregation callers degrade to an empty per-cluster result.
 _INVENTORY_TIMEOUT_SECONDS = 60
+
+# Slurm renders every timestamp in the *cluster's* local timezone by default,
+# with nothing in the output saying which one that is -- a reader on another
+# host cannot convert it. Asking for `%s` returns epoch seconds instead, so
+# the answer carries no timezone at all. Honored by squeue and sacct alike;
+# a build old enough to ignore it returns the ISO form, which callers pass
+# through as text rather than guessing an offset for.
+_EPOCH_TIME_ENV = 'SLURM_TIME_FORMAT=%s'
+
+# Wall-clock bound for the per-job reads that explain or reconstruct one
+# job's history. Unlike the inventory sweep these run on request paths
+# (`sky jobs events`), where an unanswered read must not hold the caller: on
+# expiry the SSH process is killed and subprocess.TimeoutExpired is raised,
+# and every caller degrades to saying what it could not read. Public because
+# a caller that composes several of these reads bounds its own work against
+# the same figure.
+JOB_READ_TIMEOUT_SECONDS = 10
 
 # Regex pattern to extract partition names from scontrol output
 # Matches PartitionName=<name> and captures until the next field
@@ -608,14 +627,17 @@ class SlurmClient:
             stream_logs=False)
         return stdout
 
-    def info_nodes(self) -> List[NodeInfo]:
+    def info_nodes(self, timeout: Optional[int] = None) -> List[NodeInfo]:
         """Get Slurm node information.
 
         Returns node names, states, GRES (generic resources like GPUs),
         CPUs, memory (MB), and partitions.
+
+        ``timeout`` bounds the read for callers on a request path; the
+        default leaves the runner's own behaviour untouched.
         """
         cmd = _INFO_NODES_CMD
-        rc, stdout, stderr = self._run_slurm_cmd(cmd)
+        rc, stdout, stderr = self._run_slurm_cmd(cmd, timeout=timeout)
         subprocess_utils.handle_returncode(
             rc,
             cmd,
@@ -913,8 +935,10 @@ class SlurmClient:
         # so this shrinks as the job unblocks. %Q is the integer priority,
         # not the normalized float %p.
         fmt = SEP.join(('%T', '%R', '%P', '%E', '%Q', '%b', '%D', '%q', '%S'))
-        cmd = f'squeue -h --jobs {job_id} --states all -o "{fmt}"'
-        rc, stdout, _ = self._run_slurm_cmd(cmd)
+        cmd = (f'{_EPOCH_TIME_ENV} squeue -h --jobs {job_id} '
+               f'--states all -o "{fmt}"')
+        rc, stdout, _ = self._run_slurm_cmd(cmd,
+                                            timeout=JOB_READ_TIMEOUT_SECONDS)
         if rc != 0:
             return {}
         line = stdout.strip().splitlines()
@@ -944,7 +968,8 @@ class SlurmClient:
             return {}
         joined = ','.join(job_ids)
         cmd = f'squeue -h --jobs {joined} --states all -o "%i{SEP}%T"'
-        rc, stdout, _ = self._run_slurm_cmd(cmd)
+        rc, stdout, _ = self._run_slurm_cmd(cmd,
+                                            timeout=JOB_READ_TIMEOUT_SECONDS)
         if rc != 0:
             return {}
         states = {}
@@ -964,7 +989,8 @@ class SlurmClient:
         """
         cmd = ('squeue -h --states=pending '
                f'-o "%i{SEP}%P{SEP}%Q{SEP}%T"')
-        rc, stdout, _ = self._run_slurm_cmd(cmd)
+        rc, stdout, _ = self._run_slurm_cmd(cmd,
+                                            timeout=JOB_READ_TIMEOUT_SECONDS)
         if rc != 0:
             return []
         rows = []
@@ -980,7 +1006,10 @@ class SlurmClient:
             })
         return rows
 
-    def get_job_accounting(self, job_id: str) -> List[Dict[str, str]]:
+    def get_job_accounting(self,
+                           job_id: str,
+                           timeout: Optional[int] = JOB_READ_TIMEOUT_SECONDS
+                          ) -> List[Dict[str, str]]:
         """Accounting records for ``job_id``: what happened, and when.
 
         This is the only source for a job Slurm has already forgotten --
@@ -1004,18 +1033,53 @@ class SlurmClient:
         cluster shape rather than an error: the caller says the history is
         unavailable instead of reporting that nothing happened.
         """
+        # -j is also what puts the whole history in scope: sacct's default
+        # start time is 00:00:00 today for every other selector, and the
+        # epoch when a job id is given.
+        return self._job_accounting(f'-j {shlex.quote(job_id)}', timeout)
+
+    def get_job_accounting_by_name(
+        self,
+        job_name: str,
+        since: int,
+        timeout: Optional[int] = JOB_READ_TIMEOUT_SECONDS
+    ) -> List[Dict[str, str]]:
+        """Accounting records of every job named ``job_name``.
+
+        For a caller that knows the name it submitted under but not the id
+        Slurm assigned: SkyPilot names a Slurm allocation after the cluster's
+        ``cluster_name_on_cloud``, so a cluster resolves to its allocation
+        without a lookup of its own. Names are not unique -- a relaunch under
+        the same cluster name is a second allocation -- and every match is
+        returned, newest last, for the caller to group.
+
+        ``since`` (epoch seconds) is required because ``--name`` leaves
+        sacct's default start time at 00:00:00 *today*: without a window a
+        job submitted yesterday is simply missing from the answer. It is
+        passed to sacct **relatively** ("30 minutes ago"), which keeps the two
+        hosts' clocks from having to agree on a timezone.
+        """
+        minutes = max(1, math.ceil((time.time() - since) / 60)) + 1
+        selector = (f'--name={shlex.quote(job_name)} '
+                    f'-S now-{minutes}minutes')
+        return self._job_accounting(selector, timeout)
+
+    def _job_accounting(self, selector: str,
+                        timeout: Optional[int]) -> List[Dict[str, str]]:
+        """The shared sacct read behind the two accounting queries above."""
         fields = ('job_id', 'state', 'reason', 'submit', 'eligible', 'start',
                   'end', 'exit_code', 'derived_exit_code', 'restarts',
-                  'submit_line')
+                  'partition', 'nodes', 'submit_line')
         fmt = ('JobID,State,Reason,Submit,Eligible,Start,End,ExitCode,'
-               'DerivedExitCode,Restarts,SubmitLine')
+               'DerivedExitCode,Restarts,Partition,NodeList,SubmitLine')
         # -X: the job, not its steps. -D: every attempt, see above. -P with
         # -n: pipe-separated and unheadered, so the parse needs no column
         # arithmetic.
-        cmd = f'sacct -j {job_id} -X -D -P -n --format={fmt}'
-        rc, stdout, stderr = self._run_slurm_cmd(cmd)
+        cmd = (f'{_EPOCH_TIME_ENV} sacct {selector} -X -D -P -n '
+               f'--format={fmt}')
+        rc, stdout, stderr = self._run_slurm_cmd(cmd, timeout=timeout)
         if rc != 0:
-            logger.debug(f'sacct for job {job_id} failed: '
+            logger.debug(f'sacct ({selector}) failed: '
                          f'{(stderr or stdout).strip()[:200]}')
             return []
         rows = []

--- a/sky/adaptors/slurm.py
+++ b/sky/adaptors/slurm.py
@@ -1018,10 +1018,11 @@ class SlurmClient:
             })
         return rows
 
-    def get_job_accounting(self,
-                           job_id: str,
-                           timeout: Optional[int] = JOB_READ_TIMEOUT_SECONDS
-                          ) -> List[Dict[str, str]]:
+    def get_job_accounting(
+        self,
+        job_id: str,
+        timeout: Optional[int] = ACCOUNTING_READ_TIMEOUT_SECONDS
+    ) -> List[Dict[str, str]]:
         """Accounting records for ``job_id``: what happened, and when.
 
         This is the only source for a job Slurm has already forgotten --
@@ -1054,7 +1055,7 @@ class SlurmClient:
         self,
         job_name: str,
         since: int,
-        timeout: Optional[int] = JOB_READ_TIMEOUT_SECONDS
+        timeout: Optional[int] = ACCOUNTING_READ_TIMEOUT_SECONDS
     ) -> List[Dict[str, str]]:
         """Accounting records of every job named ``job_name``.
 

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -6683,10 +6683,10 @@ def _format_job_event_time(timestamp: Any) -> str:
 @click.option('--cluster-events/--no-cluster-events',
               default=True,
               show_default=True,
-              help=('Include launch-progress events from the job\'s cluster, '
-                    'e.g. why the cluster is still pending on Slurm or '
-                    'Kubernetes. Requires an API server on version 54 or '
-                    'newer.'))
+              help=('Include what the infrastructure did while the job '
+                    'waited: the cluster\'s launch progress, and on Slurm '
+                    'the allocation\'s queue history and wait times. '
+                    'Requires an API server on version 54 or newer.'))
 @flags.output_format_option()
 @usage_lib.entrypoint
 def jobs_events(job_id: int, task: Optional[str], limit: int,
@@ -6703,8 +6703,10 @@ def jobs_events(job_id: int, task: Optional[str], limit: int,
 
     Provisioning milestones from the job's cluster are merged in by default,
     which is where a Slurm pending reason or a Kubernetes image-pull wait
-    shows up. Pass ``--no-cluster-events`` for the job's own status
-    transitions only.
+    shows up. On Slurm the allocation's own queue history comes with them:
+    how long it waited to become eligible, how long it then waited for
+    resources, and how it ended. Pass ``--no-cluster-events`` for the job's
+    own status transitions only.
 
     Use ``-o json`` for machine-readable output.
 

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -289,6 +289,12 @@ cluster_event_table = sqlalchemy.Table(
     sqlalchemy.Column('transitioned_at', sqlalchemy.Integer, primary_key=True),
     sqlalchemy.Column('type', sqlalchemy.Text),
     sqlalchemy.Column('request_id', sqlalchemy.Text, server_default=None),
+    # The primary key is (cluster_hash, reason, transitioned_at), but the two
+    # readers that have to survive a cluster's teardown look events up by
+    # `name` instead -- see get_latest_cluster_events and
+    # get_cluster_events_by_name. Without this they scan the whole table.
+    sqlalchemy.Index('ix_cluster_events_name_type', 'name', 'type',
+                     'transitioned_at'),
 )
 
 ssh_key_table = sqlalchemy.Table(

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -2064,6 +2064,11 @@ def _slurm_allocations(
     "why did this wait six hours" answerable after the fact; without it the
     timeline would only ever be visible while the job was still running.
     """
+    # Once a cluster record is gone there is no cheap way to know which cloud
+    # it ran on, so the fallback below would otherwise run for every finished
+    # job on every cloud. A deployment with no Slurm cluster configured skips
+    # it outright: reading ~/.slurm/config is a stat, the lookup is not.
+    slurm_configured: Optional[bool] = None
     allocations: List[_SlurmAllocation] = []
     for cluster_name, task_id in clusters:
         try:
@@ -2083,6 +2088,15 @@ def _slurm_allocations(
                 continue
         if record is not None:
             # The cluster is there and is not on Slurm.
+            continue
+        if slurm_configured is None:
+            try:
+                slurm_configured = bool(
+                    clouds.Slurm.existing_allowed_clusters(silent=True))
+            except Exception as e:  # pylint: disable=broad-except
+                logger.debug(f'Could not list Slurm clusters: {e}')
+                slurm_configured = False
+        if not slurm_configured:
             continue
         allocations.extend(_recorded_allocations(cluster_name, task_id))
     return allocations
@@ -2110,8 +2124,12 @@ def _recorded_allocations(cluster_name: str,
         ids = by_cluster.setdefault(match.group('cluster'), [])
         if match.group('job_id') not in ids:
             ids.append(match.group('job_id'))
+    # Events arrive newest first; the ids are reversed so the *oldest*
+    # attempt is read first, because the deadline can cut the read short and
+    # the early attempt is the one a "why did this wait so long" question is
+    # about.
     return [
-        _SlurmAllocation(slurm_cluster, None, ids, task_id)
+        _SlurmAllocation(slurm_cluster, None, list(reversed(ids)), task_id)
         for slurm_cluster, ids in by_cluster.items()
     ]
 

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -16,6 +16,7 @@ import colorama
 from pydantic import SecretStr as _SecretStr
 
 from sky import backends
+from sky import clouds
 from sky import core
 from sky import exceptions
 from sky import execution
@@ -38,6 +39,7 @@ from sky.jobs import state as managed_job_state
 from sky.jobs import utils as managed_job_utils
 from sky.metrics import utils as metrics_lib
 from sky.provision import common as provision_common
+from sky.provision.slurm import utils as slurm_provision_utils
 from sky.schemas.api import responses
 from sky.serve import serve_state
 from sky.serve import serve_utils
@@ -2019,6 +2021,114 @@ def _resolve_task_id(job_id: int, task: Union[str, int]) -> int:
                      f'Tasks: {names}.')
 
 
+# How long the Slurm side of a job-events request may take in total. Two
+# reads' worth: enough for the accounting read plus one diagnosis on a
+# healthy login node, and short enough that an unresponsive one does not turn
+# a status request into a minute of waiting.
+_SLURM_TIMELINE_BUDGET_SECONDS = 20
+
+
+def _slurm_allocations(
+    clusters: List[Tuple[str, Optional[int]]]
+) -> List[Tuple[str, str, Optional[int]]]:
+    """``(slurm cluster, sbatch job name, task id)`` per Slurm-backed cluster.
+
+    A Slurm-backed SkyPilot cluster is one long-running ``sbatch`` allocation
+    named after its ``cluster_name_on_cloud``, submitted to the Slurm cluster
+    the resources' ``region`` names (see ``provision/slurm/instance.py``).
+    Both facts live on the cluster record, which teardown removes -- so an
+    allocation is resolvable only while its cluster exists, which is the
+    window in which "why is this not running yet" gets asked. A job whose
+    cluster is gone keeps its own transitions and the durations they carry.
+    """
+    allocations: List[Tuple[str, str, Optional[int]]] = []
+    for cluster_name, task_id in clusters:
+        try:
+            record = global_user_state.get_cluster_from_name(
+                cluster_name, include_user_info=False)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.debug(f'Failed to read cluster {cluster_name!r}: {e}')
+            continue
+        handle = record.get('handle') if record is not None else None
+        resources = getattr(handle, 'launched_resources', None)
+        if resources is None or not isinstance(resources.cloud, clouds.Slurm):
+            continue
+        name_on_cloud = getattr(handle, 'cluster_name_on_cloud', None)
+        if resources.region and name_on_cloud:
+            allocations.append((resources.region, name_on_cloud, task_id))
+    return allocations
+
+
+def _job_submitted_at(job_id: int) -> int:
+    """When the job first entered the queue, as epoch seconds.
+
+    This bounds how far back a name-based ``sacct`` query looks. A job with no
+    recorded submit time falls back to a fortnight, which reaches further than
+    any allocation still resolvable through a live cluster record.
+    """
+    stamps = [
+        task.get('submitted_at')
+        for task in managed_job_state.get_managed_job_tasks(job_id)
+    ]
+    known = [int(stamp) for stamp in stamps if stamp]
+    return min(known) if known else int(time.time()) - 14 * 24 * 3600
+
+
+def _slurm_timeline_events(
+        job_id: int, clusters: List[Tuple[str, Optional[int]]],
+        tz: Optional[datetime.tzinfo]) -> List[Dict[str, Any]]:
+    """Slurm's own account of the job's allocations, as event rows.
+
+    What it adds over the launch-progress events: the *durations* of the two
+    waits Slurm imposes, which no SkyPilot-side event records, plus the
+    allocation's final state and exit code.
+
+    The rows carry no ``new_status``. A cluster event happens while the
+    managed job is STARTING and is reported as such; these are the
+    scheduler's facts about an allocation rather than a transition of the
+    job, and claiming a status change at that instant would be wrong. Every
+    other field matches the job events they merge with, so no consumer has to
+    know they are here.
+    """
+    allocations = _slurm_allocations(clusters)
+    if not allocations:
+        return []
+    since = _job_submitted_at(job_id)
+    # One budget for the whole merge, not per read. `sky jobs events` is a
+    # SHORT request, and a login node that accepts the connection but never
+    # answers would otherwise cost one read timeout per read, multiplied by
+    # the number of allocations. The reads keep their own timeouts, so the
+    # true ceiling is this plus whichever read is in flight when it passes.
+    deadline = time.monotonic() + _SLURM_TIMELINE_BUDGET_SECONDS
+    rows: List[Dict[str, Any]] = []
+    for slurm_cluster, job_name, task_id in allocations:
+        if time.monotonic() >= deadline:
+            logger.debug(f'Out of time to read the Slurm timeline of job '
+                         f'{job_id}; {job_name!r} on {slurm_cluster} and any '
+                         'later allocation are skipped')
+            break
+        try:
+            entries = slurm_provision_utils.job_timeline(slurm_cluster,
+                                                         job_name,
+                                                         since,
+                                                         deadline=deadline)
+        except Exception as e:  # pylint: disable=broad-except
+            # Best-effort, like the cluster-event merge: an unreachable login
+            # node must not fail the request.
+            logger.debug(f'Failed to read the Slurm timeline of job {job_id} '
+                         f'(allocation {job_name!r} on {slurm_cluster}): {e}')
+            continue
+        rows.extend({
+            'spot_job_id': job_id,
+            'task_id': task_id,
+            'new_status': None,
+            'code': None,
+            'reason': entry['text'],
+            'timestamp': datetime.datetime.fromtimestamp(entry['at'], tz=tz),
+        } for entry in entries)
+    return rows
+
+
 @usage_lib.entrypoint
 def get_job_events(
     job_id: int,
@@ -2035,10 +2145,13 @@ def get_job_events(
         task: Optional task name or id to filter by, resolved here. Takes
             precedence over task_id. A name that matches no task raises.
         limit: Optional limit on number of task events to return (default 10).
-        include_cluster_events: When True, merge launch-progress events from
-            the job's underlying cluster (e.g. image pulling) into the
-            timeline so provisioning milestones between STARTING and RUNNING
-            are visible.
+        include_cluster_events: When True, merge what the infrastructure did
+            while the job waited into the timeline, so the milestones between
+            STARTING and RUNNING are visible: the cluster's launch-progress
+            events (e.g. image pulling), and, for a job running on Slurm, the
+            allocation's own history from ``sacct`` -- how long it waited to
+            become eligible, how long it then waited for resources, and how
+            it ended.
 
     Returns:
         List of task event records, ordered newest first.
@@ -2086,7 +2199,7 @@ def get_job_events(
     # transitioned_at is a UTC epoch, so fromtimestamp(tz=...) yields the
     # correct instant in whichever timezone the job events use.
     tz = events[0]['timestamp'].tzinfo if events else None
-    converted = [
+    converted: List[Dict[str, Any]] = [
         {
             'spot_job_id': job_id,
             'task_id': cluster_task_id,
@@ -2098,6 +2211,18 @@ def get_job_events(
                 cluster_event['transitioned_at'], tz=tz),
         } for cluster_event, cluster_task_id in cluster_events
     ]
+    # The Slurm timeline is the same kind of row -- what the infrastructure
+    # did while the job waited -- so it shares the cluster events' share of
+    # the budget below rather than competing for the job's own.
+    try:
+        converted.extend(_slurm_timeline_events(job_id, clusters, tz))
+    except Exception as e:  # pylint: disable=broad-except
+        # The guard belongs here rather than around the read alone: resolving
+        # the allocations and the job's submit time are database reads of
+        # their own, and by this point the request already has its job events
+        # to return.
+        logger.debug(f'Failed to merge the Slurm timeline of job {job_id}: '
+                     f'{e}')
 
     # Every event's 'timestamp' is a datetime (job events from the DB, cluster
     # events converted above). datetime.timestamp() gives a comparable epoch.
@@ -2108,13 +2233,22 @@ def get_job_events(
 
     if limit is None:
         return _newest_first(events + converted)
-    # Neither source may be starved. One launch can produce more cluster
-    # events than `limit`, and dropping the oldest rows would hide the
+    # Neither source may be starved. One launch can produce more infra rows
+    # than `limit`, and dropping the oldest would hide the
     # PENDING -> STARTING -> RUNNING sequence the timeline is read for; but a
     # job with many recoveries can fill the budget with its own transitions,
-    # and the launch reason the user is waiting on is usually the newest row
-    # of all. So the cluster side keeps a floor of half the budget (at least
-    # one row), and the trailing cut then trims the oldest job events.
-    cluster_floor = min(max(limit // 2, 1), len(converted))
-    room = max(limit - len(events), cluster_floor)
-    return _newest_first(events + _newest_first(converted)[:room])[:limit]
+    # and what the reader is waiting on is usually on the infra side. So the
+    # job's own events take the budget first, the infra side is guaranteed a
+    # share of what is left, and recency settles the remainder.
+    floor = min(max(limit // 2, 1), len(converted))
+    room = max(limit - len(events), floor)
+    candidates = _newest_first(converted)[:room]
+    # The share has to be *reserved*, not merely offered as a candidate: the
+    # final cut is by recency, and a Slurm timeline is older than a recent
+    # transition by nature -- submitted/eligible/started all happen early --
+    # so a job with a full budget of newer events would hide it entirely.
+    # Capped so the job's own newest row never loses its slot; at limit=1
+    # that leaves the single row to whichever source is newest.
+    reserved = min(floor, len(candidates), limit - (1 if events else 0))
+    rest = _newest_first(events + candidates[reserved:])
+    return _newest_first(candidates[:reserved] + rest[:limit - reserved])

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -3,12 +3,13 @@ import datetime
 import ipaddress
 import os
 import pathlib
+import re
 import shlex
 import sys
 import tempfile
 import time
 import typing
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple, Union
 from urllib import parse as urlparse
 import uuid
 
@@ -2028,35 +2029,91 @@ def _resolve_task_id(job_id: int, task: Union[str, int]) -> int:
 _SLURM_TIMELINE_BUDGET_SECONDS = 20
 
 
+class _SlurmAllocation(NamedTuple):
+    """How to ask Slurm about one of a job's allocations.
+
+    Exactly one of ``job_name`` and ``job_ids`` is set: the live cluster
+    record gives the sbatch job name, while the events written at submission
+    give the ids directly.
+    """
+    slurm_cluster: str
+    job_name: Optional[str]
+    job_ids: List[str]
+    task_id: Optional[int]
+
+
+# `Launching (Slurm job 17269 on hyperpod-slurm)`, written by
+# provision/slurm/instance.py when an allocation is submitted.
+_SLURM_ALLOCATION_RE = re.compile(
+    r'^Launching \(Slurm job (?P<job_id>\S+) on (?P<cluster>.+)\)$')
+
+
 def _slurm_allocations(
-    clusters: List[Tuple[str, Optional[int]]]
-) -> List[Tuple[str, str, Optional[int]]]:
-    """``(slurm cluster, sbatch job name, task id)`` per Slurm-backed cluster.
+        clusters: List[Tuple[str, Optional[int]]]) -> List[_SlurmAllocation]:
+    """One entry per Slurm-backed cluster of the job.
 
     A Slurm-backed SkyPilot cluster is one long-running ``sbatch`` allocation
     named after its ``cluster_name_on_cloud``, submitted to the Slurm cluster
     the resources' ``region`` names (see ``provision/slurm/instance.py``).
-    Both facts live on the cluster record, which teardown removes -- so an
-    allocation is resolvable only while its cluster exists, which is the
-    window in which "why is this not running yet" gets asked. A job whose
-    cluster is gone keeps its own transitions and the durations they carry.
+    While the cluster exists its record carries both facts, and that is the
+    authoritative answer.
+
+    Teardown removes the record, so a finished job falls back to the events
+    the provisioner wrote when it submitted each allocation -- which outlive
+    the cluster, and name the allocation by id. That fallback is what makes
+    "why did this wait six hours" answerable after the fact; without it the
+    timeline would only ever be visible while the job was still running.
     """
-    allocations: List[Tuple[str, str, Optional[int]]] = []
+    allocations: List[_SlurmAllocation] = []
     for cluster_name, task_id in clusters:
         try:
             record = global_user_state.get_cluster_from_name(
                 cluster_name, include_user_info=False)
         except Exception as e:  # pylint: disable=broad-except
             logger.debug(f'Failed to read cluster {cluster_name!r}: {e}')
-            continue
+            record = None
         handle = record.get('handle') if record is not None else None
         resources = getattr(handle, 'launched_resources', None)
-        if resources is None or not isinstance(resources.cloud, clouds.Slurm):
+        if resources is not None and isinstance(resources.cloud, clouds.Slurm):
+            name_on_cloud = getattr(handle, 'cluster_name_on_cloud', None)
+            if resources.region and name_on_cloud:
+                allocations.append(
+                    _SlurmAllocation(resources.region, name_on_cloud, [],
+                                     task_id))
+                continue
+        if record is not None:
+            # The cluster is there and is not on Slurm.
             continue
-        name_on_cloud = getattr(handle, 'cluster_name_on_cloud', None)
-        if resources.region and name_on_cloud:
-            allocations.append((resources.region, name_on_cloud, task_id))
+        allocations.extend(_recorded_allocations(cluster_name, task_id))
     return allocations
+
+
+def _recorded_allocations(cluster_name: str,
+                          task_id: Optional[int]) -> List[_SlurmAllocation]:
+    """The allocations of a cluster that no longer exists, from its events.
+
+    One entry per Slurm cluster, carrying every id recorded for it -- a job
+    that recovered submitted more than one, and each is a separate attempt
+    worth reporting.
+    """
+    try:
+        events = global_user_state.get_cluster_events_by_name(
+            cluster_name, [global_user_state.ClusterEventType.LAUNCH_PROGRESS])
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f'Failed to read events of {cluster_name!r}: {e}')
+        return []
+    by_cluster: Dict[str, List[str]] = {}
+    for event in events:
+        match = _SLURM_ALLOCATION_RE.match(str(event.get('reason', '')))
+        if match is None:
+            continue
+        ids = by_cluster.setdefault(match.group('cluster'), [])
+        if match.group('job_id') not in ids:
+            ids.append(match.group('job_id'))
+    return [
+        _SlurmAllocation(slurm_cluster, None, ids, task_id)
+        for slurm_cluster, ids in by_cluster.items()
+    ]
 
 
 def _job_submitted_at(job_id: int) -> int:
@@ -2101,26 +2158,32 @@ def _slurm_timeline_events(
     # true ceiling is this plus whichever read is in flight when it passes.
     deadline = time.monotonic() + _SLURM_TIMELINE_BUDGET_SECONDS
     rows: List[Dict[str, Any]] = []
-    for slurm_cluster, job_name, task_id in allocations:
+    for alloc in allocations:
         if time.monotonic() >= deadline:
             logger.debug(f'Out of time to read the Slurm timeline of job '
-                         f'{job_id}; {job_name!r} on {slurm_cluster} and any '
-                         'later allocation are skipped')
+                         f'{job_id}; {alloc.slurm_cluster} and any later '
+                         'allocation are skipped')
             break
         try:
-            entries = slurm_provision_utils.job_timeline(slurm_cluster,
-                                                         job_name,
-                                                         since,
-                                                         deadline=deadline)
+            if alloc.job_ids:
+                entries = slurm_provision_utils.job_timeline_by_ids(
+                    alloc.slurm_cluster, alloc.job_ids, deadline=deadline)
+            else:
+                assert alloc.job_name is not None, alloc
+                entries = slurm_provision_utils.job_timeline(
+                    alloc.slurm_cluster,
+                    alloc.job_name,
+                    since,
+                    deadline=deadline)
         except Exception as e:  # pylint: disable=broad-except
             # Best-effort, like the cluster-event merge: an unreachable login
             # node must not fail the request.
             logger.debug(f'Failed to read the Slurm timeline of job {job_id} '
-                         f'(allocation {job_name!r} on {slurm_cluster}): {e}')
+                         f'on {alloc.slurm_cluster}: {e}')
             continue
         rows.extend({
             'spot_job_id': job_id,
-            'task_id': task_id,
+            'task_id': alloc.task_id,
             'new_status': None,
             'code': None,
             'reason': entry['text'],

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -329,6 +329,35 @@ def _record_pending_reason(cluster_name: str, reason: Optional[str],
                      f'{e}')
 
 
+def _record_allocation(cluster_name: str, slurm_cluster: str,
+                       job_id: str) -> None:
+    """Persist which Slurm allocation backs this cluster.
+
+    The cluster row carries the same two facts -- its resources' region, and
+    cluster_name_on_cloud on the handle -- but teardown removes it, while
+    cluster events outlive it. Recording them is what lets a finished job
+    still be asked what its allocation did, which is the whole reason to read
+    sacct: it is the only source for a job squeue has already forgotten.
+
+    One event per allocation, by id: a recovery submits a new one and adds a
+    row rather than replacing this one, so every attempt stays addressable.
+    The wording follows the launch-progress convention of this module so the
+    row reads sensibly in `sky jobs events`, and it is deliberately distinct
+    from the timeline's own `Slurm allocation ...` sentences.
+    """
+    try:
+        global_user_state.add_cluster_event(
+            cluster_name,
+            new_status=None,
+            reason=f'Launching (Slurm job {job_id} on {slurm_cluster})',
+            event_type=global_user_state.ClusterEventType.LAUNCH_PROGRESS,
+            nop_if_duplicate=True,
+        )
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f'Failed to record the Slurm allocation of '
+                     f'{cluster_name}: {e}')
+
+
 def _make_pending_callback(
     cluster_name: str,
     partition: Optional[str] = None,
@@ -825,6 +854,7 @@ def _create_virtual_instance(
         job_id = existing_jobs[0]
         logger.debug(f'Job with name {cluster_name_on_cloud} already exists '
                      f'(JOBID: {job_id})')
+        _record_allocation(cluster_name, slurm_cluster, job_id)
 
         # Wait for nodes to be allocated (job might be in PENDING state)
         _wait_for_job_nodes(client, job_id, provision_timeout, partition,
@@ -1272,6 +1302,7 @@ touch {sky_cluster_home_dir}/.hushlogin
     logger.debug(f'Successfully submitted Slurm job {job_id} to partition '
                  f'{partition} for cluster {cluster_name_on_cloud} '
                  f'with {num_nodes} nodes')
+    _record_allocation(cluster_name, slurm_cluster, job_id)
 
     _wait_for_job_nodes(client, job_id, provision_timeout, partition,
                         on_pending)

--- a/sky/provision/slurm/pending.py
+++ b/sky/provision/slurm/pending.py
@@ -156,6 +156,9 @@ def parse_dependency(expression: str) -> Dict[str, Any]:
     return parsed
 
 
+# Slurm's non-epoch timestamp form, e.g. '2026-09-08T04:05:47'.
+_ISO_TIME_RE = re.compile(r'^(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2})$')
+
 CATEGORY_QUOTA = 'quota'
 CATEGORY_RESOURCES = 'resources'
 CATEGORY_HELD = 'held'
@@ -608,7 +611,7 @@ def _classify_resources(job: Dict[str, Any], code: str,
 
 
 def _format_epoch(value: Optional[str]) -> Optional[str]:
-    """An epoch string as a readable time, or None when it is not one.
+    """A Slurm timestamp as a readable time, or None when it is not one.
 
     None rather than the raw value, because the caller interpolates this into
     a sentence about when something happens. Slurm answers `Unknown` for a
@@ -616,6 +619,12 @@ def _format_epoch(value: Optional[str]) -> Optional[str]:
     it is split out -- and "It becomes eligible at Unknown." is worse than not
     saying it. Fields that carry the scheduler's own spelling through
     untouched are shaped elsewhere (`slurm_jobs.core.shape_job`).
+
+    The reads ask for epoch seconds (`SLURM_TIME_FORMAT=%s`), which is what
+    the first branch handles. A Slurm build old enough to ignore that answers
+    in ISO form in the *cluster's* local timezone, unlabelled; that is shown
+    as it came rather than converted, since nothing here knows which
+    timezone it is.
     """
     if value is None:
         return None
@@ -623,7 +632,8 @@ def _format_epoch(value: Optional[str]) -> Optional[str]:
         stamp = datetime.datetime.fromtimestamp(int(value),
                                                 tz=datetime.timezone.utc)
     except (TypeError, ValueError):
-        return None
+        iso = _ISO_TIME_RE.match(value)
+        return f'{iso.group(1)} {iso.group(2)}' if iso else None
     return stamp.strftime('%Y-%m-%d %H:%M:%S UTC')
 
 

--- a/sky/provision/slurm/pending.py
+++ b/sky/provision/slurm/pending.py
@@ -1,0 +1,760 @@
+"""Why a Slurm job is PENDING: reason codes turned into an answer.
+
+``squeue %R`` / ``scontrol Reason=`` give one opaque code -- ``Resources``,
+``QOSGrpGRES``, ``DependencyNeverSatisfied``. ``classify_pending`` maps it onto
+one of five categories (``quota``, ``resources``, ``held``, ``dependency``,
+``other``) and writes a plain-text summary plus, where there is enough to say
+one, an action.
+
+Everything here is pure: no I/O, no scheduler calls. The caller gathers
+whatever evidence it can and passes it in through ``PendingEvidence``, which
+is what lets very different callers share one classification. Nothing is
+guessed -- with the evidence for a claim missing, the summary says so and
+``action`` is ``None`` rather than a plausible-sounding remedy.
+
+That split is also where the module boundary is. Answering about *your own*
+job needs this job's reason, its partition's node counts
+(``utils.slurm_node_info``) and the states of the jobs it depends on -- all
+reachable with the access that submitted the job. Naming the *cap* behind a
+quota reason instead needs the accounting database's QoS definitions, and
+deciding which QoS a partition attaches or which GRES a cap refers to are
+rules about that database; a caller that reads it resolves them and passes
+the results in as ``effective_qos`` / ``blocking_resource``.
+"""
+
+import dataclasses
+import datetime
+import re
+from typing import Any, Dict, List, Optional, Set
+
+# squeue renders a PENDING job's reason through ``%R``, which wraps it in
+# parentheses ('(QOSGrpGRES)'); ``%r`` and ``scontrol`` give the bare code.
+# Both spellings normalize here, and the frontend applies the same rule
+# before rendering, so neither side has to know which one produced the row.
+_PARENTHESIZED_RE = re.compile(r'^\((.*)\)$')
+
+# Slurm's spellings for "no reason yet". The sweep filters the bare 'None'
+# only, so the parenthesized form reaches this module as a reason.
+_NO_REASON = frozenset({'', 'NONE', 'NULL'})
+
+# The reason codes this module rewrites into "what the job is short of".
+# QOSGrpGRES is the QOS's *group* GRES cap (GrpTRES gres/...) being full --
+# the one pending reason that names a resource without naming *which*, and
+# the only shape a user can act on ("my team is out of B300", not "there is
+# a limit called QOSGrpGRES"). Its per-user and per-job siblings
+# (QOSMaxGRESPerUser, QOSMaxGRESPerJob) resolve against a different cap and
+# are deliberately not covered yet.
+GRES_LIMIT_REASONS = frozenset({'QOSGrpGRES'})
+
+# What an untyped ``gres/gpu`` cap is called when the job's own model is
+# unknowable. Plural: it names the resource, not one accelerator.
+_GENERIC_GPU_LABEL = 'GPUs'
+
+
+def pending_reason_code(job: Dict[str, Any]) -> str:
+    """The bare Slurm reason code of a PENDING job, or ''.
+
+    '' for a job that is not pending, carries no reason, or carries one of
+    Slurm's "none" spellings -- so a caller can test the code directly
+    instead of re-deriving the "is there a reason at all" question.
+    """
+    if (job.get('state') or '').upper() != 'PENDING':
+        return ''
+    text = str(job.get('reason') or '').strip()
+    match = _PARENTHESIZED_RE.match(text)
+    if match:
+        text = match.group(1).strip()
+    return '' if text.upper() in _NO_REASON else text
+
+
+DEPENDENCY_REASONS = frozenset({'Dependency', 'DependencyNeverSatisfied'})
+_UNSATISFIABLE_REASON = 'DependencyNeverSatisfied'
+
+# One entry of squeue's ``%E``. Slurm builds these from the job's dependency
+# list (``_foreach_depend_list2str``): a type, the job it names -- optionally
+# an array task (``123_4``, ``123_*``) and a ``+minutes`` offset -- and the
+# entry's own state in parentheses. Entries are joined by ',' for AND and '?'
+# for OR, and a *fulfilled* entry is dropped from the string entirely, so what
+# arrives here is only what is still outstanding. ``singleton`` names no job
+# at all.
+#
+# One entry can name several jobs (``afterok:123:124``): Slurm's own renderer
+# splits those into separate entries, but the man page says a dependency that
+# can never be satisfied is reported as *the full original specification* --
+# which is whatever the user typed.
+_DEPENDENCY_STATE_RE = re.compile(r'\((?P<state>[A-Za-z]+)\)$')
+_DEPENDENCY_TIME_RE = re.compile(r'\+\d+')
+_DEPENDENCY_JOB_RE = re.compile(r'\d+(?:_(?:\d+|\*))?')
+
+# The entry state that will never become 'fulfilled'.
+_FAILED_STATE = 'failed'
+
+
+def parse_dependency(expression: str) -> Dict[str, Any]:
+    """``'afterok:5122(unfulfilled)'`` -> the jobs it is waiting on.
+
+    Returns ``{'job_ids': [...], 'failed_job_ids': [...], 'singleton': bool,
+    'unsatisfiable': bool}``.
+
+    ``singleton`` is its own key because it names no job: it waits on any
+    earlier job of the same name and user, which is a different sentence for
+    the UI to say.
+
+    ``unsatisfiable`` means the job will pend forever, which is worth saying
+    differently from an ordinary wait. Which ``(failed)`` entries make it so
+    depends on the separator: sbatch joins a dependency list with ``,`` (all
+    must be satisfied) or with ``?`` (any one is enough), never a mix. A
+    failed entry is therefore fatal under ``,``, but under ``?`` the job still
+    runs while one alternative survives.
+
+    An entry this cannot parse is skipped rather than guessed at; an
+    expression that yields nothing at all leaves the UI on the raw reason
+    code. Slurm builds this string itself, so the shapes are fixed, but the
+    annotations are recent enough that an older cluster may send bare
+    entries -- which parse fine and simply carry no state.
+    """
+    parsed: Dict[str, Any] = {
+        'job_ids': [],
+        'failed_job_ids': [],
+        'singleton': False,
+        'unsatisfiable': False,
+    }
+    expression = expression.strip()
+    any_of = '?' in expression
+    entries = 0
+    failed = 0
+    for raw in re.split(r'[,?]', expression):
+        entry = raw.strip()
+        if not entry:
+            continue
+        entries += 1
+        state = _DEPENDENCY_STATE_RE.search(entry)
+        if state:
+            entry = entry[:state.start()]
+        kind, _, rest = entry.partition(':')
+        if not kind.isalpha():
+            continue
+        entry_failed = (state is not None and
+                        state.group('state').lower() == _FAILED_STATE)
+        if entry_failed:
+            failed += 1
+        if kind.lower() == 'singleton':
+            parsed['singleton'] = True
+            continue
+        # A '+minutes' offset would otherwise read as a job id.
+        for job_id in _DEPENDENCY_JOB_RE.findall(
+                _DEPENDENCY_TIME_RE.sub('', rest)):
+            if job_id not in parsed['job_ids']:
+                parsed['job_ids'].append(job_id)
+            if entry_failed and job_id not in parsed['failed_job_ids']:
+                parsed['failed_job_ids'].append(job_id)
+    # An entry too odd to parse still counts in ``entries``, so it keeps an
+    # any-of list off the unsatisfiable verdict rather than being read as one
+    # more closed path.
+    if failed and (failed == entries or not any_of):
+        parsed['unsatisfiable'] = True
+    return parsed
+
+
+CATEGORY_QUOTA = 'quota'
+CATEGORY_RESOURCES = 'resources'
+CATEGORY_HELD = 'held'
+CATEGORY_DEPENDENCY = 'dependency'
+CATEGORY_OTHER = 'other'
+
+# Matched against the reason's first comma-separated token with whitespace
+# folded to '_' (Slurm spells some reasons as sentences: 'Nodes required for
+# job are DOWN, DRAINED or reserved ...', 'launch failed requeued held').
+_QUOTA_PREFIXES = ('QOSGrp', 'QOSMax', 'QOSMin', 'AssocGrp', 'AssocMax')
+_QUOTA_CODES = frozenset({'QOSUsageThreshold'})
+_RESOURCE_CODES = frozenset({
+    'Resources', 'Priority', 'ReqNodeNotAvail', 'PartitionDown', 'Reservation'
+})
+_NODES_DOWN_PREFIX = 'Nodes_required_for_job_are_DOWN'
+_HELD_CODES = frozenset({
+    'JobHeldUser',
+    'JobHeldAdmin',
+    'JobHoldMaxRequeue',
+    'launch_failed_requeued_held',
+    'BeginTime',
+})
+
+# ---------------------------------------------------------------------------
+# Evidence shaping: pure functions over what a sinfo / squeue read returned.
+# ---------------------------------------------------------------------------
+
+
+def partitions_of(value: Any) -> Set[str]:
+    return {
+        p.strip().rstrip('*') for p in str(value or '').split(',') if p.strip()
+    }
+
+
+# sinfo base states (flags stripped) that mean the node cannot take work.
+_DRAIN_STATES = ('drain', 'drng', 'draining', 'drained')
+_DOWN_STATES = ('down', 'fail', 'failg', 'failing', 'error', 'inval', 'invalid',
+                'unk')
+_BUSY_STATES = ('alloc', 'allocated', 'mix', 'mixed', 'comp', 'completing')
+# The state sinfo reports for a node that is up with nothing running on it.
+# Only this counts as idle; everything else is unavailable, including a state
+# this code has never seen. That bias is deliberate: the resources summary
+# makes a claim about the idle count specifically, so an unrecognized spelling
+# must never inflate it. What lands in unavailable today: resv, maint, plnd,
+# futr, npc, perf, pow_up -- present, but nothing a caller submits can go
+# there.
+_IDLE_STATES = ('idle',)
+_STATE_FLAGS = '*~#%!$@^-+'
+
+
+def partition_node_counts(
+    node_infos: List[Dict[str, Any]],
+    partitions: Set[str],
+    busy_nodes: Set[str],
+) -> Optional[Dict[str, int]]:
+    """total/idle/allocated/drained/down/unavailable/powered_down over the
+    nodes of ``partitions``.
+
+    ``slurm_node_info`` queries sinfo/scontrol live (the 30-minute kv cache in
+    that module belongs to ``get_slurm_nodes_info``, a different function), so
+    every state here is current. ``busy_nodes`` comes from the running jobs in
+    the sweep and is only an overlay: sinfo reports a mixed-allocation node as
+    idle, and the sweep is at most one window old. None when no node belongs
+    to the partitions. ``powered_down`` is counted apart from ``total``,
+    which is the fleet that is actually present."""
+    counts = {
+        'total': 0,
+        'idle': 0,
+        'allocated': 0,
+        'drained': 0,
+        'down': 0,
+        'unavailable': 0,
+        'powered_down': 0,
+    }
+    for info in node_infos:
+        if not partitions_of(info.get('partition')).intersection(partitions):
+            continue
+        raw = str(info.get('node_state') or '')
+        base = raw.rstrip(_STATE_FLAGS).lower()
+        # '~' is the flag form and 'pow_dn' the base state; both mean the node
+        # is off and has to be resumed before it can run anything.
+        if '~' in raw or base.startswith('pow_dn'):
+            counts['powered_down'] += 1
+            continue
+        counts['total'] += 1
+        name = str(info.get('node_name') or '')
+        if base.startswith(_DRAIN_STATES):
+            counts['drained'] += 1
+        elif '*' in raw or base.startswith(_DOWN_STATES):
+            counts['down'] += 1
+        elif name in busy_nodes or base.startswith(_BUSY_STATES):
+            counts['allocated'] += 1
+        elif base.startswith(_IDLE_STATES):
+            counts['idle'] += 1
+        else:
+            counts['unavailable'] += 1
+    return counts if counts['total'] or counts['powered_down'] else None
+
+
+def pending_ahead(sweep: List[Dict[str, Any]], job: Dict[str,
+                                                         Any]) -> Optional[int]:
+    """Pending jobs sharing a candidate partition with a higher scheduling
+    priority (squeue %Q). None when this job's priority is unknown."""
+    mine = _int_or_none(job.get('priority'))
+    if mine is None:
+        return None
+    partitions = partitions_of(job.get('partition'))
+    ahead = 0
+    for other in sweep:
+        if str(other.get('job_id')) == str(job.get('job_id')):
+            continue
+        if (other.get('state') or '').upper() != 'PENDING':
+            continue
+        if not partitions_of(other.get('partition')).intersection(partitions):
+            continue
+        theirs = _int_or_none(other.get('priority'))
+        if theirs is not None and theirs > mine:
+            ahead += 1
+    return ahead
+
+
+def _int_or_none(value: Any) -> Optional[int]:
+    try:
+        return int(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _reason_key(code: str) -> str:
+    """The token a reason is matched on: first comma field, spaces as '_'."""
+    head = code.split(',', 1)[0].strip()
+    return re.sub(r'\s+', '_', head)
+
+
+def pending_category(code: str) -> str:
+    """One of the five taxonomy categories for a bare reason code."""
+    key = _reason_key(code)
+    if not key:
+        return CATEGORY_OTHER
+    if key in _QUOTA_CODES or key.startswith(_QUOTA_PREFIXES):
+        return CATEGORY_QUOTA
+    if key in _RESOURCE_CODES or key.startswith(_NODES_DOWN_PREFIX):
+        return CATEGORY_RESOURCES
+    if key in _HELD_CODES:
+        return CATEGORY_HELD
+    if key in DEPENDENCY_REASONS:
+        return CATEGORY_DEPENDENCY
+    return CATEGORY_OTHER
+
+
+@dataclasses.dataclass
+class PendingEvidence:
+    """What the caller managed to read for a pending job. Every field is
+    optional; ``None`` means "not read", not "zero"."""
+
+    # scontrol ``Restarts=``.
+    restarts: Optional[int] = None
+    # scontrol ``StartTime=`` for a BeginTime hold (epoch seconds or raw).
+    begin_time: Optional[str] = None
+    # sacctmgr QOS definitions (accounting.parse_qos_output). None when the
+    # read was not attempted; {} with ``accounting_error`` when it failed.
+    qoses: Optional[Dict[str, Dict[str, Any]]] = None
+    accounting_error: Optional[str] = None
+    # scontrol partition definitions (accounting.parse_partitions_output).
+    partitions: Optional[Dict[str, Dict[str, Any]]] = None
+    # accounting.rollup_usage output: live GPUs per QOS.
+    qos_usage: Optional[Dict[str, Dict[str, int]]] = None
+    # The QoS name(s) this job counts against, and what the blocking cap is
+    # called ('H200'). Both are resolved by the caller: deciding which QoS a
+    # partition attaches, and which GRES a cap refers to, needs the accounting
+    # database's definitions, so the caller that reads them owns those rules.
+    # None means nobody resolved them -- the quota branch then says the cap is
+    # unknown instead of naming one.
+    effective_qos: Optional[List[str]] = None
+    blocking_resource: Optional[str] = None
+    # Node counts for the job's partition(s): total/idle/allocated/drained/
+    # down/powered_down.
+    partition_nodes: Optional[Dict[str, int]] = None
+    # Pending jobs in the same partition(s) with a higher priority.
+    pending_ahead: Optional[int] = None
+    # Live state of every job in the queue, for dependency lookups. A job
+    # missing from this map is no longer queued.
+    dependency_states: Optional[Dict[str, str]] = None
+
+
+def _text(value: str) -> str:
+    return ' '.join(str(value).split())
+
+
+def _result(
+    category: str,
+    code: str,
+    summary: str,
+    action: Optional[str],
+    evidence: Dict[str, Any],
+) -> Dict[str, Any]:
+    return {
+        'category': category,
+        'code': code,
+        'summary': _text(summary),
+        'action': _text(action) if action else None,
+        'evidence': evidence,
+    }
+
+
+def classify_pending(
+    job: Dict[str, Any],
+    evidence: Optional[PendingEvidence] = None,
+) -> Optional[Dict[str, Any]]:
+    """``{category, code, summary, action, evidence}`` for a PENDING job.
+
+    ``job`` is a squeue-shaped row (state, reason, dependency, partition,
+    qos, gpu_type, job_id). Returns None for a job that is not pending or
+    carries no reason.
+    """
+    code = pending_reason_code(job)
+    if not code:
+        return None
+    evidence = evidence or PendingEvidence()
+    category = pending_category(code)
+    if category == CATEGORY_QUOTA:
+        return _classify_quota(job, code, evidence)
+    if category == CATEGORY_RESOURCES:
+        return _classify_resources(job, code, evidence)
+    if category == CATEGORY_HELD:
+        return _classify_held(job, code, evidence)
+    if category == CATEGORY_DEPENDENCY:
+        return _classify_dependency(job, code, evidence)
+    return _result(CATEGORY_OTHER, code, code, None, {})
+
+
+def _plural(count: int, noun: str) -> str:
+    return f'{count} {noun}' + ('' if count == 1 else 's')
+
+
+def _classify_quota(job: Dict[str, Any], code: str,
+                    evidence: PendingEvidence) -> Dict[str, Any]:
+    # Uniform signature with the other classifiers; the job's own fields are
+    # not consulted here, since which QoS it counts against and which resource
+    # the cap names both arrive resolved.
+    del job
+    key = _reason_key(code)
+    queues = evidence.effective_qos or []
+    found: Dict[str, Any] = {'qos': queues or None}
+    if evidence.qoses is None or (not evidence.qoses and
+                                  evidence.accounting_error):
+        found['accounting_error'] = evidence.accounting_error
+        why = (f' ({evidence.accounting_error})'
+               if evidence.accounting_error else '')
+        return _result(
+            CATEGORY_QUOTA,
+            code,
+            f'Slurm reports a QoS/association limit ({code}). The accounting '
+            f'database could not be read{why}, so the cap behind it is '
+            f'unknown.',
+            None,
+            found,
+        )
+    if len(queues) != 1:
+        # A multi-partition pending job counts against several QoS; without
+        # knowing which one Slurm charged the limit to, no cap can be named.
+        names = ', '.join(queues) if queues else 'unknown'
+        return _result(
+            CATEGORY_QUOTA,
+            code,
+            f'A QoS/association limit ({code}) is blocking this job; '
+            f'candidate QoS: {names}. The specific cap could not be resolved.',
+            None,
+            found,
+        )
+    qos_name = queues[0]
+    qos = evidence.qoses.get(qos_name) or {}
+    label = evidence.blocking_resource or ''
+    nominal = qos.get('nominal') or {}
+    gres_caps = {k: v for k, v in nominal.items() if k.startswith('gres/')}
+    cap_key, cap = (next(iter(gres_caps.items())) if len(gres_caps) == 1 else
+                    (None, None))
+    # Only pair a cap with usage read under the SAME TRES key. The cap may be
+    # typed (``gres/gpu:a100``) or not a GPU at all, while rollup_usage keeps
+    # only the untyped ``gres/gpu`` total -- pairing those printed ratios like
+    # 32/16. A key with no matching usage falls through to the cap-only text.
+    used = ((evidence.qos_usage or {}).get(qos_name, {}).get(cap_key)
+            if cap_key else None)
+    found.update({
+        'cap': cap,
+        'cap_tres': cap_key,
+        'used': used,
+        'resource': label or None
+    })
+
+    if key == 'QOSGrpGRES':
+        what = label or _GENERIC_GPU_LABEL
+        if cap is not None and used is not None:
+            summary = f'{what} quota for QoS {qos_name} is full ({used}/{cap}).'
+        elif cap is not None:
+            summary = f'{what} quota for QoS {qos_name} is full (cap {cap}).'
+        else:
+            summary = f'{what} group quota for QoS {qos_name} is full.'
+        action = (
+            f'Wait for the group\'s jobs in QoS {qos_name} to finish, '
+            f'submit to '
+            f'another partition or QoS, or request a higher-priority QoS.')
+        return _result(CATEGORY_QUOTA, code, summary, action, found)
+    if key.startswith('QOSMax') and key.endswith('PerUser'):
+        per_user = qos.get('max_tres_per_user') or {}
+        found['max_tres_per_user'] = per_user or None
+        cap_text = (' (' + ', '.join(f'{k}={v}' for k, v in per_user.items()) +
+                    ')' if per_user else '')
+        return _result(
+            CATEGORY_QUOTA,
+            code,
+            f'Per-user limit {key} on QoS {qos_name} reached{cap_text}.',
+            f'Wait for your own jobs in QoS {qos_name} to finish, or submit '
+            f'under another QoS.',
+            found,
+        )
+    if key.startswith('QOSMax') and key.endswith('PerJob'):
+        return _result(
+            CATEGORY_QUOTA,
+            code,
+            f'This job asks for more than QoS {qos_name} allows per job '
+            f'({key}).',
+            'Resubmit with a smaller request, or under another QoS.',
+            found,
+        )
+    if key.startswith('Assoc'):
+        return _result(
+            CATEGORY_QUOTA,
+            code,
+            f'An association (account) limit {key} is blocking this job '
+            f'(QoS {qos_name}).',
+            'Check the account limits with sacctmgr show assoc, wait for the '
+            'account\'s jobs to finish, or submit under another account.',
+            found,
+        )
+    return _result(
+        CATEGORY_QUOTA,
+        code,
+        f'QoS limit {key} on QoS {qos_name} is blocking this job.',
+        f'Check the limit with sacctmgr show qos {qos_name}, wait for jobs in '
+        f'that QoS to finish, or submit under another QoS.',
+        found,
+    )
+
+
+def _node_counts_text(nodes: Dict[str, int]) -> str:
+    parts = [f'{nodes.get("allocated", 0)} allocated']
+    for key, label in (
+        ('idle', 'idle'),
+        ('drained', 'drained'),
+        ('down', 'down'),
+            # Reserved / under maintenance / planned. Named separately so the
+            # count reads as "present but not for you", not as spare capacity.
+        ('unavailable', 'unavailable'),
+        ('powered_down', 'powered down'),
+    ):
+        if nodes.get(key):
+            parts.append(f'{nodes[key]} {label}')
+    return f'{_plural(nodes.get("total", 0), "node")}: {", ".join(parts)}'
+
+
+def _classify_resources(job: Dict[str, Any], code: str,
+                        evidence: PendingEvidence) -> Dict[str, Any]:
+    key = _reason_key(code)
+    partition = (job.get('partition') or '').strip() or 'unknown'
+    nodes = evidence.partition_nodes
+    ahead = evidence.pending_ahead
+    found: Dict[str, Any] = {
+        'partition': partition,
+        'partition_nodes': nodes,
+        'pending_ahead': ahead,
+    }
+    if ahead is None:
+        ahead_text = ''
+    elif ahead == 0:
+        # Saying "0 jobs are pending ahead of this one" right after "higher
+        # priority jobs are ahead of this one" reads as a contradiction. Both
+        # are true -- what is ahead of it is RUNNING, not queued -- so say
+        # that, since it is the difference between waiting for a backlog and
+        # waiting for a full cluster.
+        ahead_text = ' No other pending job is ahead of it.'
+    else:
+        ahead_text = (
+            f' {_plural(ahead, "job")} {"is" if ahead == 1 else "are"} pending '
+            f'ahead of this one.')
+    if key in ('Resources', 'Priority'):
+        if nodes:
+            if key == 'Priority':
+                summary = (
+                    f'Higher-priority jobs are ahead of this one in partition '
+                    f'{partition} ({_node_counts_text(nodes)}).')
+            elif nodes.get('idle'):
+                summary = (
+                    f'The {_plural(nodes["idle"], "idle node")} in partition '
+                    f'{partition} do not satisfy this job\'s request '
+                    f'({_node_counts_text(nodes)}).')
+            else:
+                summary = (f'No idle node in partition {partition} '
+                           f'({_node_counts_text(nodes)}).')
+        else:
+            summary = (f'Waiting for free resources in partition '
+                       f'{partition} ({key}).')
+        action = ('Wait for running jobs to finish, or resubmit with a smaller '
+                  'request '
+                  'or to a partition with idle nodes.'
+                  if nodes or ahead is not None else None)
+        return _result(CATEGORY_RESOURCES, code, summary + ahead_text, action,
+                       found)
+    if key == 'ReqNodeNotAvail':
+        unavailable = re.search(r'UnavailableNodes:\s*(\S+)', code)
+        found['unavailable_nodes'] = unavailable.group(
+            1) if unavailable else None
+        which = f' ({unavailable.group(1)})' if unavailable else ''
+        return _result(
+            CATEGORY_RESOURCES,
+            code,
+            f'A node this job requires is unavailable{which}: down, drained or '
+            f'reserved.',
+            'Wait for the node to return, or resubmit without the node '
+            'constraint (--nodelist / --constraint).',
+            found,
+        )
+    if key.startswith(_NODES_DOWN_PREFIX):
+        counts = f' ({_node_counts_text(nodes)})' if nodes else ''
+        return _result(
+            CATEGORY_RESOURCES,
+            code,
+            f'The nodes this job requires in partition {partition} are down, '
+            f'drained or reserved for higher-priority partitions{counts}.',
+            'Wait for the nodes to return, or resubmit to another partition.',
+            found,
+        )
+    if key == 'PartitionDown':
+        return _result(
+            CATEGORY_RESOURCES,
+            code,
+            f'Partition {partition} is down and not scheduling jobs.',
+            'Contact the cluster administrator; the job starts once the '
+            'partition is up, or resubmit to another partition.',
+            found,
+        )
+    # Reservation.
+    return _result(
+        CATEGORY_RESOURCES,
+        code,
+        'Waiting for the requested reservation to begin.',
+        'Wait for the reservation window, or resubmit without --reservation.',
+        found,
+    )
+
+
+def _format_epoch(value: Optional[str]) -> Optional[str]:
+    """An epoch string as a readable time, or None when it is not one.
+
+    None rather than the raw value, because the caller interpolates this into
+    a sentence about when something happens. Slurm answers `Unknown` for a
+    time it has not computed -- for a held job, and for an array task before
+    it is split out -- and "It becomes eligible at Unknown." is worse than not
+    saying it. Fields that carry the scheduler's own spelling through
+    untouched are shaped elsewhere (`slurm_jobs.core.shape_job`).
+    """
+    if value is None:
+        return None
+    try:
+        stamp = datetime.datetime.fromtimestamp(int(value),
+                                                tz=datetime.timezone.utc)
+    except (TypeError, ValueError):
+        return None
+    return stamp.strftime('%Y-%m-%d %H:%M:%S UTC')
+
+
+def _classify_held(job: Dict[str, Any], code: str,
+                   evidence: PendingEvidence) -> Dict[str, Any]:
+    key = _reason_key(code)
+    job_id = job.get('job_id') or '<job id>'
+    restarts = evidence.restarts
+    found: Dict[str, Any] = {'restarts': restarts}
+    release = f'release it with scontrol release {job_id}'
+    if key == 'launch_failed_requeued_held':
+        if restarts is not None:
+            summary = (f'Held after {_plural(restarts, "requeue")}: the job '
+                       f'launch failed.')
+        else:
+            summary = 'Held: the job launch failed and the job was requeued.'
+        return _result(
+            CATEGORY_HELD,
+            code,
+            summary,
+            f'Check the node and prolog logs for the failure, then {release}.',
+            found,
+        )
+    if key == 'JobHoldMaxRequeue':
+        count = (f' ({_plural(restarts, "restart")})'
+                 if restarts is not None else '')
+        return _result(
+            CATEGORY_HELD,
+            code,
+            f'Held after reaching the requeue limit{count}.',
+            f'Find out why the job keeps being requeued, then {release}.',
+            found,
+        )
+    if key == 'JobHeldUser':
+        note = (f' It has been requeued {_plural(restarts, "time")}.'
+                if restarts else '')
+        return _result(
+            CATEGORY_HELD,
+            code,
+            f'Held by the user (Slurm also reports this after a failed '
+            f'requeue).{note}',
+            f'If the hold is not intended, {release}.',
+            found,
+        )
+    if key == 'JobHeldAdmin':
+        return _result(
+            CATEGORY_HELD,
+            code,
+            'Held by an administrator.',
+            'Ask a Slurm administrator why it is held; only they can '
+            'release it.',
+            found,
+        )
+    # BeginTime.
+    begin = _format_epoch(evidence.begin_time)
+    found['begin_time'] = begin
+    when = f' It becomes eligible at {begin}.' if begin else ''
+    return _result(
+        CATEGORY_HELD,
+        code,
+        f'Not eligible yet: the requested begin time is in the future.{when}',
+        f'Wait, or start it now with scontrol update JobId={job_id} '
+        f'StartTime=now.',
+        found,
+    )
+
+
+def _classify_dependency(job: Dict[str, Any], code: str,
+                         evidence: PendingEvidence) -> Dict[str, Any]:
+    job_id = job.get('job_id') or '<job id>'
+    raw = str(job.get('dependency') or '')
+    parsed = parse_dependency(raw)
+    never = code == _UNSATISFIABLE_REASON or parsed['unsatisfiable']
+    states = evidence.dependency_states
+    blocking = []
+    for dep in parsed['job_ids']:
+        state = states.get(dep) if states is not None else None
+        blocking.append({'job_id': dep, 'state': state})
+    found = {
+        'dependency': raw or None,
+        'blocking_jobs': blocking,
+        'failed_dependencies': parsed['failed_job_ids'] or None,
+        'singleton': parsed['singleton'],
+        'unsatisfiable': never,
+    }
+
+    def _name(entry: Dict[str, Any]) -> str:
+        # The annotation first: a failed dependency has left the queue, so
+        # without this it reads as "no longer in the queue" -- true, and the
+        # least useful of the two things known about it.
+        if entry['job_id'] in parsed['failed_job_ids']:
+            return f'{entry["job_id"]} (failed)'
+        if entry['state']:
+            return f'{entry["job_id"]} ({entry["state"]})'
+        if states is not None:
+            return f'{entry["job_id"]} (no longer in the queue)'
+        return str(entry['job_id'])
+
+    if never:
+        # Name the entries Slurm marked (failed), not every job in the
+        # expression: under a ',' list the others may be waiting normally.
+        which = (', '.join(parsed['failed_job_ids']) or
+                 ', '.join(b['job_id'] for b in blocking) or 'another job')
+        return _result(
+            CATEGORY_DEPENDENCY,
+            code,
+            f'Depends on job {which} which failed; the dependency can never be '
+            f'satisfied, so this job will never run.',
+            f'Cancel and resubmit, or drop the dependency with scontrol update '
+            f'JobId={job_id} Dependency= to let it run.',
+            found,
+        )
+    sentences = []
+    if blocking:
+        names = ', '.join(_name(b) for b in blocking)
+        sentences.append(f'Waiting for job {names} to finish.')
+    if parsed['singleton']:
+        sentences.append(
+            'Waiting for earlier jobs with the same name and user to finish '
+            '(singleton).')
+    if not sentences:
+        return _result(
+            CATEGORY_DEPENDENCY,
+            code,
+            f'Waiting on another job ({code}); Slurm did not report which.',
+            None,
+            found,
+        )
+    ids = ', '.join(b['job_id'] for b in blocking)
+    action = (
+        f'Wait for job {ids} to finish; describe it if it is itself stuck.'
+        if blocking else 'Wait for the earlier same-name jobs to finish.')
+    return _result(CATEGORY_DEPENDENCY, code, ' '.join(sentences), action,
+                   found)

--- a/sky/provision/slurm/pending.py
+++ b/sky/provision/slurm/pending.py
@@ -260,11 +260,22 @@ def partition_node_counts(
 
 def pending_ahead(sweep: List[Dict[str, Any]], job: Dict[str,
                                                          Any]) -> Optional[int]:
-    """Pending jobs sharing a candidate partition with a higher scheduling
-    priority (squeue %Q). None when this job's priority is unknown."""
+    """Pending jobs sharing a candidate partition that Slurm will consider
+    before this one. None when this job's priority is unknown.
+
+    Higher priority (squeue %Q) goes first, and **a tie is broken by job id**.
+    Counting only strictly higher priorities looks equivalent until you meet a
+    cluster with no multifactor priority configured: there every job reports
+    priority 1, every comparison ties, and the answer is always "nothing is
+    ahead of you" while an older job is plainly next in line. Slurm breaks
+    such ties by submission, which the id orders -- so an id lower than
+    ours is ahead, and a job array element's `17221_2` compares by its base
+    number.
+    """
     mine = _int_or_none(job.get('priority'))
     if mine is None:
         return None
+    my_id = _base_job_id(job.get('job_id'))
     partitions = partitions_of(job.get('partition'))
     ahead = 0
     for other in sweep:
@@ -275,9 +286,31 @@ def pending_ahead(sweep: List[Dict[str, Any]], job: Dict[str,
         if not partitions_of(other.get('partition')).intersection(partitions):
             continue
         theirs = _int_or_none(other.get('priority'))
-        if theirs is not None and theirs > mine:
+        if theirs is None:
+            continue
+        if theirs > mine:
             ahead += 1
+        elif theirs == mine and my_id is not None:
+            their_id = _base_job_id(other.get('job_id'))
+            if their_id is not None and their_id < my_id:
+                ahead += 1
     return ahead
+
+
+def _base_job_id(value: Any) -> Optional[int]:
+    """The numeric part of a Slurm job id, for ordering by submission.
+
+    Slurm spells an array element `17221_2` and a heterogeneous component
+    `123+0`; both share the base job's submission order, which is all this is
+    used for.
+    """
+    if value is None:
+        return None
+    head = re.split(r'[_+]', str(value).strip(), maxsplit=1)[0]
+    try:
+        return int(head)
+    except ValueError:
+        return None
 
 
 def _int_or_none(value: Any) -> Optional[int]:

--- a/sky/provision/slurm/utils.py
+++ b/sky/provision/slurm/utils.py
@@ -7,7 +7,8 @@ import re
 import shlex
 import subprocess
 import time
-from typing import Any, Callable, Dict, List, NamedTuple, Optional, Tuple, Union
+from typing import (Any, Callable, Dict, List, NamedTuple, Optional, Sequence,
+                    Tuple, Union)
 
 from paramiko.config import SSHConfig
 
@@ -1605,7 +1606,45 @@ def job_timeline(cluster: str,
         logger.debug(f'Could not read Slurm accounting for {job_name!r} on '
                      f'{cluster}: {e}')
         records = []
+    return _timeline_of(client, cluster, records, job_name, deadline)
 
+
+def job_timeline_by_ids(
+        cluster: str,
+        job_ids: Sequence[str],
+        deadline: Optional[float] = None) -> List[Dict[str, Any]]:
+    """The same timeline, for allocations already known by id.
+
+    This is the path for a job whose cluster has been reclaimed: the ids come
+    from the events written when each allocation was submitted, so nothing
+    has to be looked up by name -- and asking sacct for an id needs no time
+    window, since `-j` puts the job's whole history in scope.
+    """
+    client = _client_for(cluster)
+    if client is None:
+        return []
+    records: List[Dict[str, str]] = []
+    for job_id in job_ids:
+        if deadline is not None and time.monotonic() >= deadline:
+            logger.debug(f'Out of time to read the rest of the Slurm '
+                         f'allocations on {cluster}')
+            break
+        try:
+            records.extend(client.get_job_accounting(job_id))
+        except Exception as e:  # pylint: disable=broad-except
+            logger.debug(f'Could not read Slurm accounting for {job_id} on '
+                         f'{cluster}: {e}')
+    return _timeline_of(client, cluster, records, None, deadline)
+
+
+def _timeline_of(client: 'slurm.SlurmClient', cluster: str,
+                 records: List[Dict[str, str]], job_name: Optional[str],
+                 deadline: Optional[float]) -> List[Dict[str, Any]]:
+    """Entries for ``records``, plus the live diagnosis of a pending one.
+
+    ``job_name`` enables the squeue fallback for a cluster with no accounting;
+    a caller that resolved by id has no name to fall back on and passes None.
+    """
     # Records are grouped by job id, not counted as one run: several records
     # under one id are a requeue's attempts, while several ids are separate
     # allocations that happen to share the name.
@@ -1631,7 +1670,7 @@ def job_timeline(cluster: str,
             logger.debug(f'Out of time to explain pending Slurm jobs '
                          f'{pending_ids} on {cluster}')
         return sorted(entries, key=lambda entry: entry['at'])
-    if not records:
+    if not records and job_name is not None:
         # Nothing from accounting: squeue still knows a queued allocation,
         # and a job that has not started is the one most in need of an
         # answer, so a cluster without slurmdbd is not left silent.

--- a/sky/provision/slurm/utils.py
+++ b/sky/provision/slurm/utils.py
@@ -1636,12 +1636,20 @@ def job_timeline(cluster: str,
         # and a job that has not started is the one most in need of an
         # answer, so a cluster without slurmdbd is not left silent.
         try:
-            pending_ids = client.query_jobs(job_name, ['pending'])
+            pending_ids = client.query_jobs(
+                job_name, ['pending'], timeout=slurm.JOB_READ_TIMEOUT_SECONDS)
         except Exception as e:  # pylint: disable=broad-except
             logger.debug(f'Could not look up pending Slurm jobs named '
                          f'{job_name!r} on {cluster}: {e}')
     now = int(time.time())
     for job_id in pending_ids:
+        # Between allocations as well as within one: `explain_pending_job`
+        # always pays for the reason itself before the deadline can stop
+        # anything, so a second id would spend a whole read's budget again.
+        if deadline is not None and time.monotonic() >= deadline:
+            logger.debug(f'Out of time to explain the rest of the pending '
+                         f'Slurm jobs on {cluster}')
+            break
         explained = explain_pending_job(cluster, job_id, deadline=deadline)
         if explained is None:
             continue

--- a/sky/provision/slurm/utils.py
+++ b/sky/provision/slurm/utils.py
@@ -15,6 +15,7 @@ from sky import exceptions
 from sky import sky_logging
 from sky import skypilot_config
 from sky.adaptors import slurm
+from sky.provision.slurm import pending as pending_lib
 from sky.skylet import constants
 from sky.skylet import runtime_utils
 from sky.utils import annotations
@@ -1296,6 +1297,108 @@ def slurm_cluster_names() -> List[str]:
         List[str]: The configured and allowed Slurm cluster names.
     """
     return clouds.Slurm.existing_allowed_clusters()
+
+
+def _client_for(cluster: str) -> Optional['slurm.SlurmClient']:
+    """A client for ``cluster``, or None when it is not configured.
+
+    None rather than an exception: an ssh_config lookup of a host that is not
+    there returns a dict with only ``hostname``, so building the client dies
+    on the missing ``user`` and the caller is handed a KeyError to report.
+    """
+    try:
+        ssh_config_dict = get_slurm_ssh_config().lookup(cluster)
+        if 'user' not in ssh_config_dict:
+            logger.debug(f'Slurm cluster {cluster!r} is not in ~/.slurm/config')
+            return None
+        slurm_user = get_submit_user(cluster)
+        return slurm.SlurmClient(
+            ssh_config_dict['hostname'],
+            int(ssh_config_dict.get('port', 22)),
+            ssh_config_dict['user'],
+            get_identity_file(ssh_config_dict),
+            ssh_proxy_command=ssh_config_dict.get('proxycommand', None),
+            ssh_proxy_jump=ssh_config_dict.get('proxyjump', None),
+            identities_only=get_identities_only(ssh_config_dict),
+            slurm_user=slurm_user,
+        )
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f'Could not build a Slurm client for {cluster!r}: {e}')
+        return None
+
+
+def explain_pending_job(cluster: str, job_id: str) -> Optional[Dict[str, Any]]:
+    """Why ``job_id`` on ``cluster`` has not started, or None.
+
+    None when the job is not pending, is not known to Slurm any more, carries
+    no reason yet, or the cluster cannot be reached -- all normal outcomes for
+    a caller that is asking opportunistically.
+
+    Evidence is gathered per category rather than always: the reads a
+    dependency needs are not the reads a resource wait needs, and paying for
+    both would double the cost of every answer. Each read is best-effort; one
+    that fails leaves its field unset and the classification says what it
+    could not read (see ``pending``).
+    """
+    client = _client_for(cluster)
+    if client is None:
+        return None
+    try:
+        details = client.get_pending_job_details(job_id)
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f'Could not read Slurm job {job_id} on {cluster}: {e}')
+        return None
+    if not details or details.get('state', '').upper() != 'PENDING':
+        return None
+
+    job = {
+        'job_id': job_id,
+        'state': 'PENDING',
+        'reason': details.get('reason', ''),
+        'partition': details.get('partition', ''),
+        'dependency': details.get('dependency', ''),
+        'priority': details.get('priority'),
+        'qos': details.get('qos', ''),
+        'num_nodes': details.get('num_nodes') or 1,
+        'gpus_per_node': 0,
+        'start_time': details.get('start_time'),
+    }
+    code = pending_lib.pending_reason_code(job)
+    if not code:
+        return None
+    category = pending_lib.pending_category(code)
+    evidence = pending_lib.PendingEvidence()
+
+    if category == pending_lib.CATEGORY_HELD:
+        evidence.begin_time = details.get('start_time')
+    elif category == pending_lib.CATEGORY_DEPENDENCY:
+        parsed = pending_lib.parse_dependency(str(job['dependency'] or ''))
+        if parsed['job_ids']:
+            try:
+                evidence.dependency_states = client.get_job_states(
+                    parsed['job_ids'])
+            except Exception as e:  # pylint: disable=broad-except
+                logger.debug(f'Could not read dependency states for '
+                             f'{job_id}: {e}')
+    elif category == pending_lib.CATEGORY_RESOURCES:
+        partitions = pending_lib.partitions_of(job['partition'])
+        try:
+            node_infos = _get_slurm_node_info_list(slurm_cluster_name=cluster)
+            evidence.partition_nodes = pending_lib.partition_node_counts(
+                node_infos, partitions, busy_nodes=set())
+        except Exception as e:  # pylint: disable=broad-except
+            logger.debug(f'Could not read node info for {cluster}: {e}')
+        try:
+            evidence.pending_ahead = pending_lib.pending_ahead(
+                client.get_pending_queue(), job)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.debug(f'Could not read the pending queue for '
+                         f'{cluster}: {e}')
+    # The quota branch needs the accounting database's QoS definitions, which
+    # this read has no access to; the classification says the cap is unknown
+    # rather than naming one.
+
+    return pending_lib.classify_pending(job, evidence)
 
 
 def slurm_node_info(

--- a/sky/provision/slurm/utils.py
+++ b/sky/provision/slurm/utils.py
@@ -1,4 +1,5 @@
 """Slurm utilities for SkyPilot."""
+import collections
 import json
 import math
 import os
@@ -21,6 +22,7 @@ from sky.skylet import runtime_utils
 from sky.utils import annotations
 from sky.utils import common_utils
 from sky.utils import gpu_names
+from sky.utils import log_utils
 from sky.utils import subprocess_utils
 from sky.utils.db import kv_cache
 
@@ -1327,7 +1329,10 @@ def _client_for(cluster: str) -> Optional['slurm.SlurmClient']:
         return None
 
 
-def explain_pending_job(cluster: str, job_id: str) -> Optional[Dict[str, Any]]:
+def explain_pending_job(
+        cluster: str,
+        job_id: str,
+        deadline: Optional[float] = None) -> Optional[Dict[str, Any]]:
     """Why ``job_id`` on ``cluster`` has not started, or None.
 
     None when the job is not pending, is not known to Slurm any more, carries
@@ -1339,7 +1344,17 @@ def explain_pending_job(cluster: str, job_id: str) -> Optional[Dict[str, Any]]:
     both would double the cost of every answer. Each read is best-effort; one
     that fails leaves its field unset and the classification says what it
     could not read (see ``pending``).
+
+    ``deadline`` (a ``time.monotonic()`` value) stops the evidence gathering
+    once it passes, so a caller on a request path can bound the whole answer
+    rather than the individual reads. The reason is already known by then;
+    what is skipped is the evidence that would have sharpened it, and the
+    classification degrades to saying so.
     """
+
+    def _out_of_time() -> bool:
+        return deadline is not None and time.monotonic() >= deadline
+
     client = _client_for(cluster)
     if client is None:
         return None
@@ -1373,7 +1388,7 @@ def explain_pending_job(cluster: str, job_id: str) -> Optional[Dict[str, Any]]:
         evidence.begin_time = details.get('start_time')
     elif category == pending_lib.CATEGORY_DEPENDENCY:
         parsed = pending_lib.parse_dependency(str(job['dependency'] or ''))
-        if parsed['job_ids']:
+        if parsed['job_ids'] and not _out_of_time():
             try:
                 evidence.dependency_states = client.get_job_states(
                     parsed['job_ids'])
@@ -1383,14 +1398,26 @@ def explain_pending_job(cluster: str, job_id: str) -> Optional[Dict[str, Any]]:
     elif category == pending_lib.CATEGORY_RESOURCES:
         partitions = pending_lib.partitions_of(job['partition'])
         try:
-            node_infos = _get_slurm_node_info_list(slurm_cluster_name=cluster)
-            evidence.partition_nodes = pending_lib.partition_node_counts(
-                node_infos, partitions, busy_nodes=set())
+            # One sinfo, not `slurm_node_info`: that one also runs
+            # `scontrol show node` over the whole cluster and derives GPU
+            # counts, none of which the node tally uses, and it is bounded
+            # for the inventory sweep rather than for a request.
+            if not _out_of_time():
+                evidence.partition_nodes = pending_lib.partition_node_counts(
+                    [{
+                        'node_name': node.node,
+                        'partition': node.partition,
+                        'node_state': node.state,
+                    } for node in client.info_nodes(
+                        timeout=slurm.JOB_READ_TIMEOUT_SECONDS)],
+                    partitions,
+                    busy_nodes=set())
         except Exception as e:  # pylint: disable=broad-except
             logger.debug(f'Could not read node info for {cluster}: {e}')
         try:
-            evidence.pending_ahead = pending_lib.pending_ahead(
-                client.get_pending_queue(), job)
+            if not _out_of_time():
+                evidence.pending_ahead = pending_lib.pending_ahead(
+                    client.get_pending_queue(), job)
         except Exception as e:  # pylint: disable=broad-except
             logger.debug(f'Could not read the pending queue for '
                          f'{cluster}: {e}')
@@ -1399,6 +1426,234 @@ def explain_pending_job(cluster: str, job_id: str) -> Optional[Dict[str, Any]]:
     # rather than naming one.
 
     return pending_lib.classify_pending(job, evidence)
+
+
+# Slurm states that mean the allocation is over. sacct reports a *projected*
+# Start and End for a job that has not reached one of these, so a timeline
+# reading those fields regardless would announce an end that has not
+# happened. 'CANCELLED by 1000' is one of these states, hence the prefix
+# match.
+_TERMINAL_STATE_PREFIXES = ('COMPLETED', 'FAILED', 'CANCELLED', 'TIMEOUT',
+                            'NODE_FAIL', 'PREEMPTED', 'BOOT_FAIL',
+                            'OUT_OF_MEMORY', 'DEADLINE', 'REVOKED',
+                            'SPECIAL_EXIT')
+
+# What each of the two waits can be blocked on. Slurm does not keep the
+# reason for a wait that is over -- its Reason column holds at most the last
+# non-resource one -- but which *side* of Eligible a wait fell on narrows it
+# to one of these two sets, which is the question a user actually asks.
+_BEFORE_ELIGIBLE = 'a dependency, a hold or a begin time'
+_AFTER_ELIGIBLE = 'resources, priority or a quota limit'
+
+
+def _epoch(value: Optional[str]) -> Optional[int]:
+    """A Slurm timestamp as epoch seconds, or None.
+
+    The reads ask for epoch seconds, so anything else is either Slurm's own
+    `Unknown` (a time it has not computed) or the ISO form from a build that
+    ignored the request. Neither can be turned into an instant here -- the
+    ISO form carries no timezone -- and an entry needs a real one to be
+    ordered against SkyPilot's own events, so both are dropped.
+    """
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+
+
+def _waited(start: Optional[int], end: Optional[int]) -> str:
+    """How long the gap was, or '' when there was none to speak of."""
+    if start is None or end is None or end <= start:
+        return ''
+    return log_utils.readable_time_duration(start, end, absolute=True)
+
+
+def _entry(event: str, at: int, text: str) -> Dict[str, Any]:
+    return {'event': event, 'at': at, 'text': f'Slurm {text}'}
+
+
+def _allocation_entries(record: Dict[str, str], attempt: int,
+                        attempts: int) -> List[Dict[str, Any]]:
+    """The events one sacct record accounts for, oldest first.
+
+    ``attempt``/``attempts`` count the records that share this record's job
+    id, which is what a requeue produces: it keeps the id and ``-D`` returns
+    one record per try, so without the numbering two sets of waits would
+    appear under the same name. Records with *different* ids are separate
+    allocations (a relaunch reusing the cluster name) and are told apart by
+    the id itself.
+    """
+    job_id = record.get('job_id') or '<unknown>'
+    label = f'allocation {job_id}'
+    if attempts > 1:
+        label = f'{label} (attempt {attempt} of {attempts})'
+    state = (record.get('state') or '').upper()
+    terminal = state.startswith(_TERMINAL_STATE_PREFIXES)
+    submit = _epoch(record.get('submit'))
+    eligible = _epoch(record.get('eligible'))
+    start = _epoch(record.get('start'))
+    end = _epoch(record.get('end'))
+    reason = record.get('reason') or ''
+    if reason.lower() in ('none', 'unknown'):
+        reason = ''
+
+    entries: List[Dict[str, Any]] = []
+    if submit is None:
+        # Without a submit time there is no interval to report, and nothing
+        # to order the rest of the record against.
+        return entries
+
+    partition = record.get('partition')
+    where = f' to partition {partition}' if partition else ''
+    try:
+        restarts = int(record.get('restarts') or 0)
+    except ValueError:
+        restarts = 0
+    requeued = ''
+    if restarts:
+        times = 'once' if restarts == 1 else f'{restarts} times'
+        requeued = f'; Slurm has requeued it {times}'
+    entries.append(
+        _entry('submitted', submit, f'{label} submitted{where}{requeued}'))
+
+    recorded = f'; Slurm recorded the reason as {reason}' if reason else ''
+    if eligible is not None:
+        waited = _waited(submit, eligible)
+        if waited:
+            text = (f'{label} became eligible to run after {waited} blocked '
+                    f'on {_BEFORE_ELIGIBLE}{recorded}')
+        else:
+            text = f'{label} was eligible to run as soon as it was submitted'
+        entries.append(_entry('eligible', eligible, text))
+    elif terminal:
+        # Eligible is the literal 'Unknown' for a job cancelled while still
+        # blocked -- measured on a held job and a dependency-blocked one
+        # alike. That is a fact worth stating outright, not a missing value
+        # to paper over.
+        entries.append(
+            _entry(
+                'never_eligible', end if end is not None else submit,
+                f'{label} never became eligible to run: blocked on '
+                f'{_BEFORE_ELIGIBLE} from submission until it ended'
+                f'{recorded}'))
+
+    if start is not None and not state.startswith('PENDING'):
+        waited = _waited(eligible if eligible is not None else submit, start)
+        if waited:
+            text = (f'{label} started after waiting {waited} for '
+                    f'{_AFTER_ELIGIBLE}')
+        else:
+            text = f'{label} started as soon as it became eligible'
+        nodes = record.get('nodes')
+        if nodes and nodes.lower() not in ('none', 'none assigned'):
+            text += f'; nodes: {nodes}'
+        entries.append(_entry('started', start, text))
+
+    if terminal and end is not None:
+        text = f'{label} ended: {state}'
+        exit_code = record.get('exit_code')
+        # 0:0 on a state that is not COMPLETED says nothing (a cancelled job
+        # reports it too), and on COMPLETED it is implied.
+        if exit_code and exit_code != '0:0':
+            text += f' (exit {exit_code})'
+        ran = _waited(start, end)
+        if ran:
+            text += f', after running {ran}'
+        entries.append(_entry('ended', end, text))
+    return entries
+
+
+def job_timeline(cluster: str,
+                 job_name: str,
+                 since: int,
+                 deadline: Optional[float] = None) -> List[Dict[str, Any]]:
+    """The Slurm side of an allocation's history, oldest first.
+
+    ``job_name`` is what the allocation was submitted under -- for a
+    SkyPilot cluster, its ``cluster_name_on_cloud`` -- and ``since`` (epoch
+    seconds) bounds how far back to look, because sacct's window for a
+    name-based query would otherwise start at 00:00:00 today.
+
+    Each entry is ``{'event', 'at', 'text'}``: a kind, an instant, and one
+    sentence. The two intervals are the point of it,
+
+        submit -> eligible   blocked on a dependency, a hold or a begin time
+        eligible -> start    blocked on resources, priority or a quota
+
+    because Slurm keeps the timestamps of a finished wait but not its reason,
+    while which side of `Eligible` the wait fell on is enough to name the
+    cause. An allocation that is still pending has no interval to report yet,
+    so it gets the live diagnosis from ``explain_pending_job`` instead.
+
+    ``deadline`` (a ``time.monotonic()`` value) bounds the whole answer for a
+    caller on a request path. The accounting read is what the timeline is
+    made of, so it always runs; past the deadline the live diagnosis -- three
+    further reads, and the one part that is also reachable on its own -- is
+    skipped.
+
+    Empty when the cluster is not configured, a read fails or times out, or
+    accounting is unavailable (no slurmdbd). Every one of those means "this
+    could not be read" rather than "nothing happened", which is why the
+    result is merged into a larger timeline instead of presented as one.
+    """
+    client = _client_for(cluster)
+    if client is None:
+        return []
+    try:
+        records = client.get_job_accounting_by_name(job_name, since)
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f'Could not read Slurm accounting for {job_name!r} on '
+                     f'{cluster}: {e}')
+        records = []
+
+    # Records are grouped by job id, not counted as one run: several records
+    # under one id are a requeue's attempts, while several ids are separate
+    # allocations that happen to share the name.
+    totals: Dict[str, int] = collections.Counter(
+        record.get('job_id', '') for record in records)
+    seen: Dict[str, int] = collections.defaultdict(int)
+    entries: List[Dict[str, Any]] = []
+    for record in records:
+        job_id = record.get('job_id', '')
+        seen[job_id] += 1
+        entries.extend(_allocation_entries(record, seen[job_id],
+                                           totals[job_id]))
+
+    pending_ids = [
+        record['job_id']
+        for record in records
+        if (record.get('state') or '').upper().startswith('PENDING')
+    ]
+    if deadline is not None and time.monotonic() >= deadline:
+        # The accounting read spent the budget. Say what it found and leave
+        # the diagnosis to a caller that asks for it directly.
+        if pending_ids:
+            logger.debug(f'Out of time to explain pending Slurm jobs '
+                         f'{pending_ids} on {cluster}')
+        return sorted(entries, key=lambda entry: entry['at'])
+    if not records:
+        # Nothing from accounting: squeue still knows a queued allocation,
+        # and a job that has not started is the one most in need of an
+        # answer, so a cluster without slurmdbd is not left silent.
+        try:
+            pending_ids = client.query_jobs(job_name, ['pending'])
+        except Exception as e:  # pylint: disable=broad-except
+            logger.debug(f'Could not look up pending Slurm jobs named '
+                         f'{job_name!r} on {cluster}: {e}')
+    now = int(time.time())
+    for job_id in pending_ids:
+        explained = explain_pending_job(cluster, job_id, deadline=deadline)
+        if explained is None:
+            continue
+        summary = explained['summary']
+        text = f'allocation {job_id} is pending: {summary}'
+        if explained.get('action'):
+            text = f'{text} {explained["action"]}'
+        entries.append(_entry('pending', now, text))
+
+    # Stable, so two entries sharing an instant keep the order they were
+    # built in (submitted before eligible).
+    return sorted(entries, key=lambda entry: entry['at'])
 
 
 def slurm_node_info(

--- a/sky/schemas/db/global_user_state/023_add_cluster_events_name_index.py
+++ b/sky/schemas/db/global_user_state/023_add_cluster_events_name_index.py
@@ -1,0 +1,55 @@
+"""Add an index for the cluster_events lookups keyed on the name column.
+
+cluster_events is keyed (cluster_hash, reason, transitioned_at), but two
+readers filter on the ``name`` column instead, because it is the only one
+that survives a cluster's teardown:
+get_latest_cluster_events (the details column of every `sky jobs queue -v`)
+and get_cluster_events_by_name (the job-events timeline). Neither name nor
+type is indexed, so both were full-table scans over every cluster's whole
+history.
+
+Revision ID: 023
+Revises: 022
+Create Date: 2026-09-09
+
+"""
+# pylint: disable=invalid-name
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '023'
+down_revision: Union[str, Sequence[str], None] = '022'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_INDEX_NAME = 'ix_cluster_events_name_type'
+
+
+def _existing_indexes(table_name: str) -> set:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return {ix['name'] for ix in inspector.get_indexes(table_name)}
+
+
+def upgrade():
+    """Create the index if it doesn't already exist.
+
+    Idempotent, and inside an autocommit block so PostgreSQL accepts the
+    implicit transactional DDL and SQLite runs the statement directly --
+    the same pattern as the spot_jobs index migrations.
+    """
+    if _INDEX_NAME in _existing_indexes('cluster_events'):
+        return
+    with op.get_context().autocommit_block():
+        # transitioned_at trails the equality columns so the ORDER BY of
+        # both readers is served by the index rather than by a sort.
+        op.create_index(_INDEX_NAME, 'cluster_events',
+                        ['name', 'type', 'transitioned_at'])
+
+
+def downgrade():
+    """No-op for backward compatibility."""
+    pass

--- a/sky/utils/db/migration_utils.py
+++ b/sky/utils/db/migration_utils.py
@@ -30,7 +30,7 @@ DB_INIT_LOCK_TIMEOUT_SECONDS = 10
 _alembic_thread_lock = threading.Lock()
 
 GLOBAL_USER_STATE_DB_NAME = 'state_db'
-GLOBAL_USER_STATE_VERSION = '022'  # add volume resize fields
+GLOBAL_USER_STATE_VERSION = '023'  # index cluster_events by name
 GLOBAL_USER_STATE_LOCK_PATH = f'~/.sky/locks/.{GLOBAL_USER_STATE_DB_NAME}.lock'
 
 SPOT_JOBS_DB_NAME = 'spot_jobs_db'

--- a/tests/unit_tests/test_jobs_events_merge.py
+++ b/tests/unit_tests/test_jobs_events_merge.py
@@ -5,9 +5,12 @@ which surfaces provisioning milestones (e.g. image pulling) from the job's
 underlying cluster in the managed-job timeline.
 """
 import datetime
+import time
+import types
 
 import pytest
 
+from sky import clouds
 from sky import global_user_state
 from sky.jobs import state as managed_job_state
 from sky.jobs import utils as managed_job_utils
@@ -424,3 +427,289 @@ def test_limit_one_returns_the_newest_event_of_either_source(monkeypatch):
 
     result = core.get_job_events(job_id=1, limit=1, include_cluster_events=True)
     assert [e['reason'] for e in result] == ['Launching (pending: Resources)']
+
+
+def _slurm_handle(name_on_cloud='sky-my-task-1-a1b2', region='dev-slurm'):
+    """A cluster record's handle, as far as the Slurm resolution reads it."""
+    resources = types.SimpleNamespace(cloud=clouds.Slurm(), region=region)
+    return types.SimpleNamespace(cluster_name_on_cloud=name_on_cloud,
+                                 launched_resources=resources)
+
+
+def _other_handle():
+    resources = types.SimpleNamespace(cloud=clouds.Kubernetes(),
+                                      region='my-context')
+    return types.SimpleNamespace(cluster_name_on_cloud='sky-my-task-1-a1b2',
+                                 launched_resources=resources)
+
+
+def _entry(event, at, text):
+    return {'event': event, 'at': at, 'text': text}
+
+
+def test_only_slurm_backed_clusters_resolve_to_an_allocation(monkeypatch):
+    records = {
+        'slurm-cluster': {
+            'handle': _slurm_handle()
+        },
+        'k8s-cluster': {
+            'handle': _other_handle()
+        },
+        'gone-cluster': None,
+    }
+    monkeypatch.setattr(global_user_state, 'get_cluster_from_name',
+                        lambda name, **kwargs: records.get(name))
+    allocations = core._slurm_allocations([('slurm-cluster', 0),
+                                           ('k8s-cluster', 1),
+                                           ('gone-cluster', 2)])
+    # The Slurm cluster name comes from the resources' region, and the sbatch
+    # job name from cluster_name_on_cloud.
+    assert allocations == [('dev-slurm', 'sky-my-task-1-a1b2', 0)]
+
+
+def test_a_cluster_read_that_fails_is_skipped(monkeypatch):
+
+    def _boom(name, **kwargs):
+        del kwargs
+        raise RuntimeError(f'db is down ({name})')
+
+    monkeypatch.setattr(global_user_state, 'get_cluster_from_name', _boom)
+    assert core._slurm_allocations([('slurm-cluster', 0)]) == []
+
+
+def _patch_slurm(monkeypatch, entries, handle=None, capture=None):
+    monkeypatch.setattr(
+        global_user_state, 'get_cluster_from_name',
+        lambda name, **kwargs: {'handle': handle or _slurm_handle()})
+
+    def _timeline(cluster, job_name, since, deadline=None):
+        if capture is not None:
+            capture.append((cluster, job_name, since, deadline))
+        return list(entries)
+
+    monkeypatch.setattr(core.slurm_provision_utils, 'job_timeline', _timeline)
+
+
+def test_slurm_entries_join_the_timeline_without_claiming_a_status(monkeypatch):
+    job_events = [
+        _job_event('Job has started',
+                   managed_job_state.ManagedJobStatus.RUNNING, 300)
+    ]
+    monkeypatch.setattr(managed_job_state, 'get_job_events',
+                        lambda **kwargs: list(job_events))
+    monkeypatch.setattr(managed_job_state, 'get_managed_job_tasks',
+                        lambda job_id: [dict(_task(), submitted_at=50)])
+    monkeypatch.setattr(global_user_state, 'get_cluster_events_by_name',
+                        lambda *args, **kwargs: [])
+    _patch_slurm(monkeypatch, [
+        _entry('submitted', 100, 'Slurm allocation 17213 submitted'),
+        _entry('started', 200, 'Slurm allocation 17213 started'),
+    ])
+
+    result = core.get_job_events(job_id=1, include_cluster_events=True)
+    assert [event['reason'] for event in result] == [
+        'Job has started',
+        'Slurm allocation 17213 started',
+        'Slurm allocation 17213 submitted',
+    ]
+    slurm_rows = [e for e in result if e['reason'].startswith('Slurm ')]
+    for row in slurm_rows:
+        # Unlike a cluster event, these are not transitions of the job, so
+        # they assert no status at that instant.
+        assert row['new_status'] is None
+        assert row['code'] is None
+        assert row['spot_job_id'] == 1
+        assert row['task_id'] == 0
+
+
+def test_the_accounting_window_starts_at_the_job_submission(monkeypatch):
+    monkeypatch.setattr(managed_job_state, 'get_job_events',
+                        lambda **kwargs: [])
+    monkeypatch.setattr(
+        managed_job_state, 'get_managed_job_tasks', lambda job_id: [
+            dict(_task(task_id=0), submitted_at=1500),
+            dict(_task(task_id=1), submitted_at=900),
+        ])
+    monkeypatch.setattr(global_user_state, 'get_cluster_events_by_name',
+                        lambda *args, **kwargs: [])
+    calls = []
+    _patch_slurm(monkeypatch, [], capture=calls)
+
+    core.get_job_events(job_id=1, include_cluster_events=True)
+    # The earliest task's submission, so a pipeline's first allocation is
+    # still inside sacct's window.
+    assert [since for _, _, since, _ in calls] == [900, 900]
+    # Both allocations are read against one budget, not one each.
+    assert len({deadline for *_, deadline in calls}) == 1
+
+
+def test_a_job_with_no_submit_time_still_gets_a_window(monkeypatch):
+    monkeypatch.setattr(managed_job_state, 'get_managed_job_tasks',
+                        lambda job_id: [dict(_task(), submitted_at=None)])
+    since = core._job_submitted_at(1)
+    # A fortnight, which reaches past any cluster still in the database.
+    assert 13 * 24 * 3600 < time.time() - since < 15 * 24 * 3600
+
+
+def test_a_slurm_read_that_fails_leaves_the_job_events_intact(monkeypatch):
+    job_events = [
+        _job_event('Job is starting',
+                   managed_job_state.ManagedJobStatus.STARTING, 100)
+    ]
+    monkeypatch.setattr(managed_job_state, 'get_job_events',
+                        lambda **kwargs: list(job_events))
+    monkeypatch.setattr(managed_job_state, 'get_managed_job_tasks',
+                        lambda job_id: [dict(_task(), submitted_at=50)])
+    monkeypatch.setattr(global_user_state, 'get_cluster_events_by_name',
+                        lambda *args, **kwargs: [])
+    monkeypatch.setattr(global_user_state, 'get_cluster_from_name',
+                        lambda name, **kwargs: {'handle': _slurm_handle()})
+
+    def _boom(cluster, job_name, since, deadline=None):
+        del cluster, job_name, since, deadline
+        raise RuntimeError('login node is unreachable')
+
+    monkeypatch.setattr(core.slurm_provision_utils, 'job_timeline', _boom)
+    assert core.get_job_events(job_id=1,
+                               include_cluster_events=True) == job_events
+
+
+def test_slurm_entries_share_the_cluster_events_budget(monkeypatch):
+    """Both are 'what the infrastructure did'; neither may starve the job's
+    own transitions, and one limit governs the pair."""
+    job_events = [
+        _job_event('Job has started',
+                   managed_job_state.ManagedJobStatus.RUNNING, 900)
+    ]
+    monkeypatch.setattr(managed_job_state, 'get_job_events',
+                        lambda **kwargs: list(job_events))
+    monkeypatch.setattr(managed_job_state, 'get_managed_job_tasks',
+                        lambda job_id: [dict(_task(), submitted_at=50)])
+    monkeypatch.setattr(
+        global_user_state, 'get_cluster_events_by_name',
+        lambda *args, **kwargs: [{
+            'reason': f'Launching (pending: Resources) {i}',
+            'transitioned_at': 100 + i,
+        } for i in range(5)])
+    _patch_slurm(
+        monkeypatch,
+        [_entry('submitted', 200 + i, f'Slurm entry {i}') for i in range(5)])
+
+    result = core.get_job_events(job_id=1, limit=3, include_cluster_events=True)
+    assert len(result) == 3
+    # The job's own newest event survives, and the infra rows fill the rest.
+    assert result[0]['reason'] == 'Job has started'
+    assert all(
+        event['reason'].startswith('Slurm entry') for event in result[1:])
+
+
+def test_the_floor_holds_when_the_job_events_are_all_newer(monkeypatch):
+    """The floor has to *reserve* a slot, not just widen the candidate pool.
+    A Slurm timeline is older than the job's recent transitions by nature --
+    submitted/eligible/started all happen early -- so a job with a full
+    budget of its own newer events would otherwise hide the whole timeline,
+    which is exactly what the reader asked for."""
+    job_events = [
+        _job_event('Job is restarting',
+                   managed_job_state.ManagedJobStatus.STARTING, 600 + i)
+        for i in range(3)
+    ]
+    monkeypatch.setattr(managed_job_state, 'get_job_events',
+                        lambda **kwargs: list(job_events))
+    monkeypatch.setattr(managed_job_state, 'get_managed_job_tasks',
+                        lambda job_id: [dict(_task(), submitted_at=50)])
+    monkeypatch.setattr(global_user_state, 'get_cluster_events_by_name',
+                        lambda *args, **kwargs: [])
+    _patch_slurm(monkeypatch,
+                 [_entry('started', 500, 'Slurm allocation 17213 started')])
+
+    result = core.get_job_events(job_id=1, limit=3, include_cluster_events=True)
+    assert len(result) == 3
+    assert result[-1]['reason'] == 'Slurm allocation 17213 started'
+
+
+def test_limit_one_prefers_the_newest_even_when_it_is_the_job_s_own(
+        monkeypatch):
+    """The mirror of test_limit_one_returns_the_newest_event_of_either_source:
+    the reserved infra share must never cost the job's own newest row, or a
+    single-row view would show an old launch line instead of the transition
+    that just happened."""
+    job_events = [
+        _job_event('Job has started',
+                   managed_job_state.ManagedJobStatus.RUNNING, 500)
+    ]
+    monkeypatch.setattr(managed_job_state, 'get_job_events',
+                        lambda **kwargs: list(job_events))
+    monkeypatch.setattr(managed_job_state, 'get_managed_job_tasks',
+                        lambda job_id: [_task()])
+    monkeypatch.setattr(global_user_state,
+                        'get_cluster_events_by_name',
+                        lambda name, event_types, limit=None: [{
+                            'reason': 'Launching (pending: Resources)',
+                            'transitioned_at': 100
+                        }])
+
+    result = core.get_job_events(job_id=1, limit=1, include_cluster_events=True)
+    assert [event['reason'] for event in result] == ['Job has started']
+
+
+def test_the_slurm_reads_share_one_budget_across_allocations(monkeypatch):
+    """Per-read timeouts do not bound a pipeline: an unresponsive login node
+    would cost them once per allocation."""
+    monkeypatch.setattr(managed_job_state, 'get_job_events',
+                        lambda **kwargs: [])
+    monkeypatch.setattr(
+        managed_job_state, 'get_managed_job_tasks', lambda job_id: [
+            dict(_task(task_id=0), submitted_at=50),
+            dict(_task(task_id=1), submitted_at=50),
+        ])
+    monkeypatch.setattr(global_user_state, 'get_cluster_events_by_name',
+                        lambda *args, **kwargs: [])
+    calls = []
+    monkeypatch.setattr(global_user_state, 'get_cluster_from_name',
+                        lambda name, **kwargs: {'handle': _slurm_handle()})
+
+    # A budget the first allocation is made to overrun, rather than a
+    # mutation mid-loop: the deadline is computed once, which is the point.
+    monkeypatch.setattr(core, '_SLURM_TIMELINE_BUDGET_SECONDS', 0.05)
+
+    def _slow(cluster, job_name, since, deadline=None):
+        del cluster, job_name, since, deadline
+        calls.append(time.monotonic())
+        time.sleep(0.06)
+        return []
+
+    monkeypatch.setattr(core.slurm_provision_utils, 'job_timeline', _slow)
+    core.get_job_events(job_id=1, include_cluster_events=True)
+    # The second allocation is not attempted once the budget is gone.
+    assert len(calls) == 1
+
+
+def test_a_failure_resolving_the_allocations_is_not_an_error(monkeypatch):
+    """The guard has to cover the whole merge: resolving the allocations and
+    the job's submit time are database reads of their own, and the request
+    already has its job events by then."""
+    job_events = [
+        _job_event('Job is starting',
+                   managed_job_state.ManagedJobStatus.STARTING, 100)
+    ]
+    monkeypatch.setattr(managed_job_state, 'get_job_events',
+                        lambda **kwargs: list(job_events))
+    calls = {'n': 0}
+
+    def _tasks(job_id):
+        del job_id
+        calls['n'] += 1
+        # The first call builds the cluster list; the second, inside the
+        # Slurm merge, is the one that fails.
+        if calls['n'] > 1:
+            raise RuntimeError('connection pool exhausted')
+        return [dict(_task(), submitted_at=50)]
+
+    monkeypatch.setattr(managed_job_state, 'get_managed_job_tasks', _tasks)
+    monkeypatch.setattr(global_user_state, 'get_cluster_events_by_name',
+                        lambda *args, **kwargs: [])
+    monkeypatch.setattr(global_user_state, 'get_cluster_from_name',
+                        lambda name, **kwargs: {'handle': _slurm_handle()})
+    assert core.get_job_events(job_id=1,
+                               include_cluster_events=True) == job_events

--- a/tests/unit_tests/test_jobs_events_merge.py
+++ b/tests/unit_tests/test_jobs_events_merge.py
@@ -88,9 +88,11 @@ def test_merge_orders_newest_first_and_truncates(monkeypatch):
     captured = {}
 
     def _fake_cluster_events(name, event_types, limit=None):
+        # Two callers now: the merge asks for both types with the budget,
+        # and resolving a torn-down cluster's allocation asks for
+        # launch-progress alone and unbounded.
+        captured.setdefault('calls', []).append((name, set(event_types), limit))
         captured['name'] = name
-        captured['event_types'] = event_types
-        captured['limit'] = limit
         return list(cluster_events)
 
     monkeypatch.setattr(global_user_state, 'get_cluster_events_by_name',
@@ -103,10 +105,10 @@ def test_merge_orders_newest_first_and_truncates(monkeypatch):
     assert captured['name'] == 'my-task-1'
     # Both the milestone sequence and the finer-grained launch progress are
     # requested.
-    assert (set(captured['event_types']) == {
+    assert (3, {
         global_user_state.ClusterEventType.STATUS_CHANGE,
         global_user_state.ClusterEventType.LAUNCH_PROGRESS,
-    })
+    }) in [(limit, types) for _, types, limit in captured['calls']]
     # Newest first, capped at limit=3. The job's own two transitions keep
     # their place and the remaining slot goes to the newest cluster event:
     # a launch can emit more cluster events than the limit, and losing the
@@ -249,8 +251,10 @@ def test_pipeline_uses_per_task_cluster_name(monkeypatch):
 
     core.get_job_events(job_id=1, include_cluster_events=True)
 
-    # Per-task cluster names, not the shared DAG name 'pipe-1'.
-    assert queried_names == ['pipe-0-1', 'pipe-1-1']
+    # Per-task cluster names, not the shared DAG name 'pipe-1'. Each is
+    # asked about twice -- once by the merge, once to resolve a torn-down
+    # cluster's Slurm allocation -- so compare the distinct names.
+    assert list(dict.fromkeys(queried_names)) == ['pipe-0-1', 'pipe-1-1']
 
 
 def test_merged_cluster_events_carry_their_task_id(monkeypatch):
@@ -459,12 +463,17 @@ def test_only_slurm_backed_clusters_resolve_to_an_allocation(monkeypatch):
     }
     monkeypatch.setattr(global_user_state, 'get_cluster_from_name',
                         lambda name, **kwargs: records.get(name))
+    monkeypatch.setattr(global_user_state, 'get_cluster_events_by_name',
+                        lambda *args, **kwargs: [])
     allocations = core._slurm_allocations([('slurm-cluster', 0),
                                            ('k8s-cluster', 1),
                                            ('gone-cluster', 2)])
     # The Slurm cluster name comes from the resources' region, and the sbatch
-    # job name from cluster_name_on_cloud.
-    assert allocations == [('dev-slurm', 'sky-my-task-1-a1b2', 0)]
+    # job name from cluster_name_on_cloud. The cluster that is simply not
+    # there has no recorded allocation either, so it contributes nothing.
+    assert allocations == [
+        core._SlurmAllocation('dev-slurm', 'sky-my-task-1-a1b2', [], 0)
+    ]
 
 
 def test_a_cluster_read_that_fails_is_skipped(monkeypatch):
@@ -716,3 +725,84 @@ def test_a_failure_resolving_the_allocations_is_not_an_error(monkeypatch):
                         lambda name, **kwargs: {'handle': _slurm_handle()})
     assert core.get_job_events(job_id=1,
                                include_cluster_events=True) == job_events
+
+
+def _alloc_event(job_id, slurm_cluster='dev-slurm', at=100):
+    return {
+        'reason': f'Launching (Slurm job {job_id} on {slurm_cluster})',
+        'transitioned_at': at,
+    }
+
+
+def test_a_torn_down_cluster_resolves_from_its_recorded_allocations(
+        monkeypatch):
+    """The point of reading sacct is a job Slurm has already forgotten, and
+    that is exactly when the cluster record is gone too. The events written
+    at submission outlive it."""
+    monkeypatch.setattr(global_user_state, 'get_cluster_from_name',
+                        lambda name, **kwargs: None)
+    monkeypatch.setattr(
+        global_user_state, 'get_cluster_events_by_name',
+        lambda *args, **kwargs: [
+            _alloc_event('17300', at=300),
+            {
+                'reason': 'Launching (pending: Resources; partition: dev)',
+                'transitioned_at': 200
+            },
+            _alloc_event('17269', at=100),
+        ])
+    allocations = core._slurm_allocations([('gone-cluster', 0)])
+    # Both attempts, oldest first, under the one Slurm cluster; the
+    # pending-reason event is not mistaken for an allocation.
+    assert allocations == [
+        core._SlurmAllocation('dev-slurm', None, ['17300', '17269'], 0)
+    ]
+
+
+def test_a_live_cluster_record_wins_over_the_recorded_events(monkeypatch):
+    """The record is authoritative while it exists; the events are the
+    fallback, so a live cluster pays no attention to them."""
+    monkeypatch.setattr(global_user_state, 'get_cluster_from_name',
+                        lambda name, **kwargs: {'handle': _slurm_handle()})
+
+    def _should_not_be_called(*args, **kwargs):
+        raise AssertionError('the events are only the fallback')
+
+    monkeypatch.setattr(global_user_state, 'get_cluster_events_by_name',
+                        _should_not_be_called)
+    assert core._slurm_allocations([
+        ('live-cluster', 0)
+    ]) == [core._SlurmAllocation('dev-slurm', 'sky-my-task-1-a1b2', [], 0)]
+
+
+def test_a_recorded_allocation_is_read_by_id_not_by_name(monkeypatch):
+    """An id needs no time window -- sacct's `-j` puts the job's whole
+    history in scope -- while a name-based query would."""
+    monkeypatch.setattr(managed_job_state, 'get_job_events',
+                        lambda **kwargs: [])
+    monkeypatch.setattr(managed_job_state, 'get_managed_job_tasks',
+                        lambda job_id: [dict(_task(), submitted_at=50)])
+    monkeypatch.setattr(global_user_state, 'get_cluster_from_name',
+                        lambda name, **kwargs: None)
+    monkeypatch.setattr(global_user_state, 'get_cluster_events_by_name',
+                        lambda *args, **kwargs: [_alloc_event('17269')])
+    by_ids = []
+    monkeypatch.setattr(
+        core.slurm_provision_utils,
+        'job_timeline_by_ids',
+        lambda cluster, job_ids, deadline=None:
+        (by_ids.append((cluster, list(job_ids))) or
+         [_entry('ended', 500, 'Slurm allocation 17269 ended: COMPLETED')]))
+
+    def _by_name(*args, **kwargs):
+        raise AssertionError('a recorded allocation is addressed by id')
+
+    monkeypatch.setattr(core.slurm_provision_utils, 'job_timeline', _by_name)
+    result = core.get_job_events(job_id=1, include_cluster_events=True)
+    assert by_ids == [('dev-slurm', ['17269'])]
+    # The recording event is a launch-progress event too, so it also merges
+    # in -- which is how a reader learns the id to pass to sacct themselves.
+    assert [event['reason'] for event in result] == [
+        'Slurm allocation 17269 ended: COMPLETED',
+        'Launching (Slurm job 17269 on dev-slurm)',
+    ]

--- a/tests/unit_tests/test_jobs_events_merge.py
+++ b/tests/unit_tests/test_jobs_events_merge.py
@@ -671,12 +671,15 @@ def test_the_slurm_reads_share_one_budget_across_allocations(monkeypatch):
 
     # A budget the first allocation is made to overrun, rather than a
     # mutation mid-loop: the deadline is computed once, which is the point.
-    monkeypatch.setattr(core, '_SLURM_TIMELINE_BUDGET_SECONDS', 0.05)
+    # The margin is wide because the fragile direction is the *first* check:
+    # jitter between computing the deadline and reaching the loop would
+    # otherwise skip every allocation and leave `calls` empty.
+    monkeypatch.setattr(core, '_SLURM_TIMELINE_BUDGET_SECONDS', 0.2)
 
     def _slow(cluster, job_name, since, deadline=None):
         del cluster, job_name, since, deadline
         calls.append(time.monotonic())
-        time.sleep(0.06)
+        time.sleep(0.25)
         return []
 
     monkeypatch.setattr(core.slurm_provision_utils, 'job_timeline', _slow)

--- a/tests/unit_tests/test_jobs_events_merge.py
+++ b/tests/unit_tests/test_jobs_events_merge.py
@@ -751,12 +751,31 @@ def test_a_torn_down_cluster_resolves_from_its_recorded_allocations(
             },
             _alloc_event('17269', at=100),
         ])
+    monkeypatch.setattr(clouds.Slurm, 'existing_allowed_clusters',
+                        classmethod(lambda cls, silent=False: ['dev-slurm']))
     allocations = core._slurm_allocations([('gone-cluster', 0)])
-    # Both attempts, oldest first, under the one Slurm cluster; the
+    # Both attempts under the one Slurm cluster, oldest first so a deadline
+    # cuts the newest rather than the one being asked about; the
     # pending-reason event is not mistaken for an allocation.
     assert allocations == [
-        core._SlurmAllocation('dev-slurm', None, ['17300', '17269'], 0)
+        core._SlurmAllocation('dev-slurm', None, ['17269', '17300'], 0)
     ]
+
+
+def test_no_slurm_configured_skips_the_allocation_lookup(monkeypatch):
+    """The fallback cannot know which cloud a reclaimed cluster ran on, so
+    without this gate every finished job on every cloud pays for it."""
+    monkeypatch.setattr(global_user_state, 'get_cluster_from_name',
+                        lambda name, **kwargs: None)
+    monkeypatch.setattr(clouds.Slurm, 'existing_allowed_clusters',
+                        classmethod(lambda cls, silent=False: []))
+
+    def _should_not_be_called(*args, **kwargs):
+        raise AssertionError('no Slurm cluster is configured')
+
+    monkeypatch.setattr(global_user_state, 'get_cluster_events_by_name',
+                        _should_not_be_called)
+    assert core._slurm_allocations([('gone-cluster', 0)]) == []
 
 
 def test_a_live_cluster_record_wins_over_the_recorded_events(monkeypatch):
@@ -782,6 +801,8 @@ def test_a_recorded_allocation_is_read_by_id_not_by_name(monkeypatch):
                         lambda **kwargs: [])
     monkeypatch.setattr(managed_job_state, 'get_managed_job_tasks',
                         lambda job_id: [dict(_task(), submitted_at=50)])
+    monkeypatch.setattr(clouds.Slurm, 'existing_allowed_clusters',
+                        classmethod(lambda cls, silent=False: ['dev-slurm']))
     monkeypatch.setattr(global_user_state, 'get_cluster_from_name',
                         lambda name, **kwargs: None)
     monkeypatch.setattr(global_user_state, 'get_cluster_events_by_name',

--- a/tests/unit_tests/test_sky/provision/slurm/test_explain_pending.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_explain_pending.py
@@ -5,10 +5,12 @@ what the gatherer does when a read fails or a cluster is not there, since it
 runs on a path where an unanswerable question must not become an exception.
 """
 import subprocess
+import time
 from unittest import mock
 
 import pytest
 
+from sky.adaptors import slurm
 from sky.provision.slurm import pending
 from sky.provision.slurm import utils
 
@@ -63,23 +65,20 @@ def test_a_pending_job_with_no_reason_yet_is_none(client):
     assert utils.explain_pending_job(_CLUSTER, _JOB) is None
 
 
+def _node(name, partition, state):
+    return slurm.NodeInfo(node=name,
+                          state=state,
+                          gres='',
+                          cpus=8,
+                          memory_gb=64.0,
+                          partition=partition)
+
+
 def test_resources_reads_node_counts_and_the_queue(client):
-    node_infos = [
-        {
-            'node_name': 'gpu-1',
-            'partition': 'h200',
-            'node_state': 'alloc'
-        },
-        {
-            'node_name': 'gpu-2',
-            'partition': 'h200',
-            'node_state': 'drain'
-        },
-        {
-            'node_name': 'cpu-1',
-            'partition': 'cpu',
-            'node_state': 'idle'
-        },
+    client.info_nodes.return_value = [
+        _node('gpu-1', 'h200', 'alloc'),
+        _node('gpu-2', 'h200', 'drain'),
+        _node('cpu-1', 'cpu', 'idle'),
     ]
     client.get_pending_queue.return_value = [
         {
@@ -95,11 +94,13 @@ def test_resources_reads_node_counts_and_the_queue(client):
             'state': 'PENDING'
         },
     ]
-    with mock.patch.object(utils,
-                           '_get_slurm_node_info_list',
-                           return_value=node_infos):
-        out = utils.explain_pending_job(_CLUSTER, _JOB)
+    out = utils.explain_pending_job(_CLUSTER, _JOB)
     assert out['category'] == pending.CATEGORY_RESOURCES
+    # One sinfo, bounded. The full inventory helper also runs
+    # `scontrol show node` cluster-wide and derives GPU counts, none of which
+    # the tally uses, and its budget is sized for the inventory sweep.
+    assert client.info_nodes.call_args.kwargs['timeout'] == (
+        slurm.JOB_READ_TIMEOUT_SECONDS)
     # Only the h200 nodes count, and drain is not idle.
     assert out['evidence']['partition_nodes']['total'] == 2
     assert out['evidence']['partition_nodes']['idle'] == 0
@@ -111,10 +112,8 @@ def test_resources_reads_node_counts_and_the_queue(client):
 def test_a_failed_node_read_still_answers(client):
     """The reason is known even when the node counts are not; the summary says
     what it could not read rather than the call failing."""
-    with mock.patch.object(utils,
-                           '_get_slurm_node_info_list',
-                           side_effect=RuntimeError('sinfo timed out')):
-        out = utils.explain_pending_job(_CLUSTER, _JOB)
+    client.info_nodes.side_effect = RuntimeError('sinfo timed out')
+    out = utils.explain_pending_job(_CLUSTER, _JOB)
     assert out['category'] == pending.CATEGORY_RESOURCES
     assert out['evidence']['partition_nodes'] is None
     assert 'Waiting for free resources' in out['summary']
@@ -155,3 +154,26 @@ def test_a_timed_out_details_read_is_none(client):
     client.get_pending_job_details.side_effect = subprocess.TimeoutExpired(
         'squeue', 10)
     assert utils.explain_pending_job(_CLUSTER, _JOB) is None
+
+
+def test_a_spent_budget_answers_from_the_reason_alone(client):
+    """Past the deadline the reason is already known; what is skipped is the
+    evidence that would have sharpened it, and the summary says so."""
+    client.info_nodes.return_value = []
+    out = utils.explain_pending_job(_CLUSTER,
+                                    _JOB,
+                                    deadline=time.monotonic() - 1)
+    assert out['category'] == pending.CATEGORY_RESOURCES
+    client.info_nodes.assert_not_called()
+    client.get_pending_queue.assert_not_called()
+    assert out['evidence']['partition_nodes'] is None
+
+
+def test_a_spent_budget_skips_the_dependency_read(client):
+    client.get_pending_job_details.return_value = _details(
+        reason='Dependency', dependency='afterok:5122(unfulfilled)')
+    out = utils.explain_pending_job(_CLUSTER,
+                                    _JOB,
+                                    deadline=time.monotonic() - 1)
+    assert out['category'] == pending.CATEGORY_DEPENDENCY
+    client.get_job_states.assert_not_called()

--- a/tests/unit_tests/test_sky/provision/slurm/test_explain_pending.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_explain_pending.py
@@ -1,0 +1,157 @@
+"""Gathering the evidence behind a pending Slurm job (utils.explain_pending_job).
+
+The classification itself is covered in test_pending.py; what matters here is
+what the gatherer does when a read fails or a cluster is not there, since it
+runs on a path where an unanswerable question must not become an exception.
+"""
+import subprocess
+from unittest import mock
+
+import pytest
+
+from sky.provision.slurm import pending
+from sky.provision.slurm import utils
+
+_CLUSTER = 'dev-slurm'
+_JOB = '17209'
+
+
+def _details(**over):
+    d = {
+        'state': 'PENDING',
+        'reason': 'Resources',
+        'partition': 'h200',
+        'priority': '4000',
+        'num_nodes': '2',
+    }
+    d.update(over)
+    return d
+
+
+@pytest.fixture
+def client():
+    """A client whose reads all succeed, patched in place of a real one."""
+    fake = mock.MagicMock()
+    fake.get_pending_job_details.return_value = _details()
+    fake.get_pending_queue.return_value = []
+    fake.get_job_states.return_value = {}
+    with mock.patch.object(utils, '_client_for', return_value=fake):
+        yield fake
+
+
+def test_unconfigured_cluster_is_not_an_exception():
+    """The ssh_config lookup of an absent host yields a dict with only
+    'hostname', so building a client raises KeyError('user'). A caller asking
+    opportunistically gets None."""
+    with mock.patch.object(utils, 'get_slurm_ssh_config') as cfg:
+        cfg.return_value.lookup.return_value = {'hostname': 'nope'}
+        assert utils.explain_pending_job('nope', _JOB) is None
+
+
+def test_a_job_slurm_has_forgotten_is_none(client):
+    client.get_pending_job_details.return_value = {}
+    assert utils.explain_pending_job(_CLUSTER, _JOB) is None
+
+
+def test_a_running_job_is_none(client):
+    client.get_pending_job_details.return_value = _details(state='RUNNING')
+    assert utils.explain_pending_job(_CLUSTER, _JOB) is None
+
+
+def test_a_pending_job_with_no_reason_yet_is_none(client):
+    client.get_pending_job_details.return_value = _details(reason='None')
+    assert utils.explain_pending_job(_CLUSTER, _JOB) is None
+
+
+def test_resources_reads_node_counts_and_the_queue(client):
+    node_infos = [
+        {
+            'node_name': 'gpu-1',
+            'partition': 'h200',
+            'node_state': 'alloc'
+        },
+        {
+            'node_name': 'gpu-2',
+            'partition': 'h200',
+            'node_state': 'drain'
+        },
+        {
+            'node_name': 'cpu-1',
+            'partition': 'cpu',
+            'node_state': 'idle'
+        },
+    ]
+    client.get_pending_queue.return_value = [
+        {
+            'job_id': '1',
+            'partition': 'h200',
+            'priority': '9000',
+            'state': 'PENDING'
+        },
+        {
+            'job_id': '2',
+            'partition': 'h200',
+            'priority': '10',
+            'state': 'PENDING'
+        },
+    ]
+    with mock.patch.object(utils,
+                           '_get_slurm_node_info_list',
+                           return_value=node_infos):
+        out = utils.explain_pending_job(_CLUSTER, _JOB)
+    assert out['category'] == pending.CATEGORY_RESOURCES
+    # Only the h200 nodes count, and drain is not idle.
+    assert out['evidence']['partition_nodes']['total'] == 2
+    assert out['evidence']['partition_nodes']['idle'] == 0
+    assert out['evidence']['partition_nodes']['drained'] == 1
+    # One of the two pending jobs outranks this one.
+    assert out['evidence']['pending_ahead'] == 1
+
+
+def test_a_failed_node_read_still_answers(client):
+    """The reason is known even when the node counts are not; the summary says
+    what it could not read rather than the call failing."""
+    with mock.patch.object(utils,
+                           '_get_slurm_node_info_list',
+                           side_effect=RuntimeError('sinfo timed out')):
+        out = utils.explain_pending_job(_CLUSTER, _JOB)
+    assert out['category'] == pending.CATEGORY_RESOURCES
+    assert out['evidence']['partition_nodes'] is None
+    assert 'Waiting for free resources' in out['summary']
+
+
+def test_dependency_reads_only_the_blocking_jobs(client):
+    client.get_pending_job_details.return_value = _details(
+        reason='Dependency', dependency='afterok:5122(unfulfilled)')
+    client.get_job_states.return_value = {'5122': 'RUNNING'}
+    out = utils.explain_pending_job(_CLUSTER, _JOB)
+    assert out['category'] == pending.CATEGORY_DEPENDENCY
+    assert '5122 (RUNNING)' in out['summary']
+    client.get_job_states.assert_called_once_with(['5122'])
+    # A dependency needs no node counts, and none were read.
+    client.get_pending_queue.assert_not_called()
+
+
+def test_quota_says_the_cap_is_unknown_here(client):
+    """This gatherer cannot read the accounting database, and the taxonomy is
+    built for that: it names the limit without inventing a number."""
+    client.get_pending_job_details.return_value = _details(reason='QOSGrpGRES',
+                                                           qos='normal')
+    out = utils.explain_pending_job(_CLUSTER, _JOB)
+    assert out['category'] == pending.CATEGORY_QUOTA
+    assert out['action'] is None
+    assert 'could not be read' in out['summary'] or 'unknown' in out['summary']
+
+
+def test_held_carries_the_begin_time(client):
+    client.get_pending_job_details.return_value = _details(
+        reason='BeginTime', start_time='1757304475')
+    out = utils.explain_pending_job(_CLUSTER, _JOB)
+    assert out['category'] == pending.CATEGORY_HELD
+    assert out['evidence']['begin_time'] is not None
+
+
+def test_a_timed_out_details_read_is_none(client):
+    client.get_pending_job_details.side_effect = subprocess.TimeoutExpired(
+        'squeue', 10)
+    assert utils.explain_pending_job(_CLUSTER, _JOB) is None

--- a/tests/unit_tests/test_sky/provision/slurm/test_job_accounting.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_job_accounting.py
@@ -5,6 +5,7 @@ every surprise this parse has to handle came from there: a base array id
 answering with one row per element, `Unknown` where a timestamp is expected,
 and a submit line that contains the separator.
 """
+import inspect
 import re
 import time
 from unittest import mock
@@ -123,3 +124,28 @@ def test_a_job_name_is_quoted():
     client = _client('')
     client.get_job_accounting_by_name('weird name; rm -rf /', since=0)
     assert "'weird name; rm -rf /'" in _cmd(client)
+
+
+def test_every_per_job_read_is_bounded_by_default():
+    """Each read's default bound, pinned. These are the reads that run on the
+    `sky jobs events` request path, and an unbounded one there is what an
+    unresponsive login node turns into a hung request -- which has happened
+    once already, to `query_jobs`. Accounting keeps the longer budget because
+    slurmdbd answers it, not slurmctld's in-memory queue.
+    """
+    expected = {
+        'get_job_accounting': slurm.ACCOUNTING_READ_TIMEOUT_SECONDS,
+        'get_job_accounting_by_name': slurm.ACCOUNTING_READ_TIMEOUT_SECONDS,
+    }
+    for name, want in expected.items():
+        sig = inspect.signature(getattr(slurm.SlurmClient, name))
+        got = sig.parameters['timeout'].default
+        assert got == want, f'{name}: {got} != {want}'
+    # The queue reads take no timeout argument; they hard-code the shorter
+    # bound at the call, so assert that instead.
+    src = inspect.getsource(slurm.SlurmClient.get_pending_job_details)
+    assert 'JOB_READ_TIMEOUT_SECONDS' in src
+    src = inspect.getsource(slurm.SlurmClient.get_pending_queue)
+    assert 'JOB_READ_TIMEOUT_SECONDS' in src
+    src = inspect.getsource(slurm.SlurmClient.get_job_states)
+    assert 'JOB_READ_TIMEOUT_SECONDS' in src

--- a/tests/unit_tests/test_sky/provision/slurm/test_job_accounting.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_job_accounting.py
@@ -1,10 +1,12 @@
-"""Parsing sacct records (SlurmClient.get_job_accounting).
+"""Parsing sacct records (SlurmClient's two accounting reads).
 
 The fixtures are real output captured from a Slurm 24.11 cluster, because
 every surprise this parse has to handle came from there: a base array id
 answering with one row per element, `Unknown` where a timestamp is expected,
 and a submit line that contains the separator.
 """
+import re
+import time
 from unittest import mock
 
 from sky.adaptors import slurm
@@ -17,17 +19,23 @@ def _client(stdout: str, rc: int = 0):
     return client
 
 
+def _cmd(client) -> str:
+    return client._run_slurm_cmd.call_args.args[0]  # pylint: disable=protected-access
+
+
 def test_a_finished_job():
-    out = ('17213|COMPLETED|Dependency|2026-09-08T04:05:47|'
-           '2026-09-08T04:27:55|2026-09-08T04:27:55|2026-09-08T04:27:55|'
-           '0:0|0:0|0|sbatch -p dev -N 1 --job-name=e2e-f2-or --wrap hostname')
+    out = ('17213|COMPLETED|Dependency|1757304347|1757305675|1757305675|'
+           '1757305676|0:0|0:0|0|dev|gpu-1|'
+           'sbatch -p dev -N 1 --job-name=e2e-f2-or --wrap hostname')
     rows = _client(out).get_job_accounting('17213')
     assert len(rows) == 1
     row = rows[0]
     assert row['state'] == 'COMPLETED'
     assert row['reason'] == 'Dependency'
-    assert row['submit'] == '2026-09-08T04:05:47'
-    assert row['eligible'] == '2026-09-08T04:27:55'
+    assert row['submit'] == '1757304347'
+    assert row['eligible'] == '1757305675'
+    assert row['partition'] == 'dev'
+    assert row['nodes'] == 'gpu-1'
     assert row['exit_code'] == '0:0'
     assert row['restarts'] == '0'
 
@@ -35,9 +43,8 @@ def test_a_finished_job():
 def test_a_submit_line_containing_the_separator_survives():
     """SubmitLine is last precisely because it can contain anything -- a
     piped command in --wrap would otherwise eat the parse."""
-    out = ('17300|COMPLETED||2026-09-08T04:05:47|2026-09-08T04:05:47|'
-           '2026-09-08T04:05:48|2026-09-08T04:06:48|0:0|0:0|0|'
-           'sbatch --wrap "squeue | head -3 | wc -l"')
+    out = ('17300|COMPLETED||1757304347|1757304347|1757304348|1757304408|'
+           '0:0|0:0|0|dev|gpu-1|sbatch --wrap "squeue | head -3 | wc -l"')
     rows = _client(out).get_job_accounting('17300')
     assert len(rows) == 1
     assert rows[0]['submit_line'] == 'sbatch --wrap "squeue | head -3 | wc -l"'
@@ -46,10 +53,10 @@ def test_a_submit_line_containing_the_separator_survives():
 def test_a_base_array_id_answers_per_element():
     """Measured: the same instant has one element running and one pending, so
     a caller passing a base id groups by the returned JobID."""
-    out = ('17221_1|RUNNING||2026-09-08T09:00:30|2026-09-08T09:00:37|'
-           '2026-09-08T09:00:37|Unknown|0:0|0:0|0|sbatch --array=1-2\n'
-           '17221_2|PENDING||2026-09-08T09:00:30|Unknown|Unknown|Unknown|'
-           '0:0|0:0|0|sbatch --array=1-2')
+    out = ('17221_1|RUNNING||1757322030|1757322037|1757322037|Unknown|'
+           '0:0|0:0|0|dev|gpu-1|sbatch --array=1-2\n'
+           '17221_2|PENDING||1757322030|Unknown|Unknown|Unknown|'
+           '0:0|0:0|0|dev|None assigned|sbatch --array=1-2')
     rows = _client(out).get_job_accounting('17221')
     assert [r['job_id'] for r in rows] == ['17221_1', '17221_2']
     assert rows[1]['eligible'] == 'Unknown'
@@ -68,12 +75,51 @@ def test_a_row_with_the_wrong_field_count_is_skipped():
     assert rows == []
 
 
-def test_the_command_asks_for_every_attempt():
+def test_the_command_asks_for_every_attempt_in_epoch_seconds():
     """-D is what makes a requeued job report each attempt; without it only
-    the latest survives, and a requeue resets Submit."""
+    the latest survives, and a requeue resets Submit. The epoch request is
+    what keeps the login node's timezone out of the answer."""
     client = _client('')
     client.get_job_accounting('42')
-    cmd = client._run_slurm_cmd.call_args.args[0]  # pylint: disable=protected-access
+    cmd = _cmd(client)
     assert ' -D ' in cmd
     assert ' -X ' in cmd
     assert 'SubmitLine' in cmd
+    assert cmd.startswith('SLURM_TIME_FORMAT=%s ')
+
+
+def test_an_id_selector_needs_no_window():
+    """sacct's default start time is the epoch for -j, so the whole history
+    of the job is in scope without one."""
+    client = _client('')
+    client.get_job_accounting('42')
+    assert ' -S ' not in _cmd(client)
+
+
+def test_a_name_selector_always_carries_a_window():
+    """With --name instead of -j, sacct's default window starts at 00:00:00
+    today -- a job submitted yesterday would silently be missing."""
+    client = _client('')
+    client.get_job_accounting_by_name('sky-train-1-abcd',
+                                      since=int(time.time()) - 3 * 3600)
+    cmd = _cmd(client)
+    assert '--name=sky-train-1-abcd' in cmd
+    # ~3h back, expressed relatively so neither host's timezone matters.
+    # The margin makes the exact figure 181 or 182, depending on where in the
+    # second the call landed.
+    minutes = int(re.search(r' -S now-(\d+)minutes', cmd).group(1))
+    assert 181 <= minutes <= 182
+
+
+def test_a_window_is_never_shorter_than_a_minute():
+    client = _client('')
+    client.get_job_accounting_by_name('sky-train-1-abcd',
+                                      since=int(time.time()))
+    assert ' -S now-2minutes' in _cmd(client)
+
+
+def test_a_job_name_is_quoted():
+    """The name comes from a cluster record, not from a literal."""
+    client = _client('')
+    client.get_job_accounting_by_name('weird name; rm -rf /', since=0)
+    assert "'weird name; rm -rf /'" in _cmd(client)

--- a/tests/unit_tests/test_sky/provision/slurm/test_job_accounting.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_job_accounting.py
@@ -1,0 +1,79 @@
+"""Parsing sacct records (SlurmClient.get_job_accounting).
+
+The fixtures are real output captured from a Slurm 24.11 cluster, because
+every surprise this parse has to handle came from there: a base array id
+answering with one row per element, `Unknown` where a timestamp is expected,
+and a submit line that contains the separator.
+"""
+from unittest import mock
+
+from sky.adaptors import slurm
+
+
+def _client(stdout: str, rc: int = 0):
+    client = slurm.SlurmClient.__new__(slurm.SlurmClient)
+    client._run_slurm_cmd = mock.Mock(  # pylint: disable=protected-access
+        return_value=(rc, stdout, ''))
+    return client
+
+
+def test_a_finished_job():
+    out = ('17213|COMPLETED|Dependency|2026-09-08T04:05:47|'
+           '2026-09-08T04:27:55|2026-09-08T04:27:55|2026-09-08T04:27:55|'
+           '0:0|0:0|0|sbatch -p dev -N 1 --job-name=e2e-f2-or --wrap hostname')
+    rows = _client(out).get_job_accounting('17213')
+    assert len(rows) == 1
+    row = rows[0]
+    assert row['state'] == 'COMPLETED'
+    assert row['reason'] == 'Dependency'
+    assert row['submit'] == '2026-09-08T04:05:47'
+    assert row['eligible'] == '2026-09-08T04:27:55'
+    assert row['exit_code'] == '0:0'
+    assert row['restarts'] == '0'
+
+
+def test_a_submit_line_containing_the_separator_survives():
+    """SubmitLine is last precisely because it can contain anything -- a
+    piped command in --wrap would otherwise eat the parse."""
+    out = ('17300|COMPLETED||2026-09-08T04:05:47|2026-09-08T04:05:47|'
+           '2026-09-08T04:05:48|2026-09-08T04:06:48|0:0|0:0|0|'
+           'sbatch --wrap "squeue | head -3 | wc -l"')
+    rows = _client(out).get_job_accounting('17300')
+    assert len(rows) == 1
+    assert rows[0]['submit_line'] == 'sbatch --wrap "squeue | head -3 | wc -l"'
+
+
+def test_a_base_array_id_answers_per_element():
+    """Measured: the same instant has one element running and one pending, so
+    a caller passing a base id groups by the returned JobID."""
+    out = ('17221_1|RUNNING||2026-09-08T09:00:30|2026-09-08T09:00:37|'
+           '2026-09-08T09:00:37|Unknown|0:0|0:0|0|sbatch --array=1-2\n'
+           '17221_2|PENDING||2026-09-08T09:00:30|Unknown|Unknown|Unknown|'
+           '0:0|0:0|0|sbatch --array=1-2')
+    rows = _client(out).get_job_accounting('17221')
+    assert [r['job_id'] for r in rows] == ['17221_1', '17221_2']
+    assert rows[1]['eligible'] == 'Unknown'
+
+
+def test_no_accounting_configured_is_empty_not_an_error():
+    """A cluster without slurmdbd is a shape, not a failure: the caller says
+    the history is unavailable rather than that nothing happened."""
+    rows = _client('sacct: error: accounting_storage is disabled',
+                   rc=1).get_job_accounting('1')
+    assert rows == []
+
+
+def test_a_row_with_the_wrong_field_count_is_skipped():
+    rows = _client('17400|COMPLETED|too-few-fields').get_job_accounting('17400')
+    assert rows == []
+
+
+def test_the_command_asks_for_every_attempt():
+    """-D is what makes a requeued job report each attempt; without it only
+    the latest survives, and a requeue resets Submit."""
+    client = _client('')
+    client.get_job_accounting('42')
+    cmd = client._run_slurm_cmd.call_args.args[0]  # pylint: disable=protected-access
+    assert ' -D ' in cmd
+    assert ' -X ' in cmd
+    assert 'SubmitLine' in cmd

--- a/tests/unit_tests/test_sky/provision/slurm/test_job_timeline.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_job_timeline.py
@@ -1,0 +1,293 @@
+"""Turning sacct records into a job's Slurm timeline (utils.job_timeline).
+
+The two intervals are the reason this exists, so most of what is asserted
+here is which side of `Eligible` a wait landed on and how the three shapes
+Slurm actually produces are read: a finished job, a job cancelled before it
+ever became eligible, and a job that is still queued.
+"""
+import subprocess
+import time
+from unittest import mock
+
+import pytest
+
+from sky.provision.slurm import utils
+
+_CLUSTER = 'dev-slurm'
+_NAME = 'sky-train-1-a1b2'
+# Fixed instants, 22m 8s from submit to eligible and 19m 4s from there to the
+# start, so the rendered durations are checkable.
+_SUBMIT = 1000000000
+_ELIGIBLE = 1000001328
+_START = 1000002472
+_END = 1000010000
+
+
+def _record(**over):
+    record = {
+        'job_id': '17213',
+        'state': 'COMPLETED',
+        'reason': '',
+        'submit': str(_SUBMIT),
+        'eligible': str(_ELIGIBLE),
+        'start': str(_START),
+        'end': str(_END),
+        'exit_code': '0:0',
+        'derived_exit_code': '0:0',
+        'restarts': '0',
+        'partition': 'h200',
+        'nodes': 'gpu-1,gpu-2',
+        'submit_line': 'sbatch --job-name=sky-train-1-a1b2 ...',
+    }
+    record.update(over)
+    return record
+
+
+@pytest.fixture
+def client():
+    fake = mock.MagicMock()
+    fake.get_job_accounting_by_name.return_value = [_record()]
+    fake.query_jobs.return_value = []
+    with mock.patch.object(utils, '_client_for', return_value=fake):
+        yield fake
+
+
+def _timeline(**kwargs):
+    return utils.job_timeline(_CLUSTER, _NAME, _SUBMIT - 60, **kwargs)
+
+
+def _by_event(entries):
+    return {entry['event']: entry for entry in entries}
+
+
+def test_a_finished_job_reports_both_waits(client):
+    entries = _timeline()
+    assert [e['event'] for e in entries
+           ] == ['submitted', 'eligible', 'started', 'ended']
+    events = _by_event(entries)
+    assert events['submitted']['at'] == _SUBMIT
+    assert 'to partition h200' in events['submitted']['text']
+    # The wait before Eligible can only be one of these three.
+    assert '22m 8s' in events['eligible']['text']
+    assert 'dependency, a hold or a begin time' in events['eligible']['text']
+    # The wait after it can only be one of these.
+    assert '19m 4s' in events['started']['text']
+    assert 'resources, priority or a quota limit' in events['started']['text']
+    assert 'gpu-1,gpu-2' in events['started']['text']
+    assert 'COMPLETED' in events['ended']['text']
+    assert '2h 5m 28s' in events['ended']['text']
+    # Every row says which system it came from.
+    assert all(entry['text'].startswith('Slurm ') for entry in entries)
+
+
+def test_no_wait_is_said_plainly_rather_than_as_zero(client):
+    client.get_job_accounting_by_name.return_value = [
+        _record(eligible=str(_SUBMIT), start=str(_SUBMIT))
+    ]
+    events = _by_event(_timeline())
+    assert 'as soon as it was submitted' in events['eligible']['text']
+    assert 'as soon as it became eligible' in events['started']['text']
+
+
+def test_a_job_cancelled_before_becoming_eligible(client):
+    """Measured: Eligible and Start are the literal 'Unknown' for a job
+    cancelled while still blocked. That is a fact to state, not a gap."""
+    client.get_job_accounting_by_name.return_value = [
+        _record(state='CANCELLED by 1000',
+                reason='DependencyNeverSatisfied',
+                eligible='Unknown',
+                start='Unknown',
+                nodes='None assigned')
+    ]
+    entries = _timeline()
+    assert [e['event'] for e in entries
+           ] == ['submitted', 'never_eligible', 'ended']
+    events = _by_event(entries)
+    assert 'never became eligible' in events['never_eligible']['text']
+    assert 'DependencyNeverSatisfied' in events['never_eligible']['text']
+    # No node list to report, and no run duration to claim.
+    assert 'None assigned' not in events['ended']['text']
+    assert 'after running' not in events['ended']['text']
+
+
+def test_a_pending_job_is_not_yet_never_eligible(client):
+    """Same 'Unknown' fields as above, but the job has not ended -- calling
+    that 'never eligible' would be wrong."""
+    client.get_job_accounting_by_name.return_value = [
+        _record(state='PENDING', eligible='Unknown', start='Unknown', end='')
+    ]
+    with mock.patch.object(utils, 'explain_pending_job', return_value=None):
+        entries = _timeline()
+    assert [e['event'] for e in entries] == ['submitted']
+
+
+def test_a_running_job_gets_no_end_event(client):
+    """sacct answers with a *projected* End for a job that is still running;
+    reporting it would announce an end that has not happened."""
+    client.get_job_accounting_by_name.return_value = [
+        _record(state='RUNNING', end=str(_END))
+    ]
+    entries = _timeline()
+    assert [e['event'] for e in entries] == ['submitted', 'eligible', 'started']
+
+
+def test_a_nonzero_exit_code_is_reported_and_a_zero_one_is_not(client):
+    client.get_job_accounting_by_name.return_value = [
+        _record(state='FAILED', exit_code='1:0')
+    ]
+    assert 'exit 1:0' in _by_event(_timeline())['ended']['text']
+    client.get_job_accounting_by_name.return_value = [_record()]
+    assert 'exit' not in _by_event(_timeline())['ended']['text']
+
+
+def test_each_attempt_of_a_requeued_job_is_numbered(client):
+    """-D returns one record per attempt, so the two waits stay attributable
+    to the attempt that had them."""
+    client.get_job_accounting_by_name.return_value = [
+        _record(state='NODE_FAIL', restarts='1'),
+        _record(submit=str(_SUBMIT + 5000),
+                eligible=str(_SUBMIT + 5000),
+                start=str(_SUBMIT + 5010),
+                end=str(_SUBMIT + 9000),
+                restarts='1'),
+    ]
+    entries = _timeline()
+    texts = [e['text'] for e in entries]
+    assert any('attempt 1 of 2' in text for text in texts)
+    assert any('attempt 2 of 2' in text for text in texts)
+    assert any('requeued it once' in text for text in texts)
+
+
+def test_entries_are_ordered_oldest_first_across_attempts(client):
+    client.get_job_accounting_by_name.return_value = [
+        _record(),
+        _record(submit=str(_SUBMIT + 5000),
+                eligible=str(_SUBMIT + 5000),
+                start=str(_SUBMIT + 5010),
+                end=str(_SUBMIT + 9000)),
+    ]
+    stamps = [entry['at'] for entry in _timeline()]
+    assert stamps == sorted(stamps)
+
+
+def test_a_pending_record_carries_the_live_diagnosis(client):
+    client.get_job_accounting_by_name.return_value = [
+        _record(state='PENDING', eligible='Unknown', start='Unknown', end='')
+    ]
+    explain = mock.Mock(
+        return_value={
+            'category': 'resources',
+            'summary': 'Waiting for free resources in partition h200.',
+            'action': 'Check the queue.',
+        })
+    with mock.patch.object(utils, 'explain_pending_job', explain):
+        events = _by_event(_timeline())
+    explain.assert_called_once_with(_CLUSTER, '17213', deadline=None)
+    assert 'Waiting for free resources' in events['pending']['text']
+    assert 'Check the queue.' in events['pending']['text']
+    # The reason is live, so it is dated now rather than backdated.
+    assert events['pending']['at'] > _END
+
+
+def test_without_accounting_a_queued_job_still_gets_an_answer(client):
+    """A cluster with no slurmdbd has no history to read, but squeue still
+    knows what is queued -- and that is the job most in need of an answer."""
+    client.get_job_accounting_by_name.return_value = []
+    client.query_jobs.return_value = ['17999']
+    explain = mock.Mock(
+        return_value={
+            'category': 'quota',
+            'summary': 'A QoS limit is holding it.',
+            'action': None,
+        })
+    with mock.patch.object(utils, 'explain_pending_job', explain):
+        entries = _timeline()
+    client.query_jobs.assert_called_once_with(_NAME, ['pending'])
+    assert [e['event'] for e in entries] == ['pending']
+    assert 'A QoS limit is holding it.' in entries[0]['text']
+
+
+def test_a_squeue_fallback_that_fails_is_not_an_error(client):
+    client.get_job_accounting_by_name.return_value = []
+    client.query_jobs.side_effect = RuntimeError('ssh: connect timed out')
+    assert _timeline() == []
+
+
+def test_non_epoch_timestamps_are_dropped_rather_than_misplaced(client):
+    """A Slurm build that ignores SLURM_TIME_FORMAT answers in the cluster's
+    local time with no timezone on it; there is no way to order that against
+    SkyPilot's own events, so it is not pretended otherwise."""
+    client.get_job_accounting_by_name.return_value = [
+        _record(submit='2026-09-08T04:05:47',
+                eligible='2026-09-08T04:27:55',
+                start='2026-09-08T04:27:55',
+                end='2026-09-08T05:27:55')
+    ]
+    assert _timeline() == []
+
+
+def test_an_unconfigured_cluster_is_empty_not_an_exception():
+    with mock.patch.object(utils, '_client_for', return_value=None):
+        assert _timeline() == []
+
+
+def test_a_timed_out_accounting_read_is_empty(client):
+    client.get_job_accounting_by_name.side_effect = subprocess.TimeoutExpired(
+        'sacct', 20)
+    assert _timeline() == []
+
+
+def test_two_allocations_sharing_a_name_are_not_called_attempts(client):
+    """A relaunch reuses the cluster name but gets a new Slurm job id. Only a
+    requeue -- same id, one record per try -- is an attempt."""
+    client.get_job_accounting_by_name.return_value = [
+        _record(job_id='17213'),
+        _record(job_id='17240',
+                submit=str(_SUBMIT + 5000),
+                eligible=str(_SUBMIT + 5000),
+                start=str(_SUBMIT + 5010),
+                end=str(_SUBMIT + 9000)),
+    ]
+    texts = [entry['text'] for entry in _timeline()]
+    assert not any('attempt' in text for text in texts)
+    assert any('allocation 17213' in text for text in texts)
+    assert any('allocation 17240' in text for text in texts)
+
+
+def test_a_spent_budget_still_returns_the_history(client):
+    """The accounting read is what the timeline is made of, so it runs
+    regardless; the diagnosis is three further reads and is reachable on its
+    own, so that is what a spent budget gives up."""
+    client.get_job_accounting_by_name.return_value = [
+        _record(state='PENDING', eligible='Unknown', start='Unknown', end='')
+    ]
+    explain = mock.Mock()
+    with mock.patch.object(utils, 'explain_pending_job', explain):
+        entries = utils.job_timeline(_CLUSTER,
+                                     _NAME,
+                                     _SUBMIT - 60,
+                                     deadline=time.monotonic() - 1)
+    explain.assert_not_called()
+    assert [entry['event'] for entry in entries] == ['submitted']
+
+
+def test_a_spent_budget_skips_the_squeue_fallback_too(client):
+    client.get_job_accounting_by_name.return_value = []
+    utils.job_timeline(_CLUSTER,
+                       _NAME,
+                       _SUBMIT - 60,
+                       deadline=time.monotonic() - 1)
+    client.query_jobs.assert_not_called()
+
+
+def test_the_deadline_reaches_the_diagnosis(client):
+    """It has to be passed down, not just checked here: the evidence reads
+    are where the time actually goes."""
+    client.get_job_accounting_by_name.return_value = [
+        _record(state='PENDING', eligible='Unknown', start='Unknown', end='')
+    ]
+    deadline = time.monotonic() + 30
+    explain = mock.Mock(return_value=None)
+    with mock.patch.object(utils, 'explain_pending_job', explain):
+        utils.job_timeline(_CLUSTER, _NAME, _SUBMIT - 60, deadline=deadline)
+    assert explain.call_args.kwargs['deadline'] == deadline

--- a/tests/unit_tests/test_sky/provision/slurm/test_job_timeline.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_job_timeline.py
@@ -11,6 +11,7 @@ from unittest import mock
 
 import pytest
 
+from sky.adaptors import slurm
 from sky.provision.slurm import utils
 
 _CLUSTER = 'dev-slurm'
@@ -202,7 +203,8 @@ def test_without_accounting_a_queued_job_still_gets_an_answer(client):
         })
     with mock.patch.object(utils, 'explain_pending_job', explain):
         entries = _timeline()
-    client.query_jobs.assert_called_once_with(_NAME, ['pending'])
+    client.query_jobs.assert_called_once_with(
+        _NAME, ['pending'], timeout=slurm.JOB_READ_TIMEOUT_SECONDS)
     assert [e['event'] for e in entries] == ['pending']
     assert 'A QoS limit is holding it.' in entries[0]['text']
 
@@ -291,3 +293,52 @@ def test_the_deadline_reaches_the_diagnosis(client):
     with mock.patch.object(utils, 'explain_pending_job', explain):
         utils.job_timeline(_CLUSTER, _NAME, _SUBMIT - 60, deadline=deadline)
     assert explain.call_args.kwargs['deadline'] == deadline
+
+
+def test_the_squeue_fallback_is_bounded(client):
+    """It runs on a request path, and it is the *likely* branch: a job whose
+    accounting record has not landed yet is exactly when someone asks why it
+    has not started. Unbounded, one unresponsive login node hangs the
+    request no matter what the budget says."""
+    client.get_job_accounting_by_name.return_value = []
+    client.query_jobs.return_value = []
+    _timeline()
+    assert client.query_jobs.call_args.kwargs['timeout'] == (
+        slurm.JOB_READ_TIMEOUT_SECONDS)
+
+
+def test_the_budget_stops_the_loop_between_pending_jobs(client):
+    """explain_pending_job always pays for the reason itself before its own
+    deadline check can skip anything, so a second id costs another read's
+    budget however little is left. Without the check in the loop both ids
+    are explained."""
+    client.get_job_accounting_by_name.return_value = [
+        _record(job_id='17213',
+                state='PENDING',
+                eligible='Unknown',
+                start='Unknown',
+                end=''),
+        _record(job_id='17214',
+                state='PENDING',
+                eligible='Unknown',
+                start='Unknown',
+                end=''),
+    ]
+    seen = []
+
+    def _explain(cluster, job_id, deadline=None):
+        del cluster, deadline
+        seen.append(job_id)
+        # The first explanation spends what was left of the budget.
+        time.sleep(0.25)
+        return {'category': 'resources', 'summary': 'Waiting.', 'action': None}
+
+    with mock.patch.object(utils, 'explain_pending_job', _explain):
+        entries = utils.job_timeline(_CLUSTER,
+                                     _NAME,
+                                     _SUBMIT - 60,
+                                     deadline=time.monotonic() + 0.2)
+    assert seen == ['17213']
+    # What it did manage to explain is still reported.
+    assert [e['event'] for e in entries if e['event'] == 'pending'
+           ] == ['pending']

--- a/tests/unit_tests/test_sky/provision/slurm/test_pending.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_pending.py
@@ -466,6 +466,18 @@ def test_begin_time_slurm_has_not_computed_says_nothing_about_when():
     assert 'StartTime=now' in out['action']
 
 
+def test_a_begin_time_that_is_not_epoch_is_shown_as_it_came():
+    """The reads ask for epoch seconds; a Slurm build old enough to ignore
+    that answers in ISO form, in the cluster's local timezone with nothing
+    saying which. Showing it verbatim beats both dropping it and converting
+    it against this host's timezone."""
+    out = sp.classify_pending(
+        _job('BeginTime'), sp.PendingEvidence(begin_time='2026-09-08T04:05:47'))
+    assert '2026-09-08 04:05:47' in out['summary']
+    # No timezone is claimed for it, unlike the epoch form.
+    assert 'UTC' not in out['summary']
+
+
 def test_dependency_waiting_with_known_state():
     job = _job('Dependency', dependency='afterok:5122(unfulfilled)')
     ev = sp.PendingEvidence(dependency_states={'5122': 'RUNNING'})

--- a/tests/unit_tests/test_sky/provision/slurm/test_pending.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_pending.py
@@ -1,0 +1,602 @@
+"""Tests for the Slurm pending taxonomy (provision/slurm/pending.py)."""
+
+import pytest
+
+from sky.provision.slurm import pending as sp
+
+QOSES = {
+    'post_training_limit': {
+        'name': 'post_training_limit',
+        'nominal': {
+            'gres/gpu': 736
+        },
+        'max_tres_per_user': {
+            'gres/gpu': 64
+        },
+    },
+    'normal': {
+        'name': 'normal',
+        'nominal': {},
+        'max_tres_per_user': {}
+    },
+}
+PARTITIONS = {
+    'post-training': {
+        'name': 'post-training',
+        'qos': 'post_training_limit'
+    },
+    'general': {
+        'name': 'general',
+        'qos': 'normal'
+    },
+}
+
+
+def _job(reason, **kw):
+    row = {
+        'job_id': '5123',
+        'state': 'PENDING',
+        'reason': reason,
+        'partition': 'h200'
+    }
+    row.update(kw)
+    return row
+
+
+def _cat(reason):
+    return sp.pending_category(sp.pending_reason_code(_job(reason)))
+
+
+# --- category mapping ---------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    'reason, category',
+    [
+        ('QOSGrpGRES', 'quota'),
+        ('(QOSGrpGRES)', 'quota'),
+        ('QOSMaxGRESPerUser', 'quota'),
+        ('QOSMaxCpuPerJobLimit', 'quota'),
+        ('AssocGrpGRES', 'quota'),
+        ('AssocMaxJobsLimit', 'quota'),
+        ('QOSUsageThreshold', 'quota'),
+        ('Resources', 'resources'),
+        ('Priority', 'resources'),
+        ('ReqNodeNotAvail, UnavailableNodes:gpu-3', 'resources'),
+        (
+            'Nodes required for job are DOWN, DRAINED or reserved for jobs in '
+            'higher priority partitions',
+            'resources',
+        ),
+        ('PartitionDown', 'resources'),
+        ('Reservation', 'resources'),
+        ('JobHeldUser', 'held'),
+        ('JobHeldAdmin', 'held'),
+        ('launch failed requeued held', 'held'),
+        ('BeginTime', 'held'),
+        ('Dependency', 'dependency'),
+        ('DependencyNeverSatisfied', 'dependency'),
+        ('BadConstraints', 'other'),
+        ('SomethingNew', 'other'),
+    ],
+)
+def test_pending_category(reason, category):
+    assert _cat(reason) == category
+
+
+def test_not_pending_or_no_reason_yields_none():
+    assert sp.classify_pending({
+        'state': 'RUNNING',
+        'reason': 'gpu-[1-4]'
+    }) is None
+    assert sp.classify_pending(_job('(None)')) is None
+    assert sp.classify_pending(_job('')) is None
+
+
+def test_result_shape_and_whitespace_collapsed():
+    out = sp.classify_pending(_job('Resources  '))
+    assert set(out) == {'category', 'code', 'summary', 'action', 'evidence'}
+    assert out['code'] == 'Resources'
+    assert '  ' not in out['summary']
+
+
+# --- quota ----------------------------------------------------------------------
+
+
+def test_quota_with_cap_and_usage_names_the_full_quota():
+    job = _job('QOSGrpGRES',
+               partition='post-training',
+               qos='normal',
+               gpu_type='H200')
+    ev = sp.PendingEvidence(
+        qoses=QOSES,
+        partitions=PARTITIONS,
+        qos_usage={
+            'post_training_limit': {
+                'gres/gpu': 736,
+                'running': 9,
+                'pending': 3
+            }
+        },
+        effective_qos=['post_training_limit'],
+        blocking_resource='H200',
+    )
+    out = sp.classify_pending(job, ev)
+    assert out['category'] == 'quota'
+    assert out['summary'] == (
+        'H200 quota for QoS post_training_limit is full (736/736).')
+    assert 'post_training_limit' in out['action']
+    assert out['evidence'] == {
+        'qos': ['post_training_limit'],
+        'cap': 736,
+        'cap_tres': 'gres/gpu',
+        'used': 736,
+        'resource': 'H200',
+    }
+
+
+def test_quota_with_cap_but_no_usage_still_names_the_cap():
+    job = _job('QOSGrpGRES', partition='post-training', qos='normal')
+    out = sp.classify_pending(
+        job,
+        sp.PendingEvidence(
+            qoses=QOSES,
+            partitions=PARTITIONS,
+            effective_qos=['post_training_limit'],
+        ),
+    )
+    assert out[
+        'summary'] == 'GPUs quota for QoS post_training_limit is full (cap 736).'
+    assert out['action']
+
+
+def test_quota_typed_cap_does_not_borrow_untyped_gpu_usage():
+    """A typed cap and the QoS-wide untyped total are different numbers;
+    pairing them printed ratios like 32/16."""
+    qoses = {
+        'typed_limit': {
+            'name': 'typed_limit',
+            'nominal': {
+                'gres/gpu:a100': 16
+            }
+        },
+        'normal': {
+            'name': 'normal',
+            'nominal': {},
+            'max_tres_per_user': {}
+        },
+    }
+    partitions = {'a100': {'name': 'a100', 'qos': 'typed_limit'}}
+    job = _job('QOSGrpGRES', partition='a100', qos='normal')
+    ev = sp.PendingEvidence(
+        qoses=qoses,
+        partitions=partitions,
+        qos_usage={'typed_limit': {
+            'gres/gpu': 32,
+            'running': 4,
+            'pending': 1
+        }},
+        effective_qos=['typed_limit'],
+    )
+    out = sp.classify_pending(job, ev)
+    assert out['summary'].endswith('is full (cap 16).')
+    assert out['evidence']['used'] is None
+    assert out['evidence']['cap_tres'] == 'gres/gpu:a100'
+
+
+def test_quota_non_gpu_cap_does_not_borrow_gpu_usage():
+    qoses = {
+        'fpga_limit': {
+            'name': 'fpga_limit',
+            'nominal': {
+                'gres/fpga': 4
+            }
+        },
+        'normal': {
+            'name': 'normal',
+            'nominal': {},
+            'max_tres_per_user': {}
+        },
+    }
+    partitions = {'fpga': {'name': 'fpga', 'qos': 'fpga_limit'}}
+    job = _job('QOSGrpGRES', partition='fpga', qos='normal')
+    ev = sp.PendingEvidence(
+        qoses=qoses,
+        partitions=partitions,
+        qos_usage={'fpga_limit': {
+            'gres/gpu': 8
+        }},
+        effective_qos=['fpga_limit'],
+    )
+    out = sp.classify_pending(job, ev)
+    assert out['summary'].endswith('is full (cap 4).')
+    assert out['evidence']['used'] is None
+
+
+def test_quota_without_accounting_says_the_cap_cannot_be_read():
+    job = _job('QOSGrpGRES', qos='post_training_limit')
+    ev = sp.PendingEvidence(
+        qoses={},
+        accounting_error='sacctmgr: command not found',
+        effective_qos=['post_training_limit'],
+    )
+    out = sp.classify_pending(job, ev)
+    assert out['category'] == 'quota'
+    assert 'could not be read' in out['summary']
+    assert 'sacctmgr: command not found' in out['summary']
+    assert out['action'] is None
+    assert out['evidence']['qos'] == ['post_training_limit']
+
+
+def test_quota_with_no_evidence_at_all_has_no_action():
+    out = sp.classify_pending(_job('QOSGrpGRES'))
+    assert out['category'] == 'quota'
+    assert out['action'] is None
+    assert out['evidence']['qos'] is None
+
+
+def test_quota_multi_candidate_qos_does_not_pick_one():
+    job = _job('QOSGrpGRES', partition='post-training,general', qos='normal')
+    out = sp.classify_pending(
+        job,
+        sp.PendingEvidence(
+            qoses=QOSES,
+            partitions=PARTITIONS,
+            # A job submitted to a partition list counts against several QoS;
+            # the caller resolved both and neither is the one Slurm charged.
+            effective_qos=['post_training_limit', 'normal'],
+        ),
+    )
+    assert 'post_training_limit, normal' in out['summary']
+    assert out['action'] is None
+
+
+def test_quota_per_user_limit_reports_the_per_user_cap():
+    job = _job('QOSMaxGRESPerUser', qos='post_training_limit')
+    out = sp.classify_pending(
+        job,
+        sp.PendingEvidence(qoses=QOSES,
+                           partitions={},
+                           effective_qos=['post_training_limit']),
+    )
+    assert 'Per-user limit QOSMaxGRESPerUser' in out['summary']
+    assert 'gres/gpu=64' in out['summary']
+    assert 'your own jobs' in out['action']
+
+
+def test_quota_association_limit():
+    job = _job('AssocGrpCPURunMinutesLimit', qos='post_training_limit')
+    out = sp.classify_pending(
+        job,
+        sp.PendingEvidence(qoses=QOSES,
+                           partitions={},
+                           effective_qos=['post_training_limit']),
+    )
+    assert out['category'] == 'quota'
+    assert 'association' in out['summary']
+    assert 'sacctmgr show assoc' in out['action']
+
+
+# --- resources ------------------------------------------------------------------
+
+
+def test_resources_with_node_counts_and_queue_position():
+    ev = sp.PendingEvidence(
+        partition_nodes={
+            'total': 64,
+            'idle': 0,
+            'allocated': 60,
+            'drained': 4,
+            'down': 0,
+        },
+        pending_ahead=3,
+    )
+    out = sp.classify_pending(_job('Resources'), ev)
+    assert out['category'] == 'resources'
+    assert out['summary'] == (
+        'No idle node in partition h200 (64 nodes: 60 allocated, 4 drained). '
+        '3 jobs are pending ahead of this one.')
+    assert out['action']
+    assert out['evidence']['pending_ahead'] == 3
+
+
+def test_resources_idle_nodes_that_do_not_fit():
+    ev = sp.PendingEvidence(partition_nodes={
+        'total': 8,
+        'idle': 2,
+        'allocated': 6,
+        'drained': 0,
+        'down': 0
+    })
+    out = sp.classify_pending(_job('Resources'), ev)
+    assert out['summary'].startswith(
+        'The 2 idle nodes in partition h200 do not satisfy')
+
+
+def test_resources_does_not_claim_idle_nodes_when_they_are_unavailable():
+    """The wrong sentence this guards against: 'the 3 idle nodes do not
+    satisfy this job's request' about nodes under maintenance."""
+    ev = sp.PendingEvidence(
+        partition_nodes={
+            'total': 5,
+            'idle': 0,
+            'allocated': 2,
+            'drained': 0,
+            'down': 0,
+            'unavailable': 3,
+            'powered_down': 0,
+        })
+    out = sp.classify_pending(_job('Resources', partition='h200'), ev)
+    assert out['summary'] == (
+        'No idle node in partition h200 (5 nodes: 2 allocated, 3 unavailable).')
+    assert 'idle node' not in out['summary'].replace('No idle node', '')
+
+
+def test_resources_names_powered_down_nodes():
+    """A partition that is entirely powered down used to render as
+    '0 nodes: 0 allocated', which reads as broken rather than asleep."""
+    ev = sp.PendingEvidence(
+        partition_nodes={
+            'total': 0,
+            'idle': 0,
+            'allocated': 0,
+            'drained': 0,
+            'down': 0,
+            'unavailable': 0,
+            'powered_down': 4,
+        })
+    out = sp.classify_pending(_job('Resources', partition='h200'), ev)
+    assert '4 powered down' in out['summary']
+
+
+def test_priority_with_nothing_queued_ahead_does_not_contradict_itself():
+    """Seen on a real cluster: "Higher-priority jobs are ahead of this one ...
+    0 jobs are pending ahead of this one." Both halves were true -- what was
+    ahead was running, not queued -- and together they read as nonsense."""
+    ev = sp.PendingEvidence(
+        partition_nodes={
+            'total': 3,
+            'idle': 0,
+            'allocated': 3,
+            'drained': 0,
+            'down': 0,
+            'unavailable': 0,
+            'powered_down': 0,
+        },
+        pending_ahead=0,
+    )
+    out = sp.classify_pending(_job('Priority', partition='dev'), ev)
+    assert '0 jobs are pending' not in out['summary'], out['summary']
+    assert out['summary'].endswith('No other pending job is ahead of it.')
+
+
+def test_resources_without_evidence_has_no_action():
+    out = sp.classify_pending(_job('Resources'))
+    assert out[
+        'summary'] == 'Waiting for free resources in partition h200 (Resources).'
+    assert out['action'] is None
+
+
+def test_priority_with_counts():
+    ev = sp.PendingEvidence(
+        partition_nodes={
+            'total': 4,
+            'idle': 0,
+            'allocated': 4,
+            'drained': 0,
+            'down': 0,
+        },
+        pending_ahead=1,
+    )
+    out = sp.classify_pending(_job('Priority'), ev)
+    assert out['summary'].startswith('Higher-priority jobs are ahead')
+    assert '1 job is pending ahead' in out['summary']
+
+
+def test_req_node_not_avail_names_the_nodes():
+    out = sp.classify_pending(
+        _job('ReqNodeNotAvail, UnavailableNodes:gpu-[3-4]'))
+    assert out['category'] == 'resources'
+    assert 'gpu-[3-4]' in out['summary']
+    assert out['evidence']['unavailable_nodes'] == 'gpu-[3-4]'
+    assert '--nodelist' in out['action']
+
+
+def test_partition_down():
+    out = sp.classify_pending(_job('PartitionDown'))
+    assert out['summary'] == 'Partition h200 is down and not scheduling jobs.'
+    assert 'administrator' in out['action']
+
+
+# --- held ---------------------------------------------------------------------------
+
+
+def test_held_after_failed_launch_with_restarts():
+    out = sp.classify_pending(_job('launch failed requeued held'),
+                              sp.PendingEvidence(restarts=2))
+    assert out['category'] == 'held'
+    assert out['summary'] == 'Held after 2 requeues: the job launch failed.'
+    assert out['action'] == (
+        'Check the node and prolog logs for the failure, then release it with '
+        'scontrol release 5123.')
+    assert out['evidence'] == {'restarts': 2}
+
+
+def test_held_after_failed_launch_without_restarts():
+    out = sp.classify_pending(_job('launch failed requeued held'))
+    assert out[
+        'summary'] == 'Held: the job launch failed and the job was requeued.'
+    assert 'scontrol release 5123' in out['action']
+
+
+def test_held_by_user_and_admin():
+    user = sp.classify_pending(_job('JobHeldUser'),
+                               sp.PendingEvidence(restarts=1))
+    assert user['summary'].startswith('Held by the user')
+    assert 'requeued 1 time' in user['summary']
+    assert 'scontrol release 5123' in user['action']
+    admin = sp.classify_pending(_job('JobHeldAdmin'))
+    assert admin['summary'] == 'Held by an administrator.'
+    assert 'administrator' in admin['action']
+
+
+def test_begin_time_with_and_without_the_time():
+    out = sp.classify_pending(_job('BeginTime'),
+                              sp.PendingEvidence(begin_time='1700000000'))
+    assert '2023-11-14 22:13:20 UTC' in out['summary']
+    assert 'StartTime=now' in out['action']
+    bare = sp.classify_pending(_job('BeginTime'))
+    assert (bare['summary'] ==
+            'Not eligible yet: the requested begin time is in the future.')
+
+
+# --- dependency -----------------------------------------------------------------
+
+
+def test_begin_time_slurm_has_not_computed_says_nothing_about_when():
+    """Slurm answers `Unknown` for a time it has not worked out yet, and that
+    used to be pasted straight into the sentence: "It becomes eligible at
+    Unknown." Saying nothing about when is the honest version."""
+    job = _job('BeginTime')
+    out = sp.classify_pending(job, sp.PendingEvidence(begin_time='Unknown'))
+    assert out['summary'] == (
+        'Not eligible yet: the requested begin time is in the future.')
+    assert out['evidence']['begin_time'] is None
+    # The action still tells the caller how to start it now.
+    assert 'StartTime=now' in out['action']
+
+
+def test_dependency_waiting_with_known_state():
+    job = _job('Dependency', dependency='afterok:5122(unfulfilled)')
+    ev = sp.PendingEvidence(dependency_states={'5122': 'RUNNING'})
+    out = sp.classify_pending(job, ev)
+    assert out['category'] == 'dependency'
+    assert out['summary'] == 'Waiting for job 5122 (RUNNING) to finish.'
+    assert out['action'] == (
+        'Wait for job 5122 to finish; describe it if it is itself stuck.')
+    assert out['evidence']['blocking_jobs'] == [{
+        'job_id': '5122',
+        'state': 'RUNNING'
+    }]
+    assert out['evidence']['unsatisfiable'] is False
+
+
+def test_dependency_on_a_job_that_left_the_queue():
+    job = _job('Dependency', dependency='afterany:5122(unfulfilled)')
+    out = sp.classify_pending(job, sp.PendingEvidence(dependency_states={}))
+    assert out[
+        'summary'] == 'Waiting for job 5122 (no longer in the queue) to finish.'
+
+
+def test_dependency_without_sweep_names_the_job_only():
+    job = _job('Dependency', dependency='afterok:5122')
+    out = sp.classify_pending(job)
+    assert out['summary'] == 'Waiting for job 5122 to finish.'
+
+
+def test_dependency_never_satisfied():
+    job = _job('DependencyNeverSatisfied', dependency='afterok:5120(failed)')
+    out = sp.classify_pending(job)
+    assert out['summary'].startswith('Depends on job 5120 which failed')
+    assert 'JobId=5123 Dependency=' in out['action']
+    assert out['evidence']['unsatisfiable'] is True
+
+
+def test_dependency_any_of_survives_one_failed_alternative():
+    """'?' is OR: the job runs as soon as 5121 succeeds, so the failed
+    alternative must not read as a dead end."""
+    job = _job('Dependency',
+               dependency='afterok:5120(failed)?afterok:5121(unfulfilled)')
+    out = sp.classify_pending(job)
+    assert out['evidence']['unsatisfiable'] is False
+    assert out['summary'].startswith('Waiting for job')
+    assert 'never run' not in out['summary']
+    assert out['evidence']['failed_dependencies'] == ['5120']
+
+
+def test_dependency_any_of_with_every_alternative_failed_is_fatal():
+    job = _job('Dependency',
+               dependency='afterok:5120(failed)?afterok:5121(failed)')
+    out = sp.classify_pending(job)
+    assert out['evidence']['unsatisfiable'] is True
+    assert out['summary'].startswith('Depends on job 5120, 5121 which failed')
+
+
+def test_dependency_all_of_names_only_the_failed_entry():
+    job = _job('Dependency',
+               dependency='afterok:5120(failed),afterok:5121(unfulfilled)')
+    out = sp.classify_pending(job)
+    assert out['evidence']['unsatisfiable'] is True
+    assert out['summary'].startswith('Depends on job 5120 which failed')
+
+
+def test_dependency_never_satisfied_reason_wins_over_the_expression():
+    """Slurm's own verdict stands even when no entry is annotated failed."""
+    job = _job('DependencyNeverSatisfied',
+               dependency='afterok:5120?afterok:5121')
+    out = sp.classify_pending(job)
+    assert out['evidence']['unsatisfiable'] is True
+    assert out['summary'].startswith('Depends on job 5120, 5121 which failed')
+
+
+def test_a_failed_dependency_is_named_as_failed_not_as_missing():
+    """It has left the queue precisely because it failed, so the sweep has no
+    state for it -- and "no longer in the queue" is the less useful of the two
+    things known about it."""
+    job = _job('Dependency',
+               dependency='afterok:5120(failed)?afterok:5121(unfulfilled)')
+    out = sp.classify_pending(
+        job, sp.PendingEvidence(dependency_states={'5121': 'PENDING'}))
+    assert '5120 (failed)' in out['summary'], out['summary']
+    assert 'no longer in the queue' not in out['summary']
+
+
+def test_dependency_singleton():
+    job = _job('Dependency', dependency='singleton(unfulfilled)')
+    out = sp.classify_pending(job)
+    assert 'singleton' in out['summary']
+    assert out['evidence']['singleton'] is True
+
+
+def test_dependency_without_expression_has_no_action():
+    out = sp.classify_pending(_job('Dependency'))
+    assert 'Slurm did not report which' in out['summary']
+    assert out['action'] is None
+
+
+# --- other ------------------------------------------------------------------------
+
+
+def test_other_returns_the_raw_code_only():
+    out = sp.classify_pending(_job('BadConstraints'))
+    assert out == {
+        'category': 'other',
+        'code': 'BadConstraints',
+        'summary': 'BadConstraints',
+        'action': None,
+        'evidence': {},
+    }
+
+
+# --- moved helpers still behave ------------------------------------------------
+
+
+def test_the_pure_parses_survived_the_move():
+    parsed = sp.parse_dependency(
+        'afterok:5122(unfulfilled),afterany:99_4+30(failed)')
+    assert parsed == {
+        'job_ids': ['5122', '99_4'],
+        'failed_job_ids': ['99_4'],
+        'singleton': False,
+        'unsatisfiable': True,
+    }
+    assert sp.pending_reason_code({
+        'state': 'PENDING',
+        'reason': '(QOSGrpGRES)'
+    }) == ('QOSGrpGRES')
+    # resolve_effective_qos and the GRES label helpers are NOT here: which
+    # QoS a partition attaches, and which resource a cap names, are rules
+    # about the accounting database, so the caller that reads it owns them and
+    # passes the answers in as evidence.
+    for gone in ('resolve_effective_qos', 'blocking_gres', 'gres_cap_labels'):
+        assert not hasattr(sp, gone), gone

--- a/tests/unit_tests/test_sky/provision/slurm/test_pending.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_pending.py
@@ -665,3 +665,15 @@ def test_a_running_job_is_not_counted_as_ahead():
 def test_an_unparseable_id_at_the_same_priority_is_not_guessed():
     mine = {'job_id': '17269', 'partition': 'dev', 'priority': '1'}
     assert sp.pending_ahead([_queued('weird', 1, partition='dev')], mine) == 0
+
+
+def test_two_elements_of_one_array_do_not_count_each_other():
+    """A known limit, locked in deliberately. Both elements collapse to the
+    same base id, so neither counts the other as ahead -- an element with a
+    late index can therefore under-report. Ordering array elements against
+    each other needs the index, which squeue does not give here; before the
+    tie-break existed no tie counted at all, so this is unchanged behaviour
+    rather than a regression."""
+    mine = {'job_id': '17221_9', 'partition': 'dev', 'priority': '1'}
+    sweep = [_queued('17221_2', 1, partition='dev')]
+    assert sp.pending_ahead(sweep, mine) == 0

--- a/tests/unit_tests/test_sky/provision/slurm/test_pending.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_pending.py
@@ -612,3 +612,56 @@ def test_the_pure_parses_survived_the_move():
     # passes the answers in as evidence.
     for gone in ('resolve_effective_qos', 'blocking_gres', 'gres_cap_labels'):
         assert not hasattr(sp, gone), gone
+
+
+# --- pending_ahead ordering -----------------------------------------------
+
+
+def _queued(job_id, priority, partition='h200', state='PENDING'):
+    return {
+        'job_id': job_id,
+        'partition': partition,
+        'priority': str(priority),
+        'state': state,
+    }
+
+
+def test_a_higher_priority_job_is_ahead():
+    mine = {'job_id': '100', 'partition': 'h200', 'priority': '500'}
+    sweep = [_queued('99', 900), _queued('101', 10)]
+    assert sp.pending_ahead(sweep, mine) == 1
+
+
+def test_an_older_job_at_the_same_priority_is_ahead():
+    """Measured on a cluster with no multifactor priority: every job reports
+    priority 1, so counting only strictly-higher priorities answered "nothing
+    is ahead of you" while an older job was plainly next. Slurm breaks the tie
+    by submission, which the id orders."""
+    mine = {'job_id': '17269', 'partition': 'dev', 'priority': '1'}
+    sweep = [
+        _queued('17260', 1, partition='dev'),  # older, so ahead
+        _queued('17999', 1, partition='dev'),  # newer, so behind
+    ]
+    assert sp.pending_ahead(sweep, mine) == 1
+
+
+def test_an_array_element_orders_by_its_base_id():
+    mine = {'job_id': '17300_4', 'partition': 'dev', 'priority': '1'}
+    sweep = [_queued('17221_9', 1, partition='dev')]
+    assert sp.pending_ahead(sweep, mine) == 1
+
+
+def test_a_job_in_another_partition_is_not_ahead():
+    mine = {'job_id': '17269', 'partition': 'dev', 'priority': '1'}
+    assert sp.pending_ahead([_queued('17260', 1, partition='cpu')], mine) == 0
+
+
+def test_a_running_job_is_not_counted_as_ahead():
+    mine = {'job_id': '17269', 'partition': 'dev', 'priority': '1'}
+    sweep = [_queued('17260', 1, partition='dev', state='RUNNING')]
+    assert sp.pending_ahead(sweep, mine) == 0
+
+
+def test_an_unparseable_id_at_the_same_priority_is_not_guessed():
+    mine = {'job_id': '17269', 'partition': 'dev', 'priority': '1'}
+    assert sp.pending_ahead([_queued('weird', 1, partition='dev')], mine) == 0


### PR DESCRIPTION
Stacked on #10666 — please review that one first; this PR's base is its branch.

## Summary

Today a managed job on Slurm can say *that* it is waiting and repeat what `squeue` calls the reason. It cannot say how long a wait was, and once the job finishes `squeue` has forgotten it (`MinJobAge`, 5 minutes by default). This PR answers both, for the user's own job with the user's own access.

**A pending reason becomes an explanation.** `squeue`'s reason is a token (`QOSGrpGRES`, `ReqNodeNotAvail`, `DependencyNeverSatisfied`). `sky/provision/slurm/pending.py` classifies it into one of five categories with a summary and, where one exists, an action — and gathers only the evidence that category needs: the states of the jobs a dependency is waiting on, or the node tally of the partition plus how many pending jobs outrank this one. Every read is optional; a read that fails leaves the field unset and the summary says what it could not read rather than inventing a number.

**`sky jobs events` grows a Slurm timeline.** `sacct` keeps the timestamps a finished job's history needs, and the two intervals they bracket separate the causes on their own:

| interval | what was blocking |
|---|---|
| `Submit → Eligible` | a dependency, a hold or a begin time |
| `Eligible → Start` | resources, priority or a quota |

So the timeline reports which of the two a job spent its time in, with the duration, plus the allocation's final state, exit code and requeue count. An allocation still in the queue has no interval yet, so it gets the live explanation instead.

The shape it produces (the `STARTING` rows and the `Launching (pending: ...)` row are what #10666 already records; the null-status rows are what this PR adds):

```
TIME                 TASK  STATUS    REASON
2026-09-08 17:46:15  0     STARTING  Instances launched on slurm
2026-09-08 17:46:14  0     -         Slurm allocation 17228 started after waiting 1m 42s for resources, priority or a quota limit; nodes: ip-10-3-93-178,ip-10-3-175-90,ip-10-3-241-24
2026-09-08 17:44:33  0     STARTING  Launching (pending: Resources; partition: dev)
2026-09-08 17:44:32  0     -         Slurm allocation 17228 was eligible to run as soon as it was submitted
2026-09-08 17:44:32  0     -         Slurm allocation 17228 submitted to partition dev
2026-09-08 17:42:31  0     STARTING  Job is starting
2026-09-08 17:42:23  0     PENDING   Job submitted to queue
```

Notes on the shape:

- **No new endpoint, no new flag, no API version bump.** The entries ride the existing `--cluster-events` switch and keep the event-row shape, so the table and `-o json` are unchanged.
- **The Slurm rows carry a null status.** A cluster event happens while the job is STARTING and is reported as such; these are the scheduler's statements about an allocation, not transitions of the job, so claiming a status change at that instant would be wrong.
- **`sacct`'s own `Reason` column is reported when present but never relied on.** SchedMD documents it as holding at most the last reason that was not Priority or Resources, and rows measured on a 24.11 cluster are worse than that: a job blocked 19 minutes on `Resources` recorded nothing, and so did one whose `squeue` reason was `DependencyNeverSatisfied`. What the timeline promises is derived from the timestamps.
- **Every read asks for epoch seconds** (`SLURM_TIME_FORMAT=%s`). Slurm otherwise renders timestamps in the *cluster's* local timezone with nothing in the output saying which, so a reader on another host cannot convert them. A build old enough to ignore the request answers in ISO form, which is shown as text but cannot be ordered against SkyPilot's own events, so those entries are dropped rather than misplaced.
- **`Eligible` is often the literal `Unknown`**, and not only for held jobs: every job cancelled while still blocked reports it. That is said outright ("never became eligible") rather than papered over as a missing value.
- **`-D` is not optional.** A requeue *resets* `Submit`, so without `--duplicates` a requeued job would report its last attempt's submission as its own and lose the earlier attempts. Records sharing a job id are a requeue's attempts and are numbered; records with different ids are separate allocations that happen to share a name.

### Cost, and how it is bounded

`sky jobs events` is a `SHORT` request, so the reads are bounded twice: each one by its own timeout (10s), and the merge as a whole by one budget shared across a pipeline's allocations. Past the budget the accounting read still runs — it is what the timeline is made of — and the diagnosis, which is three further reads and reachable on its own, is skipped. A job on any other cloud pays one indexed database read and nothing else.

The resource tally comes from a single bounded `sinfo` rather than from `slurm_node_info`, which also runs `scontrol show node` cluster-wide and derives GPU counts the tally never uses, and whose budget is sized for the inventory sweep rather than for a request.

### Two limits worth knowing

- **A finished job whose cluster is gone has no Slurm timeline.** The Slurm cluster (`resources.region`) and the `sbatch` job name (`cluster_name_on_cloud`) live on the cluster record, which teardown removes. Measured: as soon as a managed job succeeds and its cluster is reclaimed, the Slurm rows drop to zero and the request returns normally. What remains is SkyPilot's own transitions and the total durations they carry; what is lost is the *split* of the wait, the exit code and the requeue count. So "why did this take six hours to start" is answerable while the job is still around, not afterwards. Closing that means persisting those two fields — one extra cluster event at allocation time would do it — and is deliberately a separate change.
- **A cluster without `slurmdbd` has no accounting to read.** Rather than returning an empty history that reads like "nothing happened", it falls back to `squeue` for a queued allocation — the job most in need of an answer.

### Also fixed here

Merging exposed a gap in how `limit` is shared between a job's own events and the infrastructure rows. Half the budget was meant to be kept for the latter, but the code only widened the candidate pool while the final cut is by recency — so a job with a full budget of newer transitions hid them entirely. A Slurm timeline is older than a recent transition by nature (submitted / eligible / started all happen early), which makes that the common case rather than a corner. The share is now reserved, capped so the job's own newest row never loses its slot.

The reservation is for the infrastructure rows **as a class**. Within that class recency still decides, and cluster events keep arriving right up to RUNNING while the Slurm rows are all early — so at a small `limit` on a running job the reserved slot can still go to a cluster event (measured: `--limit 3` on an 18-row timeline kept two job events and one cluster event). That is left as it is: at `limit=3` the floor is one row either way, so splitting the class only changes which row survives, and the default of 50 shows everything. The row that matters while a job is stuck — the live diagnosis — is dated *now*, so it is the newest row of all and survives even `--limit 2`.

## Test plan

Unit tests, all new unless stated:

```
pytest tests/unit_tests/test_sky/provision/slurm/test_pending.py            # 60
pytest tests/unit_tests/test_sky/provision/slurm/test_explain_pending.py    # 12
pytest tests/unit_tests/test_sky/provision/slurm/test_job_accounting.py     # 10
pytest tests/unit_tests/test_sky/provision/slurm/test_job_timeline.py       # 18
pytest tests/unit_tests/test_jobs_events_merge.py                           # 25 (11 pre-existing)
```

The `sacct` and `squeue` fixtures are output captured from a Slurm 24.11 cluster, not invented, because every surprise the parsing handles came from there: a base array id answering with one row per element, `Unknown` where a timestamp belongs, and a submit line containing the field separator.

Manual verification, against a Slurm cluster with three nodes in one partition:

```bash
# Occupy the partition so the next allocation has to queue. A time limit so
# it clears itself; scancel to release early.
ssh <login-node> 'sbatch -N 3 --exclusive --time=00:04:00 --wrap "sleep 230"'

sky jobs launch -y -d --infra slurm/<cluster> --num-nodes 3 -n pendres 'echo hi'
sky jobs events <id>          # a pending row with the category, summary and action
ssh <login-node> 'scancel <filler job id>'
sky jobs events <id>          # submitted / eligible / started, with both wait durations
sky jobs events <id> -o json  # same rows, new_status null, unchanged schema
```

Reason-specific cases, each producing a different category without occupying anything:

```bash
ssh <login-node> 'scontrol update JobId=<allocation> StartTime=now+1hour'  # held / BeginTime
ssh <login-node> 'scontrol hold <allocation>'                              # held / JobHeldUser
ssh <login-node> 'sbatch --dependency=afterok:<never-runs> ...'            # dependency
```

Degradation to check explicitly, since these are the paths that must not raise: a cluster missing from `~/.slurm/config`, a login node that accepts the connection and never answers (the reads time out and the request still returns the job's own events), and a cluster with accounting disabled.

### Measured

Run on a Slurm 24.11 cluster (3 nodes, one partition, slurmdbd present), two api servers, each asserted from inside the pod to be serving the intended build before the run — the baseline arm has neither `job_timeline` nor `explain_pending_job`.

| case | result |
|---|---|
| timeline of a started allocation | `started after waiting 45s for resources, priority or a quota limit; nodes: ...` and `became eligible to run after 5m 20s blocked on a dependency, a hold or a begin time; Slurm recorded the reason as BeginTime` — both intervals match the scheduler's own timestamps to the second |
| `-o json` | 18 rows, one key set, Slurm rows `new_status: null` |
| pending on resources | `No idle node in partition dev (3 nodes: 3 allocated)`, and with the filler still completing, `(3 nodes: 1 allocated, 2 unavailable)` — completing nodes are not counted as idle |
| begin time in the future | `It becomes eligible at 2026-09-08 15:10:51 UTC`, matching `squeue`'s `StartTime` to the second — which is also what proves the epoch request took effect |
| held | action names `scontrol release <id>` with the real id |
| baseline arm, same cluster | only `Launching (pending: Resources)` / `(pending: Priority)`, no Slurm row anywhere |
| unconfigured cluster | `[]` / `None`, immediately, no exception |
| unresponsive login node | accounting 20.0s, `query_jobs` 10.0s, queue read 10.0s, all `TimeoutExpired` |
| added latency, healthy cluster | 4.37s vs 4.46s on the baseline arm — none measurable |
| finished job, cluster reclaimed | Slurm rows drop to zero, request returns normally |

The run found one thing the unit tests did not: the accounting read's longer bound had been declared but never wired, so it timed out at 10s rather than 20s. Fixed, with every per-job read's default bound now pinned by a test.

The pending reason and partition reaching `cluster_events` and the `details` column were verified live for #10666 on the same cluster.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
