### PR TITLE
[Slurm] Add quota.queue / quota.account config for sbatch --qos / --account

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -159,6 +159,9 @@ Below is the configuration syntax and some example values. See detailed explanat
     :ref:`cpu_partition <config-yaml-slurm-cpu-partition>`: cpu-batch
     :ref:`container_mounts <config-yaml-slurm-container-mounts>`:
       /datasets: /shared/datasets
+    :ref:`quota <config-yaml-slurm-quota>`:
+      queue: normal          # sbatch --qos
+      account: pre-training  # sbatch --account
     :ref:`cluster_configs <config-yaml-slurm-cluster-configs>`:
       mycluster1:
         submit_as_user: true
@@ -2613,6 +2616,53 @@ Example:
 :ref:`cluster_configs <config-yaml-slurm-cluster-configs>`. Entries are merged
 per container path, with per-cluster values overriding global values.
 
+.. _config-yaml-slurm-quota:
+
+``slurm.quota``
+~~~~~~~~~~~~~~~
+
+The queue and account a Slurm job is submitted with (optional).
+
+- ``queue``: The QOS the job requests, submitted as ``sbatch --qos``.
+- ``account``: The account the job is charged to, submitted as
+  ``sbatch --account``. Set it when the QOS is only allowed on some
+  accounts' associations, or when the submitting user belongs to several
+  accounts and the job must be charged to a specific one.
+
+Both can be set at the cloud level, per cluster and per partition under
+:ref:`cluster_configs <config-yaml-slurm-cluster-configs>`, per workspace,
+and per task in the task YAML's ``config`` block. The most specific scope
+wins: a workspace value outranks any global value, and within a workspace or
+the global config, partition outranks cluster, which outranks cloud. A task
+``config`` value applies at the scope it is written at; to override a
+per-partition server value, write it under the same
+``cluster_configs.<cluster>.partition_configs.<partition>`` path.
+
+When set at any scope, ``quota.queue`` and ``quota.account`` take precedence
+over ``sbatch_options.qos`` and ``sbatch_options.account``.
+
+Example:
+
+.. code-block:: yaml
+
+  slurm:
+    quota:
+      queue: normal
+    cluster_configs:
+      mycluster:
+        partition_configs:
+          h100:
+            quota:
+              queue: high
+              account: pre-training
+
+  workspaces:
+    pre-training:
+      slurm:
+        quota:
+          queue: high
+          account: pre-training
+
 .. _config-yaml-slurm-cluster-configs:
 
 ``slurm.cluster_configs``
@@ -2654,6 +2704,9 @@ Supported fields:
   :ref:`Container mounts <config-yaml-slurm-container-mounts>` overrides at
   the cluster level. Entries are merged per container path, with per-cluster
   values overriding global values.
+
+- ``quota``: :ref:`Queue and account <config-yaml-slurm-quota>` overrides at
+  both the cluster and partition level. The most specific level wins.
 
 - ``prometheus``: Opts the cluster into GPU metrics federation, surfacing its
   DCGM and node-exporter metrics in the SkyPilot dashboard. Sub-fields:

--- a/sky/clouds/slurm.py
+++ b/sky/clouds/slurm.py
@@ -609,6 +609,27 @@ class Slurm(clouds.Cloud):
             keys=('sbatch_options',))
         if task_sbatch is not None:
             sbatch_options.update(task_sbatch)
+        # `quota.queue` / `quota.account` name the QOS and account with
+        # workspace > global and partition > cluster > cloud precedence
+        # (task `config:` overrides apply at every scope). Set at any scope,
+        # they take precedence over the `sbatch_options` spelling.
+        queue_name = skypilot_config.get_effective_queue_name(
+            cloud='slurm',
+            region=cluster,
+            partition=partition,
+            override_configs=resources.cluster_config_overrides)
+        if queue_name is not None:
+            # sbatch accepts the short form too; drop it so the job does not
+            # carry two directives for the same option.
+            sbatch_options.pop('q', None)
+            sbatch_options['qos'] = queue_name
+        account = skypilot_config.get_effective_slurm_account(
+            cluster=cluster,
+            partition=partition,
+            override_configs=resources.cluster_config_overrides)
+        if account is not None:
+            sbatch_options.pop('A', None)
+            sbatch_options['account'] = account
 
         # Read admin-declared container mounts with two-level merge:
         # global < cluster. Each entry maps a container path to either a

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -619,6 +619,7 @@ OVERRIDEABLE_CONFIG_KEYS_IN_TASK: List[Tuple[str, ...]] = [
     ('vast', 'datacenter_only'),
     ('vast', 'create_instance_kwargs'),
     ('slurm', 'sbatch_options'),
+    ('slurm', 'quota'),
     ('slurm', 'cpu_partition'),
     ('active_workspace',),
 ]

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -1058,6 +1058,13 @@ _QUEUE_NAME_KEYS: List[Tuple[str, ...]] = [
     ('kueue', 'local_queue_name'),
 ]
 
+# Slurm names its queue (the sbatch `--qos`) and account under `quota`; the
+# `sbatch_options.qos` / `sbatch_options.account` spellings are merged
+# separately by `sky/clouds/slurm.py` and only apply when no `quota.*` value
+# is set at any scope.
+_SLURM_QUEUE_NAME_KEYS: List[Tuple[str, ...]] = [('quota', 'queue')]
+_SLURM_ACCOUNT_KEYS: List[Tuple[str, ...]] = [('quota', 'account')]
+
 _NAMESPACE_KEYS: List[Tuple[str, ...]] = [('namespace',)]
 
 # Hooks invoked at the end of `update_api_server_config_no_lock`, after the
@@ -1165,19 +1172,46 @@ def register_config_post_save_hook(fn: ConfigPostSaveHook) -> None:
         _CONFIG_POST_SAVE_HOOKS.append(fn)
 
 
-def _get_effective_k8s_config_value(
+def _region_scope_prefixes(
+        cloud: str,
+        region: Optional[str],
+        partition: Optional[str] = None) -> List[Tuple[str, ...]]:
+    """Key prefixes for one cloud's config subtree, most specific first.
+
+    Kubernetes and SSH scope per-context values under ``context_configs``;
+    Slurm scopes per-cluster values under ``cluster_configs`` with a further
+    ``partition_configs`` level below it.
+    """
+    prefixes: List[Tuple[str, ...]] = []
+    if region is not None:
+        if cloud == 'slurm':
+            if partition is not None:
+                prefixes.append((cloud, 'cluster_configs', region,
+                                 'partition_configs', partition))
+            prefixes.append((cloud, 'cluster_configs', region))
+        else:
+            prefixes.append((cloud, 'context_configs', region))
+    prefixes.append((cloud,))
+    return prefixes
+
+
+def _get_effective_scoped_config_value(
         cloud: str,
         property_keys: List[Tuple[str, ...]],
         region: Optional[str] = None,
         workspace: Optional[str] = None,
-        override_configs: Optional[Dict[str, Any]] = None) -> Optional[str]:
-    """Generic Kubernetes config-value resolver.
+        override_configs: Optional[Dict[str, Any]] = None,
+        partition: Optional[str] = None) -> Optional[str]:
+    """Generic scoped config-value resolver.
 
-    Resolution precedence (most specific first):
+    Resolution precedence (most specific first), where ``<scope>`` walks the
+    prefixes from ``_region_scope_prefixes`` (``context_configs.<region>``
+    for Kubernetes / SSH; ``cluster_configs.<region>.partition_configs
+    .<partition>`` then ``cluster_configs.<region>`` for Slurm):
 
-    1. ``workspaces.<workspace>.<cloud>.context_configs.<region>.<property>``
+    1. ``workspaces.<workspace>.<cloud>.<scope>.<property>``
     2. ``workspaces.<workspace>.<cloud>.<property>``
-    3. ``<cloud>.context_configs.<region>.<property>``
+    3. ``<cloud>.<scope>.<property>``
     4. ``<cloud>.<property>``
     5. ``None`` — caller is responsible for any default.
 
@@ -1189,6 +1223,7 @@ def _get_effective_k8s_config_value(
     """
     if workspace is None:
         workspace = get_active_workspace()
+    prefixes = _region_scope_prefixes(cloud, region, partition)
 
     # `override_configs` are cloud-level; looking up relative to a scope
     # (rather than prefixing the scope into `keys`) ensures they apply at
@@ -1209,38 +1244,61 @@ def _get_effective_k8s_config_value(
                 scope_config.get_nested(keys=(),
                                         default_value={},
                                         override_configs=override_configs))
-        if region is not None:
+        for prefix in prefixes:
             for property_key in property_keys:
-                value = scope_config.get_nested(
-                    keys=(cloud, 'context_configs', region) + property_key,
-                    default_value=None)
+                value = scope_config.get_nested(keys=prefix + property_key,
+                                                default_value=None)
                 if value is not None:
                     return value
-        for property_key in property_keys:
-            value = scope_config.get_nested(keys=(cloud,) + property_key,
-                                            default_value=None)
-            if value is not None:
-                return value
     return None
 
 
-def get_effective_queue_name(
-        cloud: str,
-        region: Optional[str] = None,
+def get_effective_queue_name(cloud: str,
+                             region: Optional[str] = None,
+                             workspace: Optional[str] = None,
+                             override_configs: Optional[Dict[str, Any]] = None,
+                             partition: Optional[str] = None) -> Optional[str]:
+    """Returns the effective queue name from config.
+
+    For Kubernetes this is the Kueue local queue, spelled either
+    ``kueue.local_queue_name`` or ``quota.queue``. Scope precedence
+    (workspace > global; context > cloud) takes priority over spelling;
+    within the same scope, ``quota.queue`` wins over
+    ``kueue.local_queue_name`` when both are set.
+
+    For Slurm this is the QOS the job is submitted with (``sbatch --qos``),
+    spelled ``quota.queue``, scoped workspace > global and partition >
+    cluster > cloud. ``partition`` selects the ``partition_configs`` level.
+    """
+    if cloud == 'slurm':
+        property_keys = _SLURM_QUEUE_NAME_KEYS
+    else:
+        property_keys = _QUEUE_NAME_KEYS
+    return _get_effective_scoped_config_value(cloud=cloud,
+                                              property_keys=property_keys,
+                                              region=region,
+                                              workspace=workspace,
+                                              override_configs=override_configs,
+                                              partition=partition)
+
+
+def get_effective_slurm_account(
+        cluster: Optional[str] = None,
+        partition: Optional[str] = None,
         workspace: Optional[str] = None,
         override_configs: Optional[Dict[str, Any]] = None) -> Optional[str]:
-    """Returns the effective Kueue local queue name from config.
+    """Returns the effective Slurm account (``sbatch --account``) from config.
 
-    Supports two equivalent spellings, ``kueue.local_queue_name`` and
-    ``quota.queue``. Scope precedence (workspace > global; context > cloud)
-    takes priority over spelling; within the same scope, ``quota.queue``
-    wins over ``kueue.local_queue_name`` when both are set.
+    Spelled ``slurm.quota.account``, scoped workspace > global and
+    partition > cluster > cloud, the same walk as
+    :func:`get_effective_queue_name` for Slurm.
     """
-    return _get_effective_k8s_config_value(cloud=cloud,
-                                           property_keys=_QUEUE_NAME_KEYS,
-                                           region=region,
-                                           workspace=workspace,
-                                           override_configs=override_configs)
+    return _get_effective_scoped_config_value(cloud='slurm',
+                                              property_keys=_SLURM_ACCOUNT_KEYS,
+                                              region=cluster,
+                                              workspace=workspace,
+                                              override_configs=override_configs,
+                                              partition=partition)
 
 
 def get_effective_namespace(
@@ -1258,11 +1316,11 @@ def get_effective_namespace(
     4. ``<cloud>.namespace``
     5. ``None`` — caller is responsible for the kubeconfig-default fallback.
     """
-    return _get_effective_k8s_config_value(cloud=cloud,
-                                           property_keys=_NAMESPACE_KEYS,
-                                           region=region,
-                                           workspace=workspace,
-                                           override_configs=override_configs)
+    return _get_effective_scoped_config_value(cloud=cloud,
+                                              property_keys=_NAMESPACE_KEYS,
+                                              region=region,
+                                              workspace=workspace,
+                                              override_configs=override_configs)
 
 
 def register_queue_name_key(key: Tuple[str, ...]) -> None:

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1509,6 +1509,24 @@ _SBATCH_OPTIONS_SCHEMA = {
     },
 }
 
+# `quota.queue` names the QOS a job is submitted with (`sbatch --qos`) and
+# `quota.account` the account it is charged to (`sbatch --account`), mirroring
+# `kubernetes.quota.queue`. Permissive so external schedulers (registered via
+# plugins) can layer their own sub-fields under `quota`.
+_SLURM_QUOTA_SCHEMA = {
+    'type': 'object',
+    'required': [],
+    'additionalProperties': True,
+    'properties': {
+        'queue': {
+            'type': 'string',
+        },
+        'account': {
+            'type': 'string',
+        },
+    },
+}
+
 _GPU_PARTITION_MAP_SCHEMA = {
     'type': 'object',
     'required': [],
@@ -2206,6 +2224,7 @@ def get_config_schema():
                 },
                 'pricing': _PRICING_SCHEMA,
                 'sbatch_options': _SBATCH_OPTIONS_SCHEMA,
+                'quota': _SLURM_QUOTA_SCHEMA,
                 'gpu_partition_map': _GPU_PARTITION_MAP_SCHEMA,
                 'cpu_partition': {
                     'type': 'string',
@@ -2292,6 +2311,7 @@ def get_config_schema():
                             },
                             'pricing': _PRICING_SCHEMA,
                             'sbatch_options': _SBATCH_OPTIONS_SCHEMA,
+                            'quota': _SLURM_QUOTA_SCHEMA,
                             'gpu_partition_map': _GPU_PARTITION_MAP_SCHEMA,
                             'cpu_partition': {
                                 'type': 'string',
@@ -2308,6 +2328,7 @@ def get_config_schema():
                                     'properties': {
                                         'pricing': _PRICING_SCHEMA,
                                         'sbatch_options': _SBATCH_OPTIONS_SCHEMA,  # pylint: disable=line-too-long
+                                        'quota': _SLURM_QUOTA_SCHEMA,
                                     },
                                 },
                             },
@@ -2815,6 +2836,7 @@ def get_config_schema():
                         },
                         'allowed_clusters': slurm_allowed_clusters_schema,
                         'sbatch_options': _SBATCH_OPTIONS_SCHEMA,
+                        'quota': _SLURM_QUOTA_SCHEMA,
                         'cluster_configs': {
                             'type': 'object',
                             'required': [],
@@ -2825,6 +2847,7 @@ def get_config_schema():
                                 'additionalProperties': False,
                                 'properties': {
                                     'sbatch_options': _SBATCH_OPTIONS_SCHEMA,
+                                    'quota': _SLURM_QUOTA_SCHEMA,
                                     'partition_configs': {
                                         'type': 'object',
                                         'required': [],
@@ -2835,6 +2858,7 @@ def get_config_schema():
                                             'additionalProperties': False,
                                             'properties': {
                                                 'sbatch_options': _SBATCH_OPTIONS_SCHEMA,  # pylint: disable=line-too-long
+                                                'quota': _SLURM_QUOTA_SCHEMA,
                                             },
                                         },
                                     },

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1518,11 +1518,15 @@ _SLURM_QUOTA_SCHEMA = {
     'required': [],
     'additionalProperties': True,
     'properties': {
+        # Non-empty: an empty value would still be emitted as a bare
+        # `--qos=` / `--account=` directive and be rejected by sbatch.
         'queue': {
             'type': 'string',
+            'minLength': 1,
         },
         'account': {
             'type': 'string',
+            'minLength': 1,
         },
     },
 }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1862,7 +1862,7 @@ def test_get_effective_namespace_override_configs(monkeypatch,
         override_configs=cloud_level_override) == 'override-namespace'
 
 
-def test_get_effective_k8s_config_value_returns_none_when_unset(
+def test_get_effective_scoped_config_value_returns_none_when_unset(
         monkeypatch, tmp_path) -> None:
     """No matching key at any scope -> None."""
     with open(tmp_path / 'empty.yaml', 'w', encoding='utf-8') as f:
@@ -1871,14 +1871,14 @@ def test_get_effective_k8s_config_value_returns_none_when_unset(
                         tmp_path / 'empty.yaml')
     skypilot_config.reload_config()
 
-    assert skypilot_config._get_effective_k8s_config_value(  # pylint: disable=protected-access
+    assert skypilot_config._get_effective_scoped_config_value(  # pylint: disable=protected-access
         cloud='kubernetes',
         property_keys=[('namespace',)],
         region='contextA',
         workspace='default') is None
 
 
-def test_get_effective_k8s_config_value_property_key_priority(
+def test_get_effective_scoped_config_value_property_key_priority(
         monkeypatch, tmp_path) -> None:
     """Within a scope, ``property_keys`` order is priority (first hit wins).
 
@@ -1906,31 +1906,31 @@ def test_get_effective_k8s_config_value_property_key_priority(
     keys = [('primary',), ('secondary',)]
 
     # Cloud-level: both set, `primary` wins.
-    assert skypilot_config._get_effective_k8s_config_value(  # pylint: disable=protected-access
+    assert skypilot_config._get_effective_scoped_config_value(  # pylint: disable=protected-access
         cloud='kubernetes',
         property_keys=keys,
         workspace='default') == 'from-primary'
     # Per-context where only `secondary` is set: falls through to it.
-    assert skypilot_config._get_effective_k8s_config_value(  # pylint: disable=protected-access
+    assert skypilot_config._get_effective_scoped_config_value(  # pylint: disable=protected-access
         cloud='kubernetes',
         property_keys=keys,
         region='contextA',
         workspace='default') == 'contextA-from-secondary'
     # Per-context where both are set: `primary` wins.
-    assert skypilot_config._get_effective_k8s_config_value(  # pylint: disable=protected-access
+    assert skypilot_config._get_effective_scoped_config_value(  # pylint: disable=protected-access
         cloud='kubernetes',
         property_keys=keys,
         region='contextB',
         workspace='default') == 'contextB-from-primary'
     # Reversed order changes the winner.
-    assert skypilot_config._get_effective_k8s_config_value(  # pylint: disable=protected-access
+    assert skypilot_config._get_effective_scoped_config_value(  # pylint: disable=protected-access
         cloud='kubernetes',
         property_keys=[('secondary',), ('primary',)],
         region='contextB',
         workspace='default') == 'contextB-from-secondary'
 
 
-def test_get_effective_k8s_config_value_full_precedence_matrix(
+def test_get_effective_scoped_config_value_full_precedence_matrix(
         monkeypatch, tmp_path) -> None:
     """Full precedence: ws per-context > ws cloud > global per-context > global cloud.
 
@@ -1964,36 +1964,36 @@ def test_get_effective_k8s_config_value_full_precedence_matrix(
     keys = [('myfield',)]
 
     # Layer 1: ws per-context wins everything.
-    assert skypilot_config._get_effective_k8s_config_value(  # pylint: disable=protected-access
+    assert skypilot_config._get_effective_scoped_config_value(  # pylint: disable=protected-access
         cloud='kubernetes',
         property_keys=keys,
         region='contextA',
         workspace='workspaceA') == 'ws-context'
     # Layer 2: ws cloud wins when ws has no per-context override.
-    assert skypilot_config._get_effective_k8s_config_value(  # pylint: disable=protected-access
+    assert skypilot_config._get_effective_scoped_config_value(  # pylint: disable=protected-access
         cloud='kubernetes',
         property_keys=keys,
         region='contextB',
         workspace='workspaceA') == 'ws-cloud'
-    assert skypilot_config._get_effective_k8s_config_value(  # pylint: disable=protected-access
+    assert skypilot_config._get_effective_scoped_config_value(  # pylint: disable=protected-access
         cloud='kubernetes',
         property_keys=keys,
         workspace='workspaceB') == 'wsB-cloud'
     # Layer 3: global per-context when ws has no override at any layer.
-    assert skypilot_config._get_effective_k8s_config_value(  # pylint: disable=protected-access
+    assert skypilot_config._get_effective_scoped_config_value(  # pylint: disable=protected-access
         cloud='kubernetes',
         property_keys=keys,
         region='contextA',
         workspace='workspaceC') == 'global-context'
     # Layer 4: global cloud as final fallback.
-    assert skypilot_config._get_effective_k8s_config_value(  # pylint: disable=protected-access
+    assert skypilot_config._get_effective_scoped_config_value(  # pylint: disable=protected-access
         cloud='kubernetes',
         property_keys=keys,
         region='contextB',
         workspace='workspaceC') == 'global-cloud'
 
 
-def test_get_effective_k8s_config_value_override_configs_at_workspace_scope(
+def test_get_effective_scoped_config_value_override_configs_at_workspace_scope(
         monkeypatch, tmp_path) -> None:
     """Cloud-level ``override_configs`` apply inside the workspace scope.
 
@@ -2022,13 +2022,13 @@ def test_get_effective_k8s_config_value_override_configs_at_workspace_scope(
     cloud_override = {'kubernetes': {'myfield': 'override-value'}}
 
     # Cloud-level override replaces the workspace's cloud-level value.
-    assert skypilot_config._get_effective_k8s_config_value(  # pylint: disable=protected-access
+    assert skypilot_config._get_effective_scoped_config_value(  # pylint: disable=protected-access
         cloud='kubernetes',
         property_keys=keys,
         workspace='workspaceA',
         override_configs=cloud_override) == 'override-value'
     # Per-context value at the workspace scope still wins (more specific).
-    assert skypilot_config._get_effective_k8s_config_value(  # pylint: disable=protected-access
+    assert skypilot_config._get_effective_scoped_config_value(  # pylint: disable=protected-access
         cloud='kubernetes',
         property_keys=keys,
         region='contextA',
@@ -2293,3 +2293,153 @@ def test_replace_skypilot_config_restores_env_var_on_exception(
 
     skypilot_config.reload_config()
     assert skypilot_config.get_nested(('aws', 'vpc_name'), None) == VPC_NAME
+
+
+def test_get_effective_queue_name_slurm(monkeypatch, tmp_path) -> None:
+    """Slurm `quota.queue`: workspace > global; partition > cluster > cloud."""
+    with open(tmp_path / 'slurm_quota.yaml', 'w', encoding='utf-8') as f:
+        f.write("""\
+        slurm:
+            quota:
+                queue: global-cloud-qos
+            cluster_configs:
+                clusterA:
+                    quota:
+                        queue: global-clusterA-qos
+                    partition_configs:
+                        gpu:
+                            quota:
+                                queue: global-clusterA-gpu-qos
+                clusterB: {}
+        workspaces:
+            workspaceA:
+                slurm:
+                    quota:
+                        queue: ws-cloud-qos
+                    cluster_configs:
+                        clusterA:
+                            quota:
+                                queue: ws-clusterA-qos
+            workspaceB: {}
+        """)
+    monkeypatch.setattr(skypilot_config, '_GLOBAL_CONFIG_PATH',
+                        tmp_path / 'slurm_quota.yaml')
+    skypilot_config.reload_config()
+
+    # Workspace scope beats every global scope, including a more specific
+    # global partition-level value.
+    assert skypilot_config.get_effective_queue_name(
+        cloud='slurm',
+        region='clusterA',
+        partition='gpu',
+        workspace='workspaceA') == 'ws-clusterA-qos'
+    assert skypilot_config.get_effective_queue_name(
+        cloud='slurm',
+        region='clusterB',
+        partition='gpu',
+        workspace='workspaceA') == 'ws-cloud-qos'
+    # Global: partition > cluster > cloud.
+    assert skypilot_config.get_effective_queue_name(
+        cloud='slurm',
+        region='clusterA',
+        partition='gpu',
+        workspace='workspaceB') == 'global-clusterA-gpu-qos'
+    assert skypilot_config.get_effective_queue_name(
+        cloud='slurm',
+        region='clusterA',
+        partition='cpu',
+        workspace='workspaceB') == 'global-clusterA-qos'
+    assert skypilot_config.get_effective_queue_name(
+        cloud='slurm', region='clusterB',
+        workspace='workspaceB') == 'global-cloud-qos'
+    # Task overrides merge into every scope, so a task pinned at the
+    # partition scope wins over the server's partition value.
+    assert skypilot_config.get_effective_queue_name(
+        cloud='slurm',
+        region='clusterA',
+        partition='gpu',
+        workspace='workspaceB',
+        override_configs={
+            'slurm': {
+                'cluster_configs': {
+                    'clusterA': {
+                        'partition_configs': {
+                            'gpu': {
+                                'quota': {
+                                    'queue': 'task-partition-qos'
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }) == 'task-partition-qos'
+
+
+def test_get_effective_queue_name_slurm_ignores_sbatch_options(
+        monkeypatch, tmp_path) -> None:
+    """`sbatch_options.qos` is not a `quota.queue` spelling for Slurm.
+
+    The legacy spelling is merged by the Slurm cloud itself and only applies
+    when no `quota.queue` is set at any scope, so the resolver must not
+    surface it.
+    """
+    with open(tmp_path / 'slurm_sbatch.yaml', 'w', encoding='utf-8') as f:
+        f.write("""\
+        slurm:
+            sbatch_options:
+                qos: sbatch-only-qos
+                account: sbatch-only-account
+        """)
+    monkeypatch.setattr(skypilot_config, '_GLOBAL_CONFIG_PATH',
+                        tmp_path / 'slurm_sbatch.yaml')
+    skypilot_config.reload_config()
+
+    assert skypilot_config.get_effective_queue_name(
+        cloud='slurm', region='clusterA', workspace='default') is None
+    assert skypilot_config.get_effective_slurm_account(
+        cluster='clusterA', workspace='default') is None
+
+
+def test_get_effective_slurm_account(monkeypatch, tmp_path) -> None:
+    """`quota.account` walks the same scopes as the Slurm `quota.queue`."""
+    with open(tmp_path / 'slurm_account.yaml', 'w', encoding='utf-8') as f:
+        f.write("""\
+        slurm:
+            quota:
+                account: global-cloud-account
+            cluster_configs:
+                clusterA:
+                    partition_configs:
+                        gpu:
+                            quota:
+                                account: global-clusterA-gpu-account
+        workspaces:
+            workspaceA:
+                slurm:
+                    quota:
+                        account: ws-cloud-account
+            workspaceB: {}
+        """)
+    monkeypatch.setattr(skypilot_config, '_GLOBAL_CONFIG_PATH',
+                        tmp_path / 'slurm_account.yaml')
+    skypilot_config.reload_config()
+
+    assert skypilot_config.get_effective_slurm_account(
+        cluster='clusterA', partition='gpu',
+        workspace='workspaceA') == 'ws-cloud-account'
+    assert skypilot_config.get_effective_slurm_account(
+        cluster='clusterA', partition='gpu',
+        workspace='workspaceB') == 'global-clusterA-gpu-account'
+    assert skypilot_config.get_effective_slurm_account(
+        cluster='clusterA', partition='cpu',
+        workspace='workspaceB') == 'global-cloud-account'
+    assert skypilot_config.get_effective_slurm_account(
+        cluster='clusterA',
+        partition='cpu',
+        workspace='workspaceB',
+        override_configs={'slurm': {
+            'quota': {
+                'account': 'task-account'
+            }
+        }}) == 'task-account'

--- a/tests/unit_tests/test_sky/clouds/test_slurm.py
+++ b/tests/unit_tests/test_sky/clouds/test_slurm.py
@@ -2336,3 +2336,172 @@ class TestResolveSkyBaseDir:
         assert result == '/home/alice'
         mock_get_config.assert_called_once()
         client.get_env.assert_not_called()
+
+
+class TestSlurmQuotaConfig:
+    """`slurm.quota.{queue,account}` land in sbatch_options as qos/account."""
+
+    def _sbatch_options(self, tmp_path, config, overrides=None):
+        # pylint: disable=protected-access
+        return TestSbatchOptionsPrecedence(
+        )._load_config_and_get_sbatch_options(
+            tmp_path, config, cluster_config_overrides=overrides)
+
+    def test_queue_sets_qos(self, tmp_path):
+        result = self._sbatch_options(tmp_path, {
+            'slurm': {
+                'quota': {
+                    'queue': 'normal'
+                },
+            },
+        })
+        assert result == {'qos': 'normal'}
+
+    def test_account_sets_account(self, tmp_path):
+        result = self._sbatch_options(tmp_path, {
+            'slurm': {
+                'quota': {
+                    'queue': 'high',
+                    'account': 'pre-training'
+                },
+            },
+        })
+        assert result == {'qos': 'high', 'account': 'pre-training'}
+
+    def test_quota_wins_over_sbatch_options_at_any_scope(self, tmp_path):
+        """A cloud-level `quota.queue` beats a partition-level sbatch qos.
+
+        Short-form spellings are dropped so the job never carries two
+        directives for the same option.
+        """
+        result = self._sbatch_options(
+            tmp_path, {
+                'slurm': {
+                    'quota': {
+                        'queue': 'quota-qos',
+                        'account': 'quota-account',
+                    },
+                    'sbatch_options': {
+                        'A': 'short-account',
+                        'constraint': 'skylake',
+                    },
+                    'cluster_configs': {
+                        'mycluster': {
+                            'partition_configs': {
+                                'gpu': {
+                                    'sbatch_options': {
+                                        'qos': 'partition-qos',
+                                        'q': 'short-qos',
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            })
+        assert result == {
+            'qos': 'quota-qos',
+            'account': 'quota-account',
+            'constraint': 'skylake',
+        }
+
+    def test_sbatch_options_kept_without_quota(self, tmp_path):
+        result = self._sbatch_options(
+            tmp_path, {
+                'slurm': {
+                    'sbatch_options': {
+                        'qos': 'sbatch-qos',
+                        'account': 'sbatch-account',
+                    },
+                },
+            })
+        assert result == {'qos': 'sbatch-qos', 'account': 'sbatch-account'}
+
+    def test_workspace_routes_to_its_queue(self, tmp_path):
+        """A workspace pin outranks every global scope, partition included."""
+        config = {
+            'slurm': {
+                'quota': {
+                    'queue': 'global-qos'
+                },
+                'cluster_configs': {
+                    'mycluster': {
+                        'partition_configs': {
+                            'gpu': {
+                                'quota': {
+                                    'queue': 'global-partition-qos',
+                                    'account': 'global-partition-account',
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+            'workspaces': {
+                'pre-training': {
+                    'slurm': {
+                        'quota': {
+                            'queue': 'pretraining-qos',
+                            'account': 'pre-training',
+                        },
+                    },
+                },
+                'other': {},
+            },
+        }
+        with skypilot_config.local_active_workspace_ctx('pre-training'):
+            result = self._sbatch_options(tmp_path, config)
+        assert result == {'qos': 'pretraining-qos', 'account': 'pre-training'}
+
+        with skypilot_config.local_active_workspace_ctx('other'):
+            result = self._sbatch_options(tmp_path, config)
+        assert result == {
+            'qos': 'global-partition-qos',
+            'account': 'global-partition-account',
+        }
+
+    def test_task_override_at_partition_scope(self, tmp_path):
+        result = self._sbatch_options(
+            tmp_path, {
+                'slurm': {
+                    'cluster_configs': {
+                        'mycluster': {
+                            'partition_configs': {
+                                'gpu': {
+                                    'quota': {
+                                        'queue': 'server-qos'
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+            overrides={
+                'slurm': {
+                    'cluster_configs': {
+                        'mycluster': {
+                            'partition_configs': {
+                                'gpu': {
+                                    'quota': {
+                                        'queue': 'task-qos'
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            })
+        assert result == {'qos': 'task-qos'}
+
+    def test_task_override_at_cloud_scope(self, tmp_path):
+        result = self._sbatch_options(tmp_path, {'slurm': {}},
+                                      overrides={
+                                          'slurm': {
+                                              'quota': {
+                                                  'queue': 'task-qos',
+                                                  'account': 'task-account',
+                                              },
+                                          },
+                                      })
+        assert result == {'qos': 'task-qos', 'account': 'task-account'}

--- a/tests/unit_tests/test_sky/utils/test_schemas.py
+++ b/tests/unit_tests/test_sky/utils/test_schemas.py
@@ -615,15 +615,26 @@ class TestWorkspaceSchema(unittest.TestCase):
                     'sbatch_options': {
                         'account': 'workspace-account',
                     },
+                    'quota': {
+                        'queue': 'workspace-qos',
+                        'account': 'workspace-account',
+                    },
                     'cluster_configs': {
                         'my-cluster': {
                             'sbatch_options': {
                                 'qos': 'workspace-qos',
                             },
+                            'quota': {
+                                'queue': 'cluster-qos',
+                            },
                             'partition_configs': {
                                 'gpu': {
                                     'sbatch_options': {
                                         'constraint': 'h100',
+                                    },
+                                    'quota': {
+                                        'queue': 'partition-qos',
+                                        'account': 'partition-account',
                                     },
                                 },
                             },

--- a/tests/unit_tests/test_sky/utils/test_schemas.py
+++ b/tests/unit_tests/test_sky/utils/test_schemas.py
@@ -645,6 +645,45 @@ class TestWorkspaceSchema(unittest.TestCase):
         }
         jsonschema.validate(instance=config, schema=self.workspaces_schema)
 
+    def test_slurm_quota_rejects_empty_values(self):
+        """An empty queue/account would become a bare `--qos=` / `--account=`."""
+        for cloud_config in (
+            {
+                'quota': {
+                    'queue': ''
+                }
+            },
+            {
+                'quota': {
+                    'account': ''
+                }
+            },
+            {
+                'cluster_configs': {
+                    'c': {
+                        'partition_configs': {
+                            'p': {
+                                'quota': {
+                                    'queue': ''
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+        ):
+            with self.assertRaises(jsonschema.exceptions.ValidationError,
+                                   msg=f'{cloud_config!r} should be rejected'):
+                jsonschema.validate(instance={'slurm': cloud_config},
+                                    schema=schemas.get_config_schema())
+            with self.assertRaises(jsonschema.exceptions.ValidationError,
+                                   msg=f'{cloud_config!r} should be rejected'):
+                jsonschema.validate(
+                    instance={'my-workspace': {
+                        'slurm': cloud_config
+                    }},
+                    schema=self.workspaces_schema)
+
     def test_workspace_slurm_rejects_global_only_properties(self):
         invalid_configs = [
             {


### PR DESCRIPTION
Adds a first-class, scope-resolved queue and account setting for Slurm, mirroring `kubernetes.quota.queue`:

```yaml
slurm:
  quota:
    queue: normal          # -> #SBATCH --qos=normal
    account: pre-training  # -> #SBATCH --account=pre-training
  cluster_configs:
    mycluster:
      partition_configs:
        h100:
          quota: {queue: high, account: pre-training}

workspaces:
  pre-training:
    slurm:
      quota: {queue: high, account: pre-training}
```

- **Resolution**: workspace > global; within each, partition > cluster > cloud. Task-level `config.slurm.quota` overrides apply at the scope they are written at (`('slurm', 'quota')` is added to `OVERRIDEABLE_CONFIG_KEYS_IN_TASK`).
- **Relation to `sbatch_options`**: the existing `sbatch_options.qos` / `sbatch_options.account` merge is unchanged. When a `quota.queue` / `quota.account` value resolves at any scope it overwrites the corresponding `sbatch_options` key (and drops the short forms `q` / `A` so the job never carries two directives for one option). Nothing changes for configs that only use `sbatch_options`.
- **Why `account` too**: `--qos` alone is enough only when the submitting user's default account association allows that QOS. A QOS restricted to some accounts, or a user who belongs to several accounts, needs `--account` alongside it, and association-level limits and fair-share are keyed on the account.
- **Resolver**: `_get_effective_k8s_config_value` becomes `_get_effective_scoped_config_value`, with the per-region path parameterized (`context_configs.<ctx>` for Kubernetes / SSH; `cluster_configs.<cluster>.partition_configs.<partition>` then `cluster_configs.<cluster>` for Slurm). `get_effective_queue_name` gains `cloud='slurm'` support and a `partition` kwarg; `get_effective_slurm_account` is new. Kubernetes behavior is unchanged (existing resolver tests pass as-is, renamed).
- **Schema**: `quota` at cloud, cluster and partition level, and the same three spots under `workspaces.<ws>.slurm`. Permissive (`additionalProperties: True`) like the Kubernetes `quota` block.
- **Docs**: new `slurm.quota` section in the config reference.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - `pytest tests/test_config.py -k effective` (12 passed; 3 new: Slurm queue precedence, `sbatch_options` not surfaced by the resolver, account precedence)
  - `pytest tests/unit_tests/test_sky/clouds/test_slurm.py tests/unit_tests/test_sky/utils/test_schemas.py tests/unit_tests/test_sky/provision/slurm/test_sbatch_config.py` (321 passed; 7 new in `TestSlurmQuotaConfig` covering qos/account emission, `quota` over `sbatch_options`, workspace routing, and task overrides at partition and cloud scope)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

**End-to-end on a live Slurm cluster** (Slurm 25.05, slurmdbd, `AccountingStorageEnforce=associations,limits,qos`; the submitting user has a default account allowed only QOS `normal`, and a second account `research` allowed `gpu-interactive`). Local API server at this commit, no plugins.

| Case | Config | Observed |
|---|---|---|
| Task-level | `config.slurm.quota: {queue: gpu-interactive, account: research}` | Job ran with `Account=research QOS=gpu-interactive` (from `scontrol show job $SLURM_JOB_ID` inside the job); submitted script carries `#SBATCH --account=research` and `#SBATCH --qos=gpu-interactive` |
| Negative control | `config.slurm.quota: {queue: gpu-interactive}` (no account) | Rejected at submission: `sbatch: error: Batch job submission failed: Invalid qos specification` |
| Workspace routing | server config `workspaces.<ws>.slurm.quota: {queue: gpu-interactive, account: research}`, bare task YAML, `sky launch -w <ws>` | Job ran with `Account=research QOS=gpu-interactive`, same directives in the script |

The negative control is why `quota.account` exists alongside `quota.queue`: the same `--qos` is rejected under the user's default account and accepted under the account whose association allows it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CDm4YE5gK4GnRgzLehV9gP
