### PR TITLE
[Dashboard] Sum all task durations in job group duration display

### DIFF
--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -1400,12 +1400,22 @@ export function ManagedJobsTable({
           0
         );
 
+        // Compute total duration across all tasks, matching the CLI's
+        // aggregated row in format_job_table. A task that has not started
+        // yet contributes 0; one that has started keeps accruing, so a
+        // group with work still in flight ticks up.
+        const totalDuration = tasks.reduce(
+          (sum, t) => sum + (t.job_duration || 0),
+          0
+        );
+
         aggregates.set(jobId, {
           aggregatedStatus,
           statusTooltip,
           resourcesDisplay,
           resourcesTooltip,
           totalRecoveries,
+          totalDuration,
         });
       }
     });
@@ -1804,9 +1814,17 @@ export function ManagedJobsTable({
             Duration{getSortDirection('job_duration')}
           </TableHead>
         ),
-        renderCell: (item) => (
-          <TableCell>{formatDuration(item.job_duration)}</TableCell>
-        ),
+        renderCell: (item, ctx) => {
+          const { renderMode, aggregates } = ctx || {};
+
+          if (renderMode === 'groupParent') {
+            return (
+              <TableCell>{formatDuration(aggregates?.totalDuration)}</TableCell>
+            );
+          }
+
+          return <TableCell>{formatDuration(item.job_duration)}</TableCell>;
+        },
       },
       {
         id: 'status',

--- a/sky/dashboard/src/pages/jobs/[job].js
+++ b/sky/dashboard/src/pages/jobs/[job].js
@@ -1465,7 +1465,20 @@ function JobDetailsContent({
       <div>
         <div className="text-gray-600 font-medium text-base">Duration</div>
         <div className="text-base mt-1">
-          {formatDuration(jobData.job_duration)}
+          {(() => {
+            if (allTasks.length <= 1) {
+              return formatDuration(jobData.job_duration);
+            }
+            // For a job group, sum the durations of all tasks instead of
+            // showing only the first task's duration, matching the CLI's
+            // aggregated row. A task that has not started yet contributes
+            // 0; one that has started keeps accruing.
+            const totalDuration = allTasks.reduce(
+              (sum, t) => sum + (t.job_duration || 0),
+              0
+            );
+            return formatDuration(totalDuration);
+          })()}
         </div>
       </div>
       <div>


### PR DESCRIPTION
## Summary

- The job group duration shown in the dashboard was only the **first task's** `job_duration`, not the sum across the group's tasks. A 5-task group whose tasks ran 22s / 3m 24s / 1m 32s / 7h 13m / 8h 7m displayed `22s`.
- Jobs list (`sky/dashboard/src/components/jobs.jsx`): added a `totalDuration` aggregate to the pre-computed `jobGroupAggregates` map and used it for the `groupParent` render mode, mirroring how the adjacent Recoveries column already aggregates.
- Job detail page (`sky/dashboard/src/pages/jobs/[job].js`): the summary "Duration" field now sums all task durations when the job has more than one task; single-task jobs are unchanged.

This makes the dashboard agree with the CLI, whose aggregated row in `format_job_table` already sums `job_duration` across tasks (`sky/jobs/utils.py:3692`) — so no CLI change is needed. Both surfaces sum the same field the per-task rows display, so the group total always equals the sum of the visible task durations.

A task that has not started yet contributes 0; a task that has started keeps accruing, so a group with work still in flight ticks up.

## Test plan

Validated end-to-end against a **local API server** (jobs consolidation mode, so the local jobs DB is the source of truth) by seeding three job groups that reproduce the reported case plus controls:

| Job | Shape | Per-task durations | Group duration shown | Expected |
|---|---|---|---|---|
| 9001 | 5-task group (1 PENDING) | 22s, 3m 24s, 1m 32s, 7h 13m, 8h 7m | **15h 24m** | sum ✅ (was `22s`) |
| 9010 | 2-task group, both terminal | 10s, 20s | **30s** | 30s ✅ |
| 9020 | single task | 45s | **45s** | unchanged ✅ |

Verified for each:

1. **Jobs list** — the collapsed group-parent row shows the summed duration; expanding the group shows each child row with its own individual duration, unchanged.
2. **Job detail page** — the summary Duration matches the sum, and the per-task durations in the Tasks table are unchanged.
3. **Single-task job** — Duration unchanged on both the list and the detail page.
4. **CLI parity** — `sky jobs queue` reports `JOB DURATION` of `15h 25m 26s` for job 9001, `30s` for 9010 and `45s` for 9020, matching the dashboard (9001 differs only by the seconds that elapse between renders, since its PENDING task is still accruing).
5. **Live count-up** — the group total on the detail page advanced (15h 23m → 15h 24m) across renders while a task was still accruing.

Automated checks:

```bash
cd sky/dashboard
npx prettier --check src/components/jobs.jsx 'src/pages/jobs/[job].js'          # clean
npx next lint --file src/components/jobs.jsx --file 'src/pages/jobs/[job].js'   # no warnings or errors
npm run build                                                                    # succeeds
```
