### PR TITLE
[API] Authorize download paths against authenticated user roots

### DIFF
--- a/sky/jobs/server/server.py
+++ b/sky/jobs/server/server.py
@@ -7,6 +7,7 @@ import fastapi
 from sky import sky_logging
 from sky.jobs import utils as managed_jobs_utils
 from sky.jobs.server import core
+from sky.server import download_utils
 from sky.server import stream_utils
 from sky.server.blob import blob_storage as bs
 from sky.server.requests import executor
@@ -14,7 +15,6 @@ from sky.server.requests import payloads
 from sky.server.requests import request_names
 from sky.server.requests import requests as api_requests
 from sky.server.requests import role_filter
-from sky.skylet import constants
 from sky.utils import common
 
 logger = sky_logging.init_logger(__name__)
@@ -176,7 +176,8 @@ async def download_logs(
     jobs_download_logs_body: payloads.JobsDownloadLogsBody = fastapi.Depends(
         role_filter.force_viewer_jobs_download_logs_body),
 ) -> None:
-    user_hash = jobs_download_logs_body.env_vars[constants.USER_ID_ENV_VAR]
+    user_hash = download_utils.download_user_id(request,
+                                                jobs_download_logs_body)
     logs_dir_on_api_server = pathlib.Path(
         bs.get_blob_storage().download_tmp_dir(user_hash))
     logs_dir_on_api_server.expanduser().mkdir(parents=True, exist_ok=True)
@@ -272,7 +273,7 @@ async def pool_download_logs(
     request: fastapi.Request,
     download_logs_body: payloads.JobsPoolDownloadLogsBody,
 ) -> None:
-    user_hash = download_logs_body.env_vars[constants.USER_ID_ENV_VAR]
+    user_hash = download_utils.download_user_id(request, download_logs_body)
     timestamp = sky_logging.get_run_timestamp()
     logs_dir_on_api_server = (
         pathlib.Path(bs.get_blob_storage().download_tmp_dir(user_hash)) /

--- a/sky/serve/server/server.py
+++ b/sky/serve/server/server.py
@@ -6,13 +6,13 @@ import fastapi
 
 from sky import sky_logging
 from sky.serve.server import core
+from sky.server import download_utils
 from sky.server import stream_utils
 from sky.server.blob import blob_storage as bs
 from sky.server.requests import executor
 from sky.server.requests import payloads
 from sky.server.requests import request_names
 from sky.server.requests import requests as api_requests
-from sky.skylet import constants
 from sky.utils import common
 
 logger = sky_logging.init_logger(__name__)
@@ -130,7 +130,7 @@ async def download_logs(
     request: fastapi.Request,
     download_logs_body: payloads.ServeDownloadLogsBody,
 ) -> None:
-    user_hash = download_logs_body.env_vars[constants.USER_ID_ENV_VAR]
+    user_hash = download_utils.download_user_id(request, download_logs_body)
     timestamp = sky_logging.get_run_timestamp()
     logs_dir_on_api_server = (
         pathlib.Path(bs.get_blob_storage().download_tmp_dir(user_hash)) /

--- a/sky/server/download_utils.py
+++ b/sky/server/download_utils.py
@@ -1,0 +1,16 @@
+"""Shared authorization for log download staging and retrieval."""
+
+import fastapi
+
+from sky.server.requests import payloads
+
+
+def download_user_id(request: fastapi.Request,
+                     body: payloads.RequestBody) -> str:
+    """Choose a download owner whose ID is a single path component."""
+    user_id = (request.state.auth_user.id
+               if request.state.auth_user is not None else body.user_hash)
+    if (not user_id or user_id in ('.', '..') or '/' in user_id or
+            '\\' in user_id):
+        raise fastapi.HTTPException(status_code=400, detail='Invalid user ID')
+    return user_id

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -2372,12 +2372,22 @@ async def logs(
     )
 
 
+def _download_user_id(request: fastapi.Request,
+                      body: payloads.RequestBody) -> str:
+    user_id = (request.state.auth_user.id
+               if request.state.auth_user is not None else body.user_hash)
+    if (not user_id or user_id in ('.', '..') or '/' in user_id or
+            '\\' in user_id):
+        raise fastapi.HTTPException(status_code=400, detail='Invalid user ID')
+    return user_id
+
+
 @app.post('/download_logs')
 async def download_logs(
         request: fastapi.Request,
         cluster_jobs_body: payloads.ClusterJobsDownloadLogsBody) -> None:
     """Downloads the logs of a job."""
-    user_hash = cluster_jobs_body.env_vars[constants.USER_ID_ENV_VAR]
+    user_hash = _download_user_id(request, cluster_jobs_body)
     logs_dir_on_api_server = pathlib.Path(
         bs.get_blob_storage().download_tmp_dir(user_hash))
     logs_dir_on_api_server.expanduser().mkdir(parents=True, exist_ok=True)
@@ -2399,26 +2409,25 @@ async def download_logs(
 async def download(download_body: payloads.DownloadBody,
                    request: fastapi.Request) -> None:
     """Downloads a folder from the cluster to the local machine."""
-    folder_paths = [
-        pathlib.Path(folder_path) for folder_path in download_body.folder_paths
-    ]
-    user_hash = download_body.env_vars[constants.USER_ID_ENV_VAR]
+    user_hash = _download_user_id(request, download_body)
     logs_dir_on_api_server = common.api_server_user_logs_dir_prefix(user_hash)
     download_tmp = bs.get_blob_storage().download_tmp_dir(user_hash)
-    for folder_path in folder_paths:
-        folder_str = str(folder_path)
-        expanded_str = str(runtime_utils.expanduser_path(folder_path))
-        if not (folder_str.startswith(str(logs_dir_on_api_server)) or
-                folder_str.startswith(download_tmp) or expanded_str.startswith(
-                    runtime_utils.expanduser(download_tmp))):
+    allowed_roots = [
+        runtime_utils.expanduser_path(pathlib.Path(root)).resolve()
+        for root in (logs_dir_on_api_server, download_tmp)
+    ]
+    folder_paths = []
+    for folder_path in download_body.folder_paths:
+        resolved_path = runtime_utils.expanduser_path(
+            pathlib.Path(folder_path)).resolve()
+        if not any(resolved_path == root or root in resolved_path.parents
+                   for root in allowed_roots):
             raise fastapi.HTTPException(
-                status_code=400,
-                detail=
-                f'Invalid folder path: {folder_path}; {logs_dir_on_api_server}')
-
-        if not runtime_utils.expanduser_path(folder_path).resolve().exists():
+                status_code=400, detail=f'Invalid folder path: {folder_path}')
+        if not resolved_path.exists():
             raise fastapi.HTTPException(
                 status_code=404, detail=f'Folder not found: {folder_path}')
+        folder_paths.append(resolved_path)
 
     # Create a temporary zip file
     log_id = str(uuid.uuid4().hex)
@@ -2429,10 +2438,7 @@ async def download(download_body: payloads.DownloadBody,
     try:
 
         def _zip_files_and_folders(folder_paths, zip_path):
-            folders = [
-                str(runtime_utils.expanduser_path(folder_path).resolve())
-                for folder_path in folder_paths
-            ]
+            folders = [str(folder_path) for folder_path in folder_paths]
             # Check for optional query parameter to control zip entry structure
             relative = request.query_params.get('relative', 'home')
             if relative == 'items':

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -67,6 +67,7 @@ from sky.server import config as server_config
 from sky.server import constants as server_constants
 from sky.server import csp_utils
 from sky.server import daemons
+from sky.server import download_utils
 from sky.server import loop_stall
 from sky.server import metrics
 from sky.server import middleware_utils
@@ -2372,22 +2373,12 @@ async def logs(
     )
 
 
-def _download_user_id(request: fastapi.Request,
-                      body: payloads.RequestBody) -> str:
-    user_id = (request.state.auth_user.id
-               if request.state.auth_user is not None else body.user_hash)
-    if (not user_id or user_id in ('.', '..') or '/' in user_id or
-            '\\' in user_id):
-        raise fastapi.HTTPException(status_code=400, detail='Invalid user ID')
-    return user_id
-
-
 @app.post('/download_logs')
 async def download_logs(
         request: fastapi.Request,
         cluster_jobs_body: payloads.ClusterJobsDownloadLogsBody) -> None:
     """Downloads the logs of a job."""
-    user_hash = _download_user_id(request, cluster_jobs_body)
+    user_hash = download_utils.download_user_id(request, cluster_jobs_body)
     logs_dir_on_api_server = pathlib.Path(
         bs.get_blob_storage().download_tmp_dir(user_hash))
     logs_dir_on_api_server.expanduser().mkdir(parents=True, exist_ok=True)
@@ -2409,7 +2400,7 @@ async def download_logs(
 async def download(download_body: payloads.DownloadBody,
                    request: fastapi.Request) -> None:
     """Downloads a folder from the cluster to the local machine."""
-    user_hash = _download_user_id(request, download_body)
+    user_hash = download_utils.download_user_id(request, download_body)
     logs_dir_on_api_server = common.api_server_user_logs_dir_prefix(user_hash)
     download_tmp = bs.get_blob_storage().download_tmp_dir(user_hash)
     allowed_roots = [

--- a/tests/unit_tests/test_sky/server/test_download_security.py
+++ b/tests/unit_tests/test_sky/server/test_download_security.py
@@ -8,6 +8,8 @@ import fastapi
 import pytest
 
 from sky import models
+from sky.jobs.server import server as jobs_server
+from sky.serve.server import server as serve_server
 from sky.server import server
 from sky.server.requests import payloads
 from sky.skylet import constants
@@ -146,3 +148,66 @@ async def test_download_separate_staging_root(download_env, tmp_path):
     with zipfile.ZipFile(response.path) as archive:
         assert archive.read(archive.namelist()[0]) == b'staged log'
     await response.background()
+
+
+_STAGING_HANDLERS = [
+    (server.download_logs, payloads.ClusterJobsDownloadLogsBody,
+     dict(cluster_name='test', job_ids=None)),
+    (jobs_server.download_logs, payloads.JobsDownloadLogsBody,
+     dict(name=None, job_id=1)),
+    (jobs_server.pool_download_logs, payloads.JobsPoolDownloadLogsBody,
+     dict(pool_name='test', local_dir='', targets=None)),
+    (serve_server.download_logs, payloads.ServeDownloadLogsBody,
+     dict(service_name='test', local_dir='', targets=None)),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('handler,body_type,kwargs', _STAGING_HANDLERS)
+@pytest.mark.parametrize('authenticated', [True, False])
+async def test_staging_then_download(download_env, handler, body_type, kwargs,
+                                     authenticated):
+    request, roots, _ = download_env
+    request.state.request_id = 'staging-test'
+    if not authenticated:
+        request.state.auth_user = None
+    expected_user = 'alice' if authenticated else 'bob'
+    staging_body = body_type(**kwargs,
+                             env_vars={constants.USER_ID_ENV_VAR: 'bob'})
+    with mock.patch.object(server.executor,
+                           'schedule_request_async',
+                           new_callable=mock.AsyncMock) as schedule:
+        await handler(request, staging_body)
+    staged_dir = pathlib.Path(staging_body.local_dir)
+    assert staged_dir == roots[expected_user] or roots[
+        expected_user] in staged_dir.parents
+    assert schedule.call_args.kwargs['request_body'] is staging_body
+    assert schedule.call_args.kwargs['auth_user'] == request.state.auth_user
+    # Populate the selected destination without contacting a remote cluster.
+    staged_log = staged_dir / 'staged.log'
+    staged_log.write_text('downloaded logs')
+    response = await server.download(body(staged_log, 'bob'), request)
+    with zipfile.ZipFile(response.path) as archive:
+        assert archive.read(archive.namelist()[0]) == b'downloaded logs'
+    await response.background()
+    if authenticated:
+        with pytest.raises(fastapi.HTTPException) as exc:
+            await server.download(body(roots['bob'] / 'run.log', 'bob'),
+                                  request)
+        assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('handler,body_type,kwargs', _STAGING_HANDLERS)
+async def test_staging_rejects_anonymous_path_component(download_env, handler,
+                                                        body_type, kwargs):
+    request, _, _ = download_env
+    request.state.auth_user = None
+    staging_body = body_type(**kwargs,
+                             env_vars={constants.USER_ID_ENV_VAR: '../bob'})
+    with mock.patch.object(server.bs.get_blob_storage(),
+                           'download_tmp_dir') as staging:
+        with pytest.raises(fastapi.HTTPException) as exc:
+            await handler(request, staging_body)
+    assert exc.value.status_code == 400
+    staging.assert_not_called()

--- a/tests/unit_tests/test_sky/server/test_download_security.py
+++ b/tests/unit_tests/test_sky/server/test_download_security.py
@@ -1,0 +1,148 @@
+"""Download authorization tests using real files and archive creation."""
+
+import pathlib
+from unittest import mock
+import zipfile
+
+import fastapi
+import pytest
+
+from sky import models
+from sky.server import server
+from sky.server.requests import payloads
+from sky.skylet import constants
+
+
+@pytest.fixture(name='download_env')
+def fixture_download_env(tmp_path, monkeypatch):
+    clients = tmp_path / 'clients'
+    monkeypatch.setattr(server.common, 'API_SERVER_CLIENT_DIR', clients)
+    roots = {}
+    for user in ('alice', 'bob'):
+        root = server.common.api_server_user_logs_dir_prefix(user)
+        root.mkdir(parents=True)
+        (root / 'run.log').write_text(user)
+        roots[user] = root
+    secret = tmp_path / 'secret'
+    secret.write_text('private credential')
+    (roots['alice'] / 'escape').symlink_to(secret)
+    sibling = roots['alice'].with_name('sky_logs_evil')
+    sibling.mkdir()
+    (sibling / 'secret').write_text('private credential')
+    request = fastapi.Request({'type': 'http', 'query_string': b''})
+    request.state.auth_user = models.User(id='alice', name='Alice')
+    return request, roots, secret
+
+
+def body(path, user='alice'):
+    return payloads.DownloadBody(folder_paths=[str(path)],
+                                 env_vars={constants.USER_ID_ENV_VAR: user})
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('attack', [
+    'traversal', 'absolute', 'sibling', 'symlink', 'cross_user',
+    'user_traversal'
+])
+async def test_download_rejects_escape(download_env, attack):
+    request, roots, secret = download_env
+    user = 'alice'
+    paths = {
+        'traversal': roots['alice'] / '..' / '..' / '..' / 'secret',
+        'absolute': secret,
+        'sibling': roots['alice'].with_name('sky_logs_evil') / 'secret',
+        'symlink': roots['alice'] / 'escape',
+        'cross_user': roots['bob'] / 'run.log',
+        'user_traversal': secret,
+    }
+    if attack == 'cross_user':
+        user = 'bob'
+    elif attack == 'user_traversal':
+        request.state.auth_user = None
+        user = '../../../'
+    with pytest.raises(fastapi.HTTPException) as exc:
+        await server.download(body(paths[attack], user), request)
+    assert exc.value.status_code == 400
+    assert not list(roots['alice'].glob('folder_*.zip'))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('relative', ['home', 'items'])
+@pytest.mark.parametrize('anonymous', [False, True])
+async def test_download_archive(download_env, relative, anonymous):
+    request, roots, _ = download_env
+    request.scope['query_string'] = f'relative={relative}'.encode()
+    if anonymous:
+        request.state.auth_user = None
+    # The authenticated identity controls access even with a forged body ID.
+    user = 'alice' if anonymous else 'bob'
+    response = await server.download(body(roots['alice'] / 'run.log', user),
+                                     request)
+    with zipfile.ZipFile(response.path) as archive:
+        assert len(archive.namelist()) == 1
+        assert archive.read(archive.namelist()[0]) == b'alice'
+        if relative == 'items':
+            assert archive.namelist() == ['run.log']
+    await response.background()
+    assert not pathlib.Path(response.path).exists()
+
+
+@pytest.mark.asyncio
+async def test_download_directory_does_not_read_nested_symlink(download_env):
+    request, roots, _ = download_env
+    response = await server.download(body(roots['alice']), request)
+    with zipfile.ZipFile(response.path) as archive:
+        assert b'private credential' not in [
+            archive.read(name) for name in archive.namelist()
+        ]
+    await response.background()
+
+
+@pytest.mark.asyncio
+async def test_download_missing_allowed_path(download_env):
+    request, roots, _ = download_env
+    with pytest.raises(fastapi.HTTPException) as exc:
+        await server.download(body(roots['alice'] / 'missing'), request)
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_download_logs_uses_authenticated_destination(download_env):
+    request, roots, _ = download_env
+    request.state.request_id = 'download-test'
+    download_body = payloads.ClusterJobsDownloadLogsBody(
+        cluster_name='test',
+        job_ids=None,
+        env_vars={constants.USER_ID_ENV_VAR: 'bob'})
+    with mock.patch.object(server.executor,
+                           'schedule_request_async',
+                           new_callable=mock.AsyncMock) as schedule:
+        await server.download_logs(request, download_body)
+    assert pathlib.Path(download_body.local_dir) == roots['alice']
+    assert schedule.call_args.kwargs['auth_user'] == request.state.auth_user
+
+
+@pytest.mark.asyncio
+async def test_download_expands_and_normalizes_path(download_env, monkeypatch):
+    request, _, secret = download_env
+    monkeypatch.setenv('HOME', str(secret.parent))
+    path = '~/clients/alice/sky_logs/../sky_logs/run.log'
+    response = await server.download(body(path), request)
+    with zipfile.ZipFile(response.path) as archive:
+        assert archive.read(archive.namelist()[0]) == b'alice'
+    await response.background()
+
+
+@pytest.mark.asyncio
+async def test_download_separate_staging_root(download_env, tmp_path):
+    request, _, _ = download_env
+    staging = tmp_path / 'staging' / 'alice'
+    staging.mkdir(parents=True)
+    (staging / 'run.log').write_text('staged log')
+    with mock.patch.object(server.bs.get_blob_storage(),
+                           'download_tmp_dir',
+                           return_value=str(staging)):
+        response = await server.download(body(staging / 'run.log'), request)
+    with zipfile.ZipFile(response.path) as archive:
+        assert archive.read(archive.namelist()[0]) == b'staged log'
+    await response.background()


### PR DESCRIPTION
`POST /download` authorizes the raw path with `str.startswith()` but resolves it before creating the ZIP. A path containing `..`, a sibling directory sharing the allowed prefix, or an escaping symlink can therefore pass authorization and read files outside the intended log directory. The handler also takes the user ID from request-body environment variables, bypassing the authenticated identity override in `executor.prepare_request_async()`.

Resolve requested paths and allowed roots before checking component-wise containment, and pass the authorized paths to the archive writer. Use the shared `download_utils.download_user_id()` in `/download` and all four staging handlers: cluster-job, managed-job, pool, and service logs. Each staging handler previously selected its destination before the executor replaced the body identity. Using the authenticated ID for both staging and retrieval prevents valid downloads from being rejected when the body ID differs. Anonymous access retains body-based identity, with path components rejected in user IDs.

The original raw-prefix check and body-derived identity were introduced in [#4660](https://github.com/skypilot-org/skypilot/pull/4660), confirmed from complete git history and the introducing diff. `/debug/dump_download/{dump_filename}` already checks resolved-path containment and is unchanged.

Tested locally:
- `python -m pytest tests/unit_tests/test_sky/server/test_download_security.py -n0`: 27 cases passed and the process exited cleanly. Tests invoke real staging handlers, path authorization, and ZIP creation against temporary files. Remote log collection is represented by writing a fixture log into the selected staging directory; executor scheduling is mocked.
- Coverage includes traversal, absolute and sibling-prefix escapes, symlinks, forged user identity, anonymous identity validation in every staging handler, valid downloads in both archive layouts, nested symlinks, missing files, tilde paths, and separate staging roots. All four staging handlers are exercised through subsequent download with authenticated/body-ID mismatches and anonymous requests.
- Before the shared-helper follow-up, running the initial regressions alongside `test_server.py` reported 75 passing tests; the process hung in Python thread shutdown after the summary and was interrupted. This was not a clean suite shutdown.
- Authentication middleware, remote collection, and a deployed rolling update have not been exercised.

Update behavior: paths staged by an old handler under a body ID different from the authenticated ID will be rejected by the patched download handler. Restart the log-download operation once the updated handlers are serving it. Existing paths under the authenticated user's root remain authorized if the files survive the server restart. Mixed-version replicas can still select inconsistent roots until the rollout completes. The patch does not relax authorization to accept another user's directory or migrate staged files.

Manual validation on an isolated server: authenticate as user A, download an existing A-owned log and inspect its ZIP contents; then submit a B-owned log path with B's ID in `env_vars`, and an A-prefixed path escaping via `..`. Both unauthorized downloads should return HTTP 400 with no archive. Download A's job logs and confirm they are staged under A's directory.
