### PR TITLE
[API] Honor SQLite lock timeout for asynchronous writes

### DIFF
--- a/sky/utils/db/db_utils.py
+++ b/sky/utils/db/db_utils.py
@@ -349,7 +349,8 @@ class SQLiteConn(threading.local):
                     # Init logic like requests.init_db_within_lock will handle
                     # initialization like setting the WAL mode, so we do not
                     # duplicate that logic here.
-                    self._async_conn = await aiosqlite.connect(self.db_path)
+                    self._async_conn = await aiosqlite.connect(
+                        self.db_path, timeout=_DB_TIMEOUT_S)
         return self._async_conn
 
     async def execute_and_commit_async(self,

--- a/tests/unit_tests/test_sky/utils/test_db_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_db_utils.py
@@ -1,4 +1,5 @@
 """Unit tests for database utilities with SKY_RUNTIME_DIR environment variable."""
+import asyncio
 import os
 import sqlite3
 from unittest import mock
@@ -61,6 +62,54 @@ async def isolated_database(tmp_path):
         yield conn, str(db_path)
     finally:
         await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_async_write_waits_for_competing_writer(isolated_database):
+    """Async writes use the same lock budget as synchronous writes."""
+    conn, db_path = isolated_database
+    blocker = sqlite3.connect(db_path)
+    blocker.execute('BEGIN IMMEDIATE')
+
+    async def release_writer():
+        # Exceed sqlite3's default five-second timeout.
+        await asyncio.sleep(6)
+        blocker.commit()
+
+    release = asyncio.create_task(release_writer())
+    try:
+        result = await asyncio.wait_for(conn.execute_get_returning_value_async(
+            'INSERT INTO items (value) VALUES (?) RETURNING value',
+            ('after_lock',)),
+                                        timeout=15)
+        assert result == ('after_lock',)
+        assert blocker.execute('SELECT value FROM items').fetchall() == [
+            ('after_lock',)
+        ]
+    finally:
+        await release
+        blocker.close()
+
+
+@pytest.mark.asyncio
+async def test_async_write_fails_when_lock_budget_expires(
+        isolated_database, monkeypatch):
+    """A persistent lock still fails without inserting or retrying the write."""
+    conn, db_path = isolated_database
+    monkeypatch.setattr(db_utils, '_DB_TIMEOUT_S', 0.05)
+    blocker = sqlite3.connect(db_path)
+    blocker.execute('BEGIN IMMEDIATE')
+    try:
+        with pytest.raises(sqlite3.OperationalError,
+                           match='database is locked'):
+            await asyncio.wait_for(conn.execute_get_returning_value_async(
+                'INSERT INTO items (value) VALUES (?) RETURNING value',
+                ('locked',)),
+                                   timeout=2)
+        assert blocker.execute('SELECT value FROM items').fetchall() == []
+    finally:
+        blocker.rollback()
+        blocker.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Asynchronous SQLite writes currently use `sqlite3`'s default five-second lock timeout, while synchronous `SQLiteConn` writes use the existing 60-second `_DB_TIMEOUT_S` budget. Under concurrent writes this can fail API request admission with `sqlite3.OperationalError: database is locked` even when the competing transaction finishes within SkyPilot's intended budget.

Pass the same timeout to `aiosqlite.connect`. This changes the native SQLite busy timeout; it does not retry SQL transactions or API requests. Persistent contention still raises after the configured budget expires.

Tested:

- Added real SQLite contention tests: a competing writer holds its transaction for six seconds, after which one insert succeeds; a lock exceeding a reduced budget raises and inserts no row.
- Both regression tests fail with the original connection setup and pass with this change.
- `python -m pytest --confcutdir=tests/unit_tests/test_sky/utils tests/unit_tests/test_sky/utils/test_db_utils.py -o addopts= -q -p no:cacheprovider`: 43 passed on Python 3.11.
- Exact pinned YAPF/isort checks pass for both changed files. Pylint and mypy pass for `sky/utils/db/db_utils.py`.
- Ran `bash format.sh --files sky/utils/db/db_utils.py tests/unit_tests/test_sky/utils/test_db_utils.py`; its repository-wide mypy stage cannot finish in the sparse checkout because `examples/admin_policy/example_policy` is absent. Targeted checks above pass.

Manual test plan:

1. Run `pytest --confcutdir=tests/unit_tests/test_sky/utils tests/unit_tests/test_sky/utils/test_db_utils.py -o addopts= -q -k async_write`. Expect two passing tests: the first waits for the six-second competing transaction and reads exactly one inserted row; the second raises at its configured 0.05-second budget and reads zero rows.
2. Remove `timeout=_DB_TIMEOUT_S` from the async connection and repeat. Expect both tests to fail: the first reaches SQLite's five-second default before the writer releases, and the second exceeds its two-second test deadline.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10679" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->