### PR TITLE
[Server] Bound the auth users upsert with server-side timeouts aligned to the auth deadline

### DIFF
--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -440,8 +440,10 @@ initialize_and_get_db = _db_manager.get_engine
 #   generic statement cancel (57014);
 # - statement_timeout bounds each statement itself;
 # - idle_in_transaction_session_timeout terminates a session that goes
-#   quiet inside the transaction (the orphan case; 57P05 on that session's
-#   next statement), which releases the row lock it holds.
+#   quiet inside the transaction (the orphan case), which releases the row
+#   lock it holds. The terminated session's own next statement fails: with
+#   SQLSTATE 25P03 if the client reads the FATAL, otherwise as a closed
+#   connection (the FATAL was sent while nobody was reading).
 #
 # `SET LOCAL` is transaction-scoped: it applies to this transaction only and
 # resets at COMMIT/ROLLBACK, so it is safe through a transaction-mode

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -467,7 +467,10 @@ def _user_upsert_timeouts_ms() -> Tuple[int, int, int]:
     percentage of the configured auth deadline (see the note above).
     Computed per call: the deadline lookup is one environment read, which is
     nothing next to the statements it bounds, and it lets tests vary the
-    deadline.
+    deadline. The read sees the server's own setting only: the variable is
+    stripped from client request payloads and from the per-request
+    environment overlay (`executor.override_request_env_and_config`) before
+    the request worker calls this.
 
     Raises:
         ValueError: if the configured deadline is not a positive number (see

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -425,33 +425,71 @@ initialize_and_get_db = _db_manager.get_engine
 #
 # The upsert runs on the request authentication path for every request, on
 # the API server's bounded auth thread pool, under a client-side deadline
-# (`AUTH_DB_TIMEOUT_SECONDS` in `sky.server.auth.db_lookup`, 5 s; not
-# imported here because this module is not server-only). That deadline frees
-# the caller but not the thread: a thread that waits on the users row lock,
-# or a session that stops talking inside its open transaction, keeps its
-# thread and its connection for as long as the database allows. One orphaned
+# (`AUTH_DB_TIMEOUT_SECONDS` in `sky.server.auth.db_lookup`; not imported
+# here because this module is not server-only). That deadline frees the
+# caller but not the thread: a thread that waits on the users row lock, or a
+# session that stops talking inside its open transaction, keeps its thread
+# and its connection for as long as the database allows. One orphaned
 # session holding a single users row then pins every later upsert of that
 # row until the pool is exhausted.
 #
-# These values MUST stay at or below that deadline, so the database gives up
-# before (or as) the caller does and the thread is released:
-# - lock_timeout < statement_timeout, so a row-lock wait reports the
-#   distinct "lock not available" error (SQLSTATE 55P03) instead of a
-#   generic statement cancel (57014);
-# - statement_timeout bounds each statement itself;
-# - idle_in_transaction_session_timeout terminates a session that goes
-#   quiet inside the transaction (the orphan case), which releases the row
-#   lock it holds. The terminated session's own next statement fails: with
-#   SQLSTATE 25P03 if the client reads the FATAL, otherwise as a closed
+# The three timeouts are therefore derived from that same deadline, read
+# through `db_utils.get_auth_db_timeout_seconds()` (the one place the
+# configured value is parsed), as these percentages of it. They MUST stay at
+# or below the deadline so the database gives up before (or as) the caller
+# does and the thread is released:
+# - lock_timeout (78 %) < statement_timeout (80 %), so a row-lock wait
+#   reports the distinct "lock not available" error (SQLSTATE 55P03) instead
+#   of a generic statement cancel (57014);
+# - statement_timeout (80 %) bounds each statement itself, with a little
+#   headroom under the deadline for the round trip;
+# - idle_in_transaction_session_timeout (100 %) terminates a session that
+#   goes quiet inside the transaction (the orphan case), which releases the
+#   row lock it holds. The terminated session's own next statement fails:
+#   with SQLSTATE 25P03 if the client reads the FATAL, otherwise as a closed
 #   connection (the FATAL was sent while nobody was reading).
+# At the default 5 s deadline these are 3900 / 4000 / 5000 ms.
 #
 # `SET LOCAL` is transaction-scoped: it applies to this transaction only and
 # resets at COMMIT/ROLLBACK, so it is safe through a transaction-mode
 # connection pooler and leaks nothing into later transactions on the same
 # server connection.
-_USER_UPSERT_LOCK_TIMEOUT_MS = 3900
-_USER_UPSERT_STATEMENT_TIMEOUT_MS = 4000
-_USER_UPSERT_IDLE_IN_TRANSACTION_TIMEOUT_MS = 5000
+_USER_UPSERT_LOCK_TIMEOUT_PERCENT = 78
+_USER_UPSERT_STATEMENT_TIMEOUT_PERCENT = 80
+_USER_UPSERT_IDLE_IN_TRANSACTION_TIMEOUT_PERCENT = 100
+
+
+def _user_upsert_timeouts_ms() -> Tuple[int, int, int]:
+    """The users upsert's server-side timeouts, in whole milliseconds.
+
+    Returns ``(lock_timeout, statement_timeout,
+    idle_in_transaction_session_timeout)``, each the corresponding
+    percentage of the configured auth deadline (see the note above).
+    Computed per call: the deadline lookup is one environment read, which is
+    nothing next to the statements it bounds, and it lets tests vary the
+    deadline.
+
+    Raises:
+        ValueError: if the configured deadline is not a positive number (see
+            `db_utils.get_auth_db_timeout_seconds`), or is so small that the
+            three values would not be distinct, ordered, positive integers.
+            Postgres treats a timeout of ``0`` as *disabled*, so a rounding
+            to zero must never reach the database.
+    """
+    deadline_ms = db_utils.get_auth_db_timeout_seconds() * 1000
+    lock_ms = round(deadline_ms * _USER_UPSERT_LOCK_TIMEOUT_PERCENT / 100)
+    statement_ms = round(deadline_ms * _USER_UPSERT_STATEMENT_TIMEOUT_PERCENT /
+                         100)
+    idle_ms = round(deadline_ms *
+                    _USER_UPSERT_IDLE_IN_TRANSACTION_TIMEOUT_PERCENT / 100)
+    if not 0 < lock_ms < statement_ms < idle_ms:
+        raise ValueError(
+            f'{constants.ENV_VAR_AUTH_DB_TIMEOUT_SECONDS} is too small '
+            f'({deadline_ms} ms) to derive distinct server-side timeouts for '
+            f'the users upsert (got lock_timeout={lock_ms}ms, '
+            f'statement_timeout={statement_ms}ms, '
+            f'idle_in_transaction_session_timeout={idle_ms}ms).')
+    return lock_ms, statement_ms, idle_ms
 
 
 def _bound_user_upsert_transaction(session: orm.Session) -> None:
@@ -464,14 +502,14 @@ def _bound_user_upsert_transaction(session: orm.Session) -> None:
     through SQLAlchemy's normal error handling and reaches the caller as a
     regular DB error.
     """
+    lock_ms, statement_ms, idle_ms = _user_upsert_timeouts_ms()
     for parameter, value_ms in (
-        ('lock_timeout', _USER_UPSERT_LOCK_TIMEOUT_MS),
-        ('statement_timeout', _USER_UPSERT_STATEMENT_TIMEOUT_MS),
-        ('idle_in_transaction_session_timeout',
-         _USER_UPSERT_IDLE_IN_TRANSACTION_TIMEOUT_MS),
+        ('lock_timeout', lock_ms),
+        ('statement_timeout', statement_ms),
+        ('idle_in_transaction_session_timeout', idle_ms),
     ):
-        # SET does not accept bind parameters; the values are module
-        # constants, never user input.
+        # SET does not accept bind parameters; the values are integers
+        # derived from a validated setting, never user input.
         session.execute(
             sqlalchemy.text(f'SET LOCAL {parameter} = \'{value_ms}ms\''))
 

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -421,6 +421,58 @@ _db_manager = db_utils.DatabaseManager(
     'state', create_table, post_init_fn=lambda _: _sqlite_supports_returning())
 initialize_and_get_db = _db_manager.get_engine
 
+# Server-side bounds on the `users` upsert transaction (Postgres only).
+#
+# The upsert runs on the request authentication path for every request, on
+# the API server's bounded auth thread pool, under a client-side deadline
+# (`AUTH_DB_TIMEOUT_SECONDS` in `sky.server.auth.db_lookup`, 5 s; not
+# imported here because this module is not server-only). That deadline frees
+# the caller but not the thread: a thread that waits on the users row lock,
+# or a session that stops talking inside its open transaction, keeps its
+# thread and its connection for as long as the database allows. One orphaned
+# session holding a single users row then pins every later upsert of that
+# row until the pool is exhausted.
+#
+# These values MUST stay at or below that deadline, so the database gives up
+# before (or as) the caller does and the thread is released:
+# - lock_timeout < statement_timeout, so a row-lock wait reports the
+#   distinct "lock not available" error (SQLSTATE 55P03) instead of a
+#   generic statement cancel (57014);
+# - statement_timeout bounds each statement itself;
+# - idle_in_transaction_session_timeout terminates a session that goes
+#   quiet inside the transaction (the orphan case; 57P05 on that session's
+#   next statement), which releases the row lock it holds.
+#
+# `SET LOCAL` is transaction-scoped: it applies to this transaction only and
+# resets at COMMIT/ROLLBACK, so it is safe through a transaction-mode
+# connection pooler and leaks nothing into later transactions on the same
+# server connection.
+_USER_UPSERT_LOCK_TIMEOUT_MS = 3900
+_USER_UPSERT_STATEMENT_TIMEOUT_MS = 4000
+_USER_UPSERT_IDLE_IN_TRANSACTION_TIMEOUT_MS = 5000
+
+
+def _bound_user_upsert_transaction(session: orm.Session) -> None:
+    """Issue the `SET LOCAL` timeouts for the users upsert transaction.
+
+    Must run before any other statement in the session: the Session
+    auto-begins its transaction on the first statement, and `SET LOCAL`
+    only takes effect inside that transaction. Issued explicitly through
+    the Session (not from an engine event hook) so a failure here goes
+    through SQLAlchemy's normal error handling and reaches the caller as a
+    regular DB error.
+    """
+    for parameter, value_ms in (
+        ('lock_timeout', _USER_UPSERT_LOCK_TIMEOUT_MS),
+        ('statement_timeout', _USER_UPSERT_STATEMENT_TIMEOUT_MS),
+        ('idle_in_transaction_session_timeout',
+         _USER_UPSERT_IDLE_IN_TRANSACTION_TIMEOUT_MS),
+    ):
+        # SET does not accept bind parameters; the values are module
+        # constants, never user input.
+        session.execute(
+            sqlalchemy.text(f'SET LOCAL {parameter} = \'{value_ms}ms\''))
+
 
 @metrics_lib.time_me
 def add_or_update_user(
@@ -442,6 +494,10 @@ def add_or_update_user(
     if created_at is None:
         created_at = int(time.time())
     with orm.Session(engine) as session:
+        if engine.dialect.name == db_utils.SQLAlchemyDialect.POSTGRESQL.value:
+            # First statements of the transaction; see the constants above.
+            _bound_user_upsert_transaction(session)
+
         # Check for duplicate names if not allowed (within the same transaction)
         if not allow_duplicate_name:
             existing_user = session.query(user_table).filter(

--- a/sky/server/auth/db_lookup.py
+++ b/sky/server/auth/db_lookup.py
@@ -23,7 +23,6 @@ only, so an exception raised in a middleware surfaces as a bare 500,
 which clients do not retry.
 """
 import asyncio
-import os
 from typing import Any, Callable, Optional
 
 import fastapi
@@ -34,6 +33,7 @@ from sky.server.requests import executor
 from sky.users import permission
 from sky.utils import common_utils
 from sky.utils import context_utils
+from sky.utils.db import db_utils
 
 logger = sky_logging.init_logger(__name__)
 
@@ -42,14 +42,20 @@ logger = sky_logging.init_logger(__name__)
 # trouble, while staying well below the SQLAlchemy pool checkout timeout
 # (30s) and typical pooler queue-wait timeouts so requests fail fast
 # before executor threads pile up.
-AUTH_DB_TIMEOUT_SECONDS = float(
-    os.environ.get('SKYPILOT_AUTH_DB_TIMEOUT_SECONDS', '5'))
+#
+# Configured by `constants.ENV_VAR_AUTH_DB_TIMEOUT_SECONDS` (default 5 s),
+# read through the shared helper so the server-side timeouts the users
+# upsert derives from the same value cannot drift from this one. A value
+# that is not a positive number fails here, at server startup, with a
+# message naming the variable.
+AUTH_DB_TIMEOUT_SECONDS = db_utils.get_auth_db_timeout_seconds()
 
 # Postgres SQLSTATE codes raised when the database itself gives up on an
 # auth-path call at a server-side timeout. The users upsert sets these
-# timeouts on its own transaction (see `global_user_state.add_or_update_user`)
-# at or below `AUTH_DB_TIMEOUT_SECONDS`, so the database normally fails the
-# call *before* `asyncio.wait_for` does -- and, unlike `wait_for`, actually
+# timeouts on its own transaction (see `global_user_state.add_or_update_user`),
+# derived from the same configured deadline as `AUTH_DB_TIMEOUT_SECONDS` and
+# strictly below or equal to it, so the database normally fails the call
+# *before* `asyncio.wait_for` does -- and, unlike `wait_for`, actually
 # releases the executor thread. Such an error is the same condition as the
 # client-side deadline (a slow or locked database) and gets the same
 # retryable 503; anything else still propagates unchanged.

--- a/sky/server/auth/db_lookup.py
+++ b/sky/server/auth/db_lookup.py
@@ -45,16 +45,72 @@ logger = sky_logging.init_logger(__name__)
 AUTH_DB_TIMEOUT_SECONDS = float(
     os.environ.get('SKYPILOT_AUTH_DB_TIMEOUT_SECONDS', '5'))
 
+# Postgres SQLSTATE codes raised when the database itself gives up on an
+# auth-path call at a server-side timeout. The users upsert sets these
+# timeouts on its own transaction (see `global_user_state.add_or_update_user`)
+# at or below `AUTH_DB_TIMEOUT_SECONDS`, so the database normally fails the
+# call *before* `asyncio.wait_for` does -- and, unlike `wait_for`, actually
+# releases the executor thread. Such an error is the same condition as the
+# client-side deadline (a slow or locked database) and gets the same
+# retryable 503; anything else still propagates unchanged.
+_SERVER_TIMEOUT_PGCODES = {
+    '55P03': 'lock_timeout',  # LockNotAvailable
+    '57014': 'statement_timeout',  # QueryCanceled
+    '57P05': 'idle_in_transaction_session_timeout',
+}
+
+
+class AuthDBTimeoutError(asyncio.TimeoutError):
+    """An auth DB call was cut off by the database's own timeout.
+
+    Subclasses ``asyncio.TimeoutError`` so every ``except asyncio.TimeoutError``
+    in the auth middlewares keeps answering ``db_timeout_response()`` unchanged.
+    """
+
+
+def _server_timeout_pgcode(exc: BaseException) -> Optional[str]:
+    """``exc``'s SQLSTATE if it is one of the server-side timeouts, else None.
+
+    ``sqlalchemy.exc.DBAPIError`` wraps the driver's error as ``.orig``; a
+    driver error that escaped unwrapped (raw connections) carries ``pgcode``
+    itself. Duck-typed so this module does not import psycopg2, which is a
+    server-only dependency.
+    """
+    orig = getattr(exc, 'orig', exc)
+    pgcode = getattr(orig, 'pgcode', None)
+    if pgcode in _SERVER_TIMEOUT_PGCODES:
+        return pgcode
+    return None
+
+
+async def _run_with_deadline(pool: Any, func: Callable[..., Any],
+                             *args: Any) -> Any:
+    try:
+        return await asyncio.wait_for(context_utils.to_thread_with_executor(
+            pool, func, *args),
+                                      timeout=AUTH_DB_TIMEOUT_SECONDS)
+    except Exception as e:  # pylint: disable=broad-except
+        pgcode = _server_timeout_pgcode(e)
+        if pgcode is None:
+            raise
+        reason = _SERVER_TIMEOUT_PGCODES[pgcode]
+        logger.warning(f'Auth DB call {getattr(func, "__name__", func)} was '
+                       f'cut off by the database\'s {reason} '
+                       f'(pgcode {pgcode}): '
+                       f'{common_utils.format_exception(e)}')
+        raise AuthDBTimeoutError(reason) from e
+
 
 async def call_with_deadline(func: Callable[..., Any], *args: Any) -> Any:
     """Run a sync auth DB lookup on the auth executor with a total deadline.
 
-    Raises ``asyncio.TimeoutError`` when the deadline elapses and
-    ``ConcurrentWorkerExhaustedError`` when the executor is saturated.
+    Raises ``asyncio.TimeoutError`` when the deadline elapses (or when the
+    database cut the call off at its own, aligned timeout -- see
+    `_SERVER_TIMEOUT_PGCODES`) and ``ConcurrentWorkerExhaustedError`` when
+    the executor is saturated.
     """
-    return await asyncio.wait_for(context_utils.to_thread_with_executor(
-        executor.get_auth_thread_executor(), func, *args),
-                                  timeout=AUTH_DB_TIMEOUT_SECONDS)
+    return await _run_with_deadline(executor.get_auth_thread_executor(), func,
+                                    *args)
 
 
 async def _call_on_request_pool(func: Callable[..., Any], *args: Any) -> Any:
@@ -68,9 +124,8 @@ async def _call_on_request_pool(func: Callable[..., Any], *args: Any) -> Any:
     `POLICY_UPDATE_LOCK_TIMEOUT_SECONDS` would otherwise let a burst of first
     logins exhaust authentication for every other request on this worker.
     """
-    return await asyncio.wait_for(context_utils.to_thread_with_executor(
-        executor.get_request_thread_executor(), func, *args),
-                                  timeout=AUTH_DB_TIMEOUT_SECONDS)
+    return await _run_with_deadline(executor.get_request_thread_executor(),
+                                    func, *args)
 
 
 async def ensure_role_for_authenticated_user(

--- a/sky/server/auth/db_lookup.py
+++ b/sky/server/auth/db_lookup.py
@@ -56,7 +56,7 @@ AUTH_DB_TIMEOUT_SECONDS = float(
 _SERVER_TIMEOUT_PGCODES = {
     '55P03': 'lock_timeout',  # LockNotAvailable
     '57014': 'statement_timeout',  # QueryCanceled
-    '57P05': 'idle_in_transaction_session_timeout',
+    '25P03': 'idle_in_transaction_session_timeout',
 }
 
 

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -712,6 +712,12 @@ def override_request_env_and_config(
             # Remove the db connection uri from client supplied env vars, as
             # the client should not set the db string on server side.
             request_body.env_vars.pop(constants.ENV_VAR_DB_CONNECTION_URI, None)
+            # Likewise the auth DB deadline: `add_or_update_user` below derives
+            # the server-side timeouts on its own transaction from it, and a
+            # client (in particular an older one that still forwards the
+            # variable) must not be able to loosen or break them.
+            request_body.env_vars.pop(constants.ENV_VAR_AUTH_DB_TIMEOUT_SECONDS,
+                                      None)
             # Remove the in-cluster context name from client supplied env
             # vars. When a client runs inside a Kubernetes pod (e.g., a
             # managed job with api_server_access), its env has

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -103,6 +103,10 @@ def request_body_env_vars() -> dict:
     # Any new environment variables that are server-specific should
     # use SKYPILOT_SERVER_ENV_VAR_PREFIX.
     env_vars.pop(constants.ENV_VAR_DB_CONNECTION_URI, None)
+    # The auth DB deadline is a server-side setting: the server derives the
+    # timeouts it puts on its own users upsert from it, so a client must not
+    # be able to supply it.
+    env_vars.pop(constants.ENV_VAR_AUTH_DB_TIMEOUT_SECONDS, None)
     # Remove the in-cluster context name - this is only meaningful for the
     # local Kubernetes environment and should not be forwarded to the server,
     # which has its own cluster context configuration.

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -734,7 +734,8 @@ ENV_VAR_DB_POOL_HOSTPORT = (f'{SKYPILOT_ENV_VAR_PREFIX}DB_POOL_HOSTPORT')
 # from the same value (`sky.global_user_state.add_or_update_user`), so read
 # it through `sky.utils.db.db_utils.get_auth_db_timeout_seconds()` rather
 # than from the environment directly: that keeps the two from drifting
-# apart.
+# apart. Server-side only: it is stripped from client request payloads and
+# from the per-request environment overlay on the server.
 ENV_VAR_AUTH_DB_TIMEOUT_SECONDS = (
     f'{SKYPILOT_ENV_VAR_PREFIX}AUTH_DB_TIMEOUT_SECONDS')
 DEFAULT_AUTH_DB_TIMEOUT_SECONDS = 5.0

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -728,6 +728,17 @@ ENV_VAR_DB_POOL_CONNECTION_URI = (
     f'{SKYPILOT_ENV_VAR_PREFIX}DB_POOL_CONNECTION_URI')
 ENV_VAR_DB_POOL_HOSTPORT = (f'{SKYPILOT_ENV_VAR_PREFIX}DB_POOL_HOSTPORT')
 
+# Total deadline, in seconds, on each DB lookup the API server's
+# authentication middlewares make (`sky.server.auth.db_lookup`). The users
+# upsert derives the server-side timeouts it sets on its own transaction
+# from the same value (`sky.global_user_state.add_or_update_user`), so read
+# it through `sky.utils.db.db_utils.get_auth_db_timeout_seconds()` rather
+# than from the environment directly: that keeps the two from drifting
+# apart.
+ENV_VAR_AUTH_DB_TIMEOUT_SECONDS = (
+    f'{SKYPILOT_ENV_VAR_PREFIX}AUTH_DB_TIMEOUT_SECONDS')
+DEFAULT_AUTH_DB_TIMEOUT_SECONDS = 5.0
+
 # Environment variable that is set to 'true' if basic
 # authentication is enabled in the API server.
 ENV_VAR_ENABLE_BASIC_AUTH = 'ENABLE_BASIC_AUTH'

--- a/sky/utils/db/db_utils.py
+++ b/sky/utils/db/db_utils.py
@@ -2,6 +2,7 @@
 import asyncio
 import contextlib
 import enum
+import math
 import os
 import pathlib
 import sqlite3
@@ -612,6 +613,41 @@ def _pooler_configured() -> bool:
     return bool(
         os.environ.get(constants.ENV_VAR_DB_POOL_CONNECTION_URI) or
         os.environ.get(constants.ENV_VAR_DB_POOL_HOSTPORT))
+
+
+def get_auth_db_timeout_seconds() -> float:
+    """The deadline on the API server's auth-path DB calls, in seconds.
+
+    Read from ``constants.ENV_VAR_AUTH_DB_TIMEOUT_SECONDS`` (default
+    ``constants.DEFAULT_AUTH_DB_TIMEOUT_SECONDS``). This is the single
+    source for that value: ``sky.server.auth.db_lookup`` uses it as the
+    client-side ``asyncio.wait_for`` deadline on every auth DB lookup, and
+    ``sky.global_user_state.add_or_update_user`` derives the server-side
+    ``SET LOCAL`` timeouts on the users upsert from it, so the database
+    always gives up at or before the caller does. The environment is read
+    on each call (a cheap lookup) so tests can vary it.
+
+    Raises:
+        ValueError: if the variable is set but is not a positive, finite
+            number of seconds. A non-positive deadline would fail every
+            auth call client-side, and as a Postgres timeout ``0`` means
+            *disabled* (and a negative value is rejected), so such a value
+            is refused loudly rather than silently substituted.
+    """
+    raw = os.environ.get(constants.ENV_VAR_AUTH_DB_TIMEOUT_SECONDS)
+    if raw is None:
+        return constants.DEFAULT_AUTH_DB_TIMEOUT_SECONDS
+    try:
+        seconds = float(raw)
+    except ValueError:
+        raise ValueError(
+            f'{constants.ENV_VAR_AUTH_DB_TIMEOUT_SECONDS}={raw!r} is not a '
+            'number of seconds.') from None
+    if not (math.isfinite(seconds) and seconds > 0):
+        raise ValueError(
+            f'{constants.ENV_VAR_AUTH_DB_TIMEOUT_SECONDS}={raw!r} must be a '
+            'positive, finite number of seconds.')
+    return seconds
 
 
 # Bound on the connect phase of a no_pool engine. Unlike a pooled checkout,

--- a/sky/utils/db/db_utils.py
+++ b/sky/utils/db/db_utils.py
@@ -615,6 +615,14 @@ def _pooler_configured() -> bool:
         os.environ.get(constants.ENV_VAR_DB_POOL_HOSTPORT))
 
 
+# Postgres timeout settings (lock_timeout, statement_timeout,
+# idle_in_transaction_session_timeout) are 32-bit signed milliseconds, so the
+# largest deadline whose derived timeouts the database still accepts is
+# 2147483.647 s; anything above that would make every users upsert fail on
+# the SET LOCAL itself.
+AUTH_DB_TIMEOUT_MAX_SECONDS = 2147483
+
+
 def get_auth_db_timeout_seconds() -> float:
     """The deadline on the API server's auth-path DB calls, in seconds.
 
@@ -625,14 +633,20 @@ def get_auth_db_timeout_seconds() -> float:
     ``sky.global_user_state.add_or_update_user`` derives the server-side
     ``SET LOCAL`` timeouts on the users upsert from it, so the database
     always gives up at or before the caller does. The environment is read
-    on each call (a cheap lookup) so tests can vary it.
+    on each call (a cheap lookup) so tests can vary it; that read always
+    sees the server's own setting, because the variable is stripped from
+    client request payloads (`payloads.request_body_env_vars`) and again
+    from the per-request environment overlay on the server
+    (`executor.override_request_env_and_config`).
 
     Raises:
         ValueError: if the variable is set but is not a positive, finite
-            number of seconds. A non-positive deadline would fail every
-            auth call client-side, and as a Postgres timeout ``0`` means
-            *disabled* (and a negative value is rejected), so such a value
-            is refused loudly rather than silently substituted.
+            number of seconds no greater than
+            ``AUTH_DB_TIMEOUT_MAX_SECONDS``. A non-positive deadline would
+            fail every auth call client-side, and as a Postgres timeout
+            ``0`` means *disabled* (and a negative value is rejected), so
+            such a value is refused loudly rather than silently substituted;
+            a larger one would exceed Postgres' millisecond range.
     """
     raw = os.environ.get(constants.ENV_VAR_AUTH_DB_TIMEOUT_SECONDS)
     if raw is None:
@@ -643,10 +657,12 @@ def get_auth_db_timeout_seconds() -> float:
         raise ValueError(
             f'{constants.ENV_VAR_AUTH_DB_TIMEOUT_SECONDS}={raw!r} is not a '
             'number of seconds.') from None
-    if not (math.isfinite(seconds) and seconds > 0):
+    if not (math.isfinite(seconds) and
+            0 < seconds <= AUTH_DB_TIMEOUT_MAX_SECONDS):
         raise ValueError(
             f'{constants.ENV_VAR_AUTH_DB_TIMEOUT_SECONDS}={raw!r} must be a '
-            'positive, finite number of seconds.')
+            'positive, finite number of seconds, at most '
+            f'{AUTH_DB_TIMEOUT_MAX_SECONDS}.')
     return seconds
 
 

--- a/tests/unit_tests/test_sky/server/requests/test_executor.py
+++ b/tests/unit_tests/test_sky/server/requests/test_executor.py
@@ -13,6 +13,7 @@ from unittest import mock
 import pytest
 
 from sky import exceptions
+from sky import global_user_state
 from sky import skypilot_config
 from sky.server import config as server_config
 from sky.server import constants as server_constants
@@ -25,6 +26,7 @@ from sky.server.requests import process
 from sky.server.requests import requests as requests_lib
 from sky.skylet import constants
 from sky.utils import context_utils
+from sky.utils.db import db_utils
 
 
 @pytest.fixture()
@@ -1521,6 +1523,42 @@ def test_override_env_applied_for_client_request(stub_override_request_env_deps,
             body, request_id='not-a-daemon-uuid', request_name='sky.launch'):
         assert os.environ['SKYPILOT_POD_MEMORY_BYTES_LIMIT'] == str(100 * 1024 *
                                                                     1024)
+
+
+@pytest.mark.parametrize('server_value', [None, '8'])
+def test_client_cannot_override_auth_db_timeout(stub_override_request_env_deps,
+                                                monkeypatch, server_value):
+    """A client-supplied SKYPILOT_AUTH_DB_TIMEOUT_SECONDS is dropped.
+
+    The users upsert inside the overlay derives its server-side SET LOCAL
+    timeouts from that variable at call time, so a client (an older one
+    still forwards every SKYPILOT_* variable) must not be able to loosen
+    or break them: the worker keeps the server's own setting, or none.
+    """
+    if server_value is None:
+        monkeypatch.delenv(constants.ENV_VAR_AUTH_DB_TIMEOUT_SECONDS,
+                           raising=False)
+    else:
+        monkeypatch.setenv(constants.ENV_VAR_AUTH_DB_TIMEOUT_SECONDS,
+                           server_value)
+    expected_deadline = db_utils.get_auth_db_timeout_seconds()
+    expected_timeouts = global_user_state._user_upsert_timeouts_ms()  # pylint: disable=protected-access
+
+    body = payloads.RequestBody(
+        env_vars={
+            constants.ENV_VAR_AUTH_DB_TIMEOUT_SECONDS: '1000000',
+            constants.USER_ID_ENV_VAR: 'client-user-id',
+            constants.USER_ENV_VAR: 'client-user',
+        })
+
+    with executor.override_request_env_and_config(
+            body, request_id='not-a-daemon-uuid', request_name='sky.launch'):
+        assert os.environ.get(
+            constants.ENV_VAR_AUTH_DB_TIMEOUT_SECONDS) == server_value
+        assert db_utils.get_auth_db_timeout_seconds() == expected_deadline
+        assert (global_user_state._user_upsert_timeouts_ms()  # pylint: disable=protected-access
+                == expected_timeouts)
+    assert constants.ENV_VAR_AUTH_DB_TIMEOUT_SECONDS not in body.env_vars
 
 
 def test_daemon_env_mutations_reverted_on_exit(stub_override_request_env_deps,

--- a/tests/unit_tests/test_sky/server/requests/test_payloads.py
+++ b/tests/unit_tests/test_sky/server/requests/test_payloads.py
@@ -16,6 +16,7 @@ def test_request_body_env_vars_includes_expected_keys(monkeypatch):
     monkeypatch.setenv(skypilot_config.ENV_VAR_PROJECT_CONFIG,
                        '/tmp/project.yaml')
     monkeypatch.setenv(constants.ENV_VAR_DB_CONNECTION_URI, 'db-uri')
+    monkeypatch.setenv(constants.ENV_VAR_AUTH_DB_TIMEOUT_SECONDS, '1000000')
 
     monkeypatch.setattr(payloads.common, 'is_api_server_local', lambda: True)
     local_env = payloads.request_body_env_vars()
@@ -23,6 +24,9 @@ def test_request_body_env_vars_includes_expected_keys(monkeypatch):
     assert local_env[
         skypilot_config.ENV_VAR_SKYPILOT_CONFIG] == '/tmp/config.yaml'
     assert constants.ENV_VAR_DB_CONNECTION_URI not in local_env
+    # Server-side setting: the server derives the timeouts on its own users
+    # upsert from it, so a client must never supply it.
+    assert constants.ENV_VAR_AUTH_DB_TIMEOUT_SECONDS not in local_env
     assert skypilot_config.ENV_VAR_GLOBAL_CONFIG not in local_env
     assert skypilot_config.ENV_VAR_PROJECT_CONFIG not in local_env
 
@@ -33,6 +37,7 @@ def test_request_body_env_vars_includes_expected_keys(monkeypatch):
     assert skypilot_config.ENV_VAR_GLOBAL_CONFIG not in remote_env
     assert skypilot_config.ENV_VAR_PROJECT_CONFIG not in remote_env
     assert constants.CLIENT_USER_HASH_ENV_VAR not in remote_env
+    assert constants.ENV_VAR_AUTH_DB_TIMEOUT_SECONDS not in remote_env
 
 
 def test_request_body_env_vars_client_user_hash_with_basic_auth(monkeypatch):

--- a/tests/unit_tests/test_sky/server/test_auth_db_deadline.py
+++ b/tests/unit_tests/test_sky/server/test_auth_db_deadline.py
@@ -27,6 +27,8 @@ These tests pin the containment behavior:
   error still propagates unchanged.
 """
 
+# pylint: disable=protected-access,redefined-outer-name,missing-class-docstring
+
 import asyncio
 import os
 import time
@@ -83,7 +85,8 @@ def mock_request():
 def call_next_sentinel():
     """call_next that records whether the request reached the router."""
 
-    async def call_next(_request):
+    async def call_next(request):
+        del request  # unused
         call_next.reached = True
         return fastapi.responses.JSONResponse({'message': 'success'})
 

--- a/tests/unit_tests/test_sky/server/test_auth_db_deadline.py
+++ b/tests/unit_tests/test_sky/server/test_auth_db_deadline.py
@@ -19,7 +19,12 @@ These tests pin the containment behavior:
   not retry;
 * the basic-auth path on ``/api/health`` stays best-effort: probes must
   survive a DB incident, so it proceeds unauthenticated instead of
-  failing.
+  failing;
+* a lookup the *database* cut off at one of the server-side timeouts the
+  auth path sets on its own transaction (``lock_timeout``,
+  ``statement_timeout``, ``idle_in_transaction_session_timeout``) gets the
+  same retryable 503 as the client-side deadline, while every other DB
+  error still propagates unchanged.
 """
 
 import asyncio
@@ -29,6 +34,7 @@ import unittest.mock as mock
 
 import fastapi
 import pytest
+import sqlalchemy.exc
 
 from sky import exceptions
 from sky import models
@@ -478,3 +484,169 @@ class TestEnsureRoleForAuthenticatedUser:
         # contention on the policy lock, a healthy database doing its job.
         assert b'assigning roles' in response.body
         perm.queue_role_repair.assert_called_once_with('u-broken')
+
+
+class _PgError(Exception):
+    """Stand-in for a psycopg2 error: carries the SQLSTATE as ``pgcode``.
+
+    Duck-typed on purpose -- `db_lookup` must not depend on psycopg2 (a
+    server-only extra), and a manually constructed psycopg2 error has no
+    pgcode anyway; only the C layer sets it from a real server reply.
+    """
+
+    def __init__(self, pgcode, message):
+        super().__init__(message)
+        self.pgcode = pgcode
+
+
+def _raises_db_error(pgcode, message='canceling statement due to timeout'):
+    """A synchronous stand-in for a DB call the database itself cut off."""
+
+    def _call(*args, **kwargs):
+        del args, kwargs
+        raise sqlalchemy.exc.OperationalError('INSERT INTO users ...', {},
+                                              _PgError(pgcode, message))
+
+    return _call
+
+
+# The three timeouts `global_user_state.add_or_update_user` sets on its own
+# Postgres transaction, and the SQLSTATE each produces.
+_SERVER_TIMEOUT_PGCODES = (
+    '55P03',  # lock_timeout: lock_not_available
+    '57014',  # statement_timeout: query_canceled
+    '57P05',  # idle_in_transaction_session_timeout (next statement)
+)
+
+
+class TestServerSideTimeoutMapping:
+    """A DB-side timeout on the auth path is the deadline path's 503."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize('pgcode', _SERVER_TIMEOUT_PGCODES)
+    async def test_server_timeout_pgcodes_become_timeout_errors(
+            self, monkeypatch, pgcode):
+        # The database gives up well before the client deadline here.
+        monkeypatch.setattr(db_lookup, 'AUTH_DB_TIMEOUT_SECONDS', 5)
+        with pytest.raises(asyncio.TimeoutError) as excinfo:
+            await db_lookup.call_with_deadline(_raises_db_error(pgcode))
+        assert isinstance(excinfo.value, db_lookup.AuthDBTimeoutError)
+        # The original DB error is kept as the cause for the log/debugging.
+        assert isinstance(excinfo.value.__cause__,
+                          sqlalchemy.exc.OperationalError)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize('pgcode', _SERVER_TIMEOUT_PGCODES)
+    async def test_request_pool_variant_maps_the_same_way(
+            self, monkeypatch, pgcode):
+        monkeypatch.setattr(db_lookup, 'AUTH_DB_TIMEOUT_SECONDS', 5)
+        with pytest.raises(asyncio.TimeoutError):
+            await db_lookup._call_on_request_pool(_raises_db_error(pgcode))
+
+    @pytest.mark.asyncio
+    async def test_raw_driver_error_with_pgcode_is_mapped_too(
+            self, monkeypatch):
+        """Raw connections raise the driver error unwrapped (no `.orig`)."""
+        monkeypatch.setattr(db_lookup, 'AUTH_DB_TIMEOUT_SECONDS', 5)
+
+        def _raw(*args, **kwargs):
+            del args, kwargs
+            raise _PgError('55P03', 'lock timeout')
+
+        with pytest.raises(asyncio.TimeoutError):
+            await db_lookup.call_with_deadline(_raw)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        'pgcode',
+        [
+            '23505',  # unique_violation: a real data error
+            '08006',  # connection_failure
+            '40P01',  # deadlock_detected
+            None,  # driver error with no SQLSTATE (e.g. socket EBADF)
+        ])
+    async def test_other_db_errors_still_propagate_unchanged(
+            self, monkeypatch, pgcode):
+        """The mapping is narrow: only the aligned server-side timeouts."""
+        monkeypatch.setattr(db_lookup, 'AUTH_DB_TIMEOUT_SECONDS', 5)
+        with pytest.raises(sqlalchemy.exc.OperationalError) as excinfo:
+            await db_lookup.call_with_deadline(_raises_db_error(pgcode))
+        assert not isinstance(excinfo.value, asyncio.TimeoutError)
+
+    @pytest.mark.asyncio
+    async def test_non_db_errors_still_propagate_unchanged(self, monkeypatch):
+        monkeypatch.setattr(db_lookup, 'AUTH_DB_TIMEOUT_SECONDS', 5)
+
+        def _boom(*args, **kwargs):
+            del args, kwargs
+            raise RuntimeError('not a database error')
+
+        with pytest.raises(RuntimeError):
+            await db_lookup.call_with_deadline(_boom)
+
+    @pytest.mark.asyncio
+    async def test_exhaustion_is_not_swallowed_by_the_mapping(
+            self, monkeypatch):
+        monkeypatch.setattr(db_lookup, 'AUTH_DB_TIMEOUT_SECONDS', 5)
+        exhausted = threads.OnDemandThreadExecutor(name='test-exhausted-map',
+                                                   max_workers=0)
+        with mock.patch.object(db_lookup.executor,
+                               'get_auth_thread_executor',
+                               return_value=exhausted):
+            with pytest.raises(exceptions.ConcurrentWorkerExhaustedError):
+                await db_lookup.call_with_deadline(lambda: 'never runs')
+
+    @pytest.mark.asyncio
+    async def test_auth_proxy_upsert_cut_off_by_lock_timeout_is_503(
+            self, monkeypatch, mock_request, call_next_sentinel):
+        """The incident shape: the users row is locked by another session
+        and this request's upsert waits. With `lock_timeout` set on the
+        transaction the database fails the wait (55P03) and the thread is
+        freed; the client must see the same retryable 503 as a deadline."""
+        monkeypatch.setattr(db_lookup, 'AUTH_DB_TIMEOUT_SECONDS', 5)
+        proxy_config = mock.Mock()
+        proxy_config.enabled = True
+        with mock.patch.object(server.server_config,
+                               'load_external_proxy_config',
+                               return_value=proxy_config):
+            middleware = server.AuthProxyMiddleware(app=mock.Mock())
+
+        with mock.patch.object(
+                server,
+                '_extract_user_from_header',
+                return_value=models.User(id='u-1', name='tester')), \
+                mock.patch(
+                    'sky.global_user_state.add_or_update_user',
+                    _raises_db_error(
+                        '55P03',
+                        'canceling statement due to lock timeout')):
+            response = await middleware.dispatch(mock_request,
+                                                 call_next_sentinel)
+
+        _assert_retryable_timeout_503(response)
+        assert not call_next_sentinel.reached
+
+    @pytest.mark.asyncio
+    async def test_bearer_token_lookup_cut_off_by_statement_timeout_is_503(
+            self, monkeypatch, mock_request, call_next_sentinel):
+        monkeypatch.setattr(db_lookup, 'AUTH_DB_TIMEOUT_SECONDS', 5)
+        mock_request.headers = {'authorization': 'Bearer sky_token'}
+        middleware = server.BearerTokenMiddleware(app=mock.Mock())
+
+        with mock.patch.dict(
+                os.environ,
+            {constants.ENV_VAR_ENABLE_SERVICE_ACCOUNTS: 'true'}), \
+                mock.patch('sky.users.token_service.token_service') as tks, \
+                mock.patch(
+                    'sky.global_user_state.get_service_account_token_by_hash',
+                    _raises_db_error('57014')):
+            tks.verify_token.return_value = {
+                'sub': 'sa-1',
+                'name': 'sa',
+                'token_id': 'tok-1'
+            }
+            response = await middleware.dispatch(mock_request,
+                                                 call_next_sentinel)
+
+        _assert_retryable_timeout_503(response)
+        assert not call_next_sentinel.reached

--- a/tests/unit_tests/test_sky/server/test_auth_db_deadline.py
+++ b/tests/unit_tests/test_sky/server/test_auth_db_deadline.py
@@ -518,7 +518,7 @@ def _raises_db_error(pgcode, message='canceling statement due to timeout'):
 _SERVER_TIMEOUT_PGCODES = (
     '55P03',  # lock_timeout: lock_not_available
     '57014',  # statement_timeout: query_canceled
-    '57P05',  # idle_in_transaction_session_timeout (next statement)
+    '25P03',  # idle_in_transaction_session_timeout (next statement)
 )
 
 

--- a/tests/unit_tests/test_sky/test_global_user_state_user_upsert_timeouts.py
+++ b/tests/unit_tests/test_sky/test_global_user_state_user_upsert_timeouts.py
@@ -1,0 +1,246 @@
+"""The users upsert bounds its own Postgres transaction with SET LOCAL timeouts.
+
+`add_or_update_user` runs on the request authentication path under a
+client-side deadline (`sky.server.auth.db_lookup.AUTH_DB_TIMEOUT_SECONDS`)
+that frees the caller but not the executor thread. On Postgres the function
+therefore also asks the database to give up: `SET LOCAL lock_timeout /
+statement_timeout / idle_in_transaction_session_timeout`, issued as the
+first statements of the transaction so they cover the upsert. `SET LOCAL` is
+transaction-scoped, so it resets at COMMIT and is safe through a
+transaction-mode connection pooler.
+
+These tests pin:
+
+* Postgres: the three SET LOCAL statements are the first statements issued,
+  on the same session (hence inside the same auto-begun transaction) as the
+  upsert, and the values stay at or below the auth deadline;
+* SQLite: no SET LOCAL at all (unsupported there); behavior unchanged.
+"""
+
+# pylint: disable=protected-access,redefined-outer-name,missing-class-docstring
+from unittest import mock
+
+import pytest
+import sqlalchemy
+from sqlalchemy import event
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.sql import elements
+
+from sky import global_user_state
+from sky import models
+from sky.server.auth import db_lookup
+from sky.skylet import constants
+from sky.utils.db import db_utils
+
+_EXPECTED_SET_LOCAL = (
+    f'SET LOCAL lock_timeout = '
+    f'\'{global_user_state._USER_UPSERT_LOCK_TIMEOUT_MS}ms\'',
+    f'SET LOCAL statement_timeout = '
+    f'\'{global_user_state._USER_UPSERT_STATEMENT_TIMEOUT_MS}ms\'',
+    f'SET LOCAL idle_in_transaction_session_timeout = '
+    f'\'{global_user_state._USER_UPSERT_IDLE_IN_TRANSACTION_TIMEOUT_MS}ms\'',
+)
+
+
+class _RecordingSession:
+    """Stand-in for `orm.Session` that records what is executed, in order.
+
+    A query issued through `session.query(...)` is recorded as the string
+    'QUERY' so its position relative to the SET LOCAL statements is visible.
+    """
+
+    def __init__(self):
+        self.statements = []
+        self.commit_after = None
+
+    def execute(self, statement):
+        self.statements.append(statement)
+        result = mock.Mock()
+        result.fetchone.return_value = mock.Mock(id='u-1',
+                                                 name='tester',
+                                                 password=None,
+                                                 created_at=1,
+                                                 type=None,
+                                                 preferred_workspace=None,
+                                                 was_inserted=True)
+        result.rowcount = 1
+        return result
+
+    def query(self, *args, **kwargs):
+        del args, kwargs
+        self.statements.append('QUERY')
+        chain = mock.Mock()
+        chain.filter.return_value.first.return_value = None
+        chain.filter_by.return_value.first.return_value = None
+        return chain
+
+    def commit(self):
+        self.commit_after = len(self.statements)
+
+
+@pytest.fixture
+def postgres_session():
+    """`add_or_update_user` against a fake Postgres engine + recording session.
+
+    The engine is a mock whose dialect says Postgres; the ORM session is the
+    recorder above, so the test sees exactly which statements the function
+    issues and in what order, without a live database.
+    """
+    engine = mock.Mock()
+    engine.dialect.name = db_utils.SQLAlchemyDialect.POSTGRESQL.value
+    session = _RecordingSession()
+    with mock.patch.object(global_user_state._db_manager, '_engine', engine), \
+            mock.patch('sky.global_user_state.orm.Session') as session_cls:
+        session_cls.return_value.__enter__.return_value = session
+        yield session
+
+
+def _set_local_texts(statements):
+    return [
+        str(s)
+        for s in statements
+        if isinstance(s, elements.TextClause) and str(s).startswith('SET LOCAL')
+    ]
+
+
+class TestPostgresUpsertIsBounded:
+
+    def test_set_local_timeouts_precede_the_upsert_in_one_session(
+            self, postgres_session):
+        global_user_state.add_or_update_user(
+            models.User(id='u-1', name='tester'))
+
+        statements = postgres_session.statements
+        # Exactly the three SET LOCALs, first, in this order.
+        assert _set_local_texts(statements[:3]) == list(_EXPECTED_SET_LOCAL)
+        # Then the upsert itself, then COMMIT -- all on the same session, so
+        # SQLAlchemy's autobegin puts the SET LOCALs and the INSERT in one
+        # transaction and COMMIT resets the timeouts.
+        assert len(statements) == 4
+        assert isinstance(statements[3], postgresql.Insert)
+        assert statements[3].table is global_user_state.user_table
+        assert postgres_session.commit_after == 4
+
+    def test_set_local_comes_before_the_duplicate_name_check_too(
+            self, postgres_session):
+        """With allow_duplicate_name=False the first statement is a SELECT;
+        the timeouts must still be issued before it, or the SELECT (which
+        can wait on the same row lock) runs unbounded."""
+        global_user_state.add_or_update_user(models.User(id='u-1',
+                                                         name='tester'),
+                                             allow_duplicate_name=False)
+
+        statements = postgres_session.statements
+        assert _set_local_texts(statements[:3]) == list(_EXPECTED_SET_LOCAL)
+        assert statements[3] == 'QUERY'
+        assert isinstance(statements[4], postgresql.Insert)
+
+    def test_set_local_is_issued_through_the_session_not_a_hook(
+            self, postgres_session):
+        """Issued via `session.execute(text(...))`, so a failure (e.g. the
+        pooler never assigns a server) surfaces through SQLAlchemy's normal
+        error handling, not from inside an engine event listener."""
+        global_user_state.add_or_update_user(
+            models.User(id='u-1', name='tester'))
+        for statement in postgres_session.statements[:3]:
+            assert isinstance(statement, elements.TextClause)
+
+    def test_no_bind_parameters_in_set_local(self, postgres_session):
+        """SET does not accept bind parameters; the values are literals."""
+        global_user_state.add_or_update_user(
+            models.User(id='u-1', name='tester'))
+        for statement in postgres_session.statements[:3]:
+            assert not statement.compile().params
+
+
+class TestTimeoutValues:
+    """The server-side bounds must be at or below the caller's deadline."""
+
+    def test_values_are_at_or_below_the_auth_deadline(self):
+        deadline_ms = db_lookup.AUTH_DB_TIMEOUT_SECONDS * 1000
+        assert global_user_state._USER_UPSERT_LOCK_TIMEOUT_MS <= deadline_ms
+        assert (global_user_state._USER_UPSERT_STATEMENT_TIMEOUT_MS <=
+                deadline_ms)
+        assert (global_user_state._USER_UPSERT_IDLE_IN_TRANSACTION_TIMEOUT_MS <=
+                deadline_ms)
+
+    def test_lock_timeout_wins_over_statement_timeout(self):
+        """Lower lock_timeout so a row-lock wait reports the distinct
+        'lock not available' error (55P03) rather than a generic cancel."""
+        assert (global_user_state._USER_UPSERT_LOCK_TIMEOUT_MS <
+                global_user_state._USER_UPSERT_STATEMENT_TIMEOUT_MS)
+
+    def test_idle_in_transaction_is_the_largest(self):
+        """It terminates the session, so it must only fire for a session that
+        has really gone quiet mid-transaction, after the statement bounds."""
+        assert (global_user_state._USER_UPSERT_IDLE_IN_TRANSACTION_TIMEOUT_MS >=
+                global_user_state._USER_UPSERT_STATEMENT_TIMEOUT_MS)
+
+
+def _fresh_sqlite_db(tmp_path, monkeypatch):
+    """Point the global state DB at a tmp sqlite file (real engine)."""
+    monkeypatch.setenv(constants.SKY_RUNTIME_DIR_ENV_VAR_KEY, str(tmp_path))
+    monkeypatch.setattr(
+        global_user_state,
+        '_db_manager',
+        db_utils.DatabaseManager(
+            'state',
+            global_user_state.create_table,
+            post_init_fn=lambda _: global_user_state._sqlite_supports_returning(
+            ),
+        ),
+    )
+    return global_user_state._db_manager.get_engine()
+
+
+class TestSqliteUpsertIsUnchanged:
+
+    def test_sqlite_issues_no_set_local(self, tmp_path, monkeypatch):
+        engine = _fresh_sqlite_db(tmp_path, monkeypatch)
+        assert engine.dialect.name == db_utils.SQLAlchemyDialect.SQLITE.value
+        executed = []
+
+        def _capture(conn, cursor, statement, parameters, context, executemany):
+            del conn, cursor, parameters, context, executemany
+            executed.append(statement)
+
+        event.listen(engine, 'before_cursor_execute', _capture)
+        try:
+            newly_added = global_user_state.add_or_update_user(
+                models.User(id='u-sqlite', name='tester'))
+            again = global_user_state.add_or_update_user(
+                models.User(id='u-sqlite', name='tester-renamed'))
+        finally:
+            event.remove(engine, 'before_cursor_execute', _capture)
+
+        assert newly_added is True
+        assert again is False
+        assert executed, 'the upsert must have reached the database'
+        assert not [s for s in executed if 'SET LOCAL' in s.upper()]
+        stored = global_user_state.get_user('u-sqlite')
+        assert stored is not None and stored.name == 'tester-renamed'
+
+    def test_sqlite_engine_is_not_asked_for_postgres_settings(
+            self, tmp_path, monkeypatch):
+        """Belt and braces: SET LOCAL is a syntax error on SQLite, so the
+        Postgres-only helper must never see a SQLite session."""
+        _fresh_sqlite_db(tmp_path, monkeypatch)
+        with mock.patch.object(global_user_state,
+                               '_bound_user_upsert_transaction') as bound:
+            global_user_state.add_or_update_user(
+                models.User(id='u-sqlite-2', name='tester'))
+        bound.assert_not_called()
+
+
+def test_set_local_statement_text_is_valid_sql():
+    """Compile the statements as Postgres SQL (no live DB): each is exactly
+    one `SET LOCAL <parameter> = '<n>ms'`."""
+    session = _RecordingSession()
+    global_user_state._bound_user_upsert_transaction(session)
+    compiled = [
+        str(s.compile(dialect=postgresql.dialect())) for s in session.statements
+    ]
+    assert compiled == list(_EXPECTED_SET_LOCAL)
+    for text in compiled:
+        assert ';' not in text
+        assert isinstance(sqlalchemy.text(text), elements.TextClause)

--- a/tests/unit_tests/test_sky/test_global_user_state_user_upsert_timeouts.py
+++ b/tests/unit_tests/test_sky/test_global_user_state_user_upsert_timeouts.py
@@ -195,13 +195,28 @@ class TestAuthDbTimeoutSetting:
         monkeypatch.setenv(_DEADLINE_ENV, raw)
         assert db_utils.get_auth_db_timeout_seconds() == expected
 
-    @pytest.mark.parametrize('raw', ['abc', '', '0', '-1', 'nan', 'inf'])
+    @pytest.mark.parametrize('raw',
+                             ['abc', '', '0', '-1', 'nan', 'inf', '2147484'])
     def test_nonsensical_values_are_refused_loudly(self, monkeypatch, raw):
         """Not silently replaced by the default: a non-positive deadline
-        would fail every auth call, and `0` disables a Postgres timeout."""
+        would fail every auth call, `0` disables a Postgres timeout, and a
+        deadline above Postgres' 32-bit millisecond range would make the
+        SET LOCAL itself fail on every upsert."""
         monkeypatch.setenv(_DEADLINE_ENV, raw)
         with pytest.raises(ValueError, match=_DEADLINE_ENV):
             db_utils.get_auth_db_timeout_seconds()
+
+    def test_largest_accepted_deadline_fits_postgres_milliseconds(
+            self, monkeypatch):
+        """Boundary: the largest accepted value derives timeouts that are
+        still valid Postgres settings (<= 2147483647 ms); one more second
+        is refused (see above)."""
+        monkeypatch.setenv(_DEADLINE_ENV,
+                           str(db_utils.AUTH_DB_TIMEOUT_MAX_SECONDS))
+        assert (db_utils.get_auth_db_timeout_seconds() ==
+                db_utils.AUTH_DB_TIMEOUT_MAX_SECONDS)
+        for value_ms in global_user_state._user_upsert_timeouts_ms():
+            assert 0 < value_ms <= 2147483647
 
     def test_db_lookup_deadline_comes_from_the_same_source(self):
         """`db_lookup.AUTH_DB_TIMEOUT_SECONDS` is read at import through the

--- a/tests/unit_tests/test_sky/test_global_user_state_user_upsert_timeouts.py
+++ b/tests/unit_tests/test_sky/test_global_user_state_user_upsert_timeouts.py
@@ -9,15 +9,27 @@ first statements of the transaction so they cover the upsert. `SET LOCAL` is
 transaction-scoped, so it resets at COMMIT and is safe through a
 transaction-mode connection pooler.
 
+The three values are derived from the configured deadline
+(`SKYPILOT_AUTH_DB_TIMEOUT_SECONDS`, default 5 s), which both modules read
+through the one helper `db_utils.get_auth_db_timeout_seconds()`.
+
 These tests pin:
 
 * Postgres: the three SET LOCAL statements are the first statements issued,
   on the same session (hence inside the same auto-begun transaction) as the
-  upsert, and the values stay at or below the auth deadline;
+  upsert;
+* the values: exactly 3900 / 4000 / 5000 ms at the default deadline (the
+  values a deployment on the default already runs with), derived from the
+  configured deadline otherwise, always `lock < statement < idle <= deadline`,
+  and read from the same source as `db_lookup.AUTH_DB_TIMEOUT_SECONDS`; a
+  nonsensical setting is refused loudly instead of reaching the database;
 * SQLite: no SET LOCAL at all (unsupported there); behavior unchanged.
 """
 
 # pylint: disable=protected-access,redefined-outer-name,missing-class-docstring
+import os
+import subprocess
+import sys
 from unittest import mock
 
 import pytest
@@ -32,14 +44,18 @@ from sky.server.auth import db_lookup
 from sky.skylet import constants
 from sky.utils.db import db_utils
 
-_EXPECTED_SET_LOCAL = (
-    f'SET LOCAL lock_timeout = '
-    f'\'{global_user_state._USER_UPSERT_LOCK_TIMEOUT_MS}ms\'',
-    f'SET LOCAL statement_timeout = '
-    f'\'{global_user_state._USER_UPSERT_STATEMENT_TIMEOUT_MS}ms\'',
-    f'SET LOCAL idle_in_transaction_session_timeout = '
-    f'\'{global_user_state._USER_UPSERT_IDLE_IN_TRANSACTION_TIMEOUT_MS}ms\'',
-)
+_DEADLINE_ENV = constants.ENV_VAR_AUTH_DB_TIMEOUT_SECONDS
+
+
+def _expected_set_local():
+    """The three statements the upsert must issue, for the current env."""
+    lock_ms, statement_ms, idle_ms = global_user_state._user_upsert_timeouts_ms(
+    )
+    return [
+        f'SET LOCAL lock_timeout = \'{lock_ms}ms\'',
+        f'SET LOCAL statement_timeout = \'{statement_ms}ms\'',
+        f'SET LOCAL idle_in_transaction_session_timeout = \'{idle_ms}ms\'',
+    ]
 
 
 class _RecordingSession:
@@ -112,7 +128,7 @@ class TestPostgresUpsertIsBounded:
 
         statements = postgres_session.statements
         # Exactly the three SET LOCALs, first, in this order.
-        assert _set_local_texts(statements[:3]) == list(_EXPECTED_SET_LOCAL)
+        assert _set_local_texts(statements[:3]) == _expected_set_local()
         # Then the upsert itself, then COMMIT -- all on the same session, so
         # SQLAlchemy's autobegin puts the SET LOCALs and the INSERT in one
         # transaction and COMMIT resets the timeouts.
@@ -131,7 +147,7 @@ class TestPostgresUpsertIsBounded:
                                              allow_duplicate_name=False)
 
         statements = postgres_session.statements
-        assert _set_local_texts(statements[:3]) == list(_EXPECTED_SET_LOCAL)
+        assert _set_local_texts(statements[:3]) == _expected_set_local()
         assert statements[3] == 'QUERY'
         assert isinstance(statements[4], postgresql.Insert)
 
@@ -152,29 +168,146 @@ class TestPostgresUpsertIsBounded:
         for statement in postgres_session.statements[:3]:
             assert not statement.compile().params
 
+    def test_values_follow_the_configured_deadline(self, postgres_session,
+                                                   monkeypatch):
+        """The statements the database receives carry the derived values."""
+        monkeypatch.setenv(_DEADLINE_ENV, '8')
+        global_user_state.add_or_update_user(
+            models.User(id='u-1', name='tester'))
+        assert _set_local_texts(postgres_session.statements[:3]) == [
+            'SET LOCAL lock_timeout = \'6240ms\'',
+            'SET LOCAL statement_timeout = \'6400ms\'',
+            'SET LOCAL idle_in_transaction_session_timeout = \'8000ms\'',
+        ]
+
+
+class TestAuthDbTimeoutSetting:
+    """`get_auth_db_timeout_seconds` is the one source of the deadline."""
+
+    def test_default_is_five_seconds(self, monkeypatch):
+        monkeypatch.delenv(_DEADLINE_ENV, raising=False)
+        assert db_utils.get_auth_db_timeout_seconds() == 5.0
+        assert constants.DEFAULT_AUTH_DB_TIMEOUT_SECONDS == 5.0
+
+    @pytest.mark.parametrize('raw, expected', [('8', 8.0), ('2.5', 2.5),
+                                               ('0.05', 0.05)])
+    def test_reads_the_environment(self, monkeypatch, raw, expected):
+        monkeypatch.setenv(_DEADLINE_ENV, raw)
+        assert db_utils.get_auth_db_timeout_seconds() == expected
+
+    @pytest.mark.parametrize('raw', ['abc', '', '0', '-1', 'nan', 'inf'])
+    def test_nonsensical_values_are_refused_loudly(self, monkeypatch, raw):
+        """Not silently replaced by the default: a non-positive deadline
+        would fail every auth call, and `0` disables a Postgres timeout."""
+        monkeypatch.setenv(_DEADLINE_ENV, raw)
+        with pytest.raises(ValueError, match=_DEADLINE_ENV):
+            db_utils.get_auth_db_timeout_seconds()
+
+    def test_db_lookup_deadline_comes_from_the_same_source(self):
+        """`db_lookup.AUTH_DB_TIMEOUT_SECONDS` is read at import through the
+        same helper; in the (unchanged) environment of this process the two
+        agree, so the client-side deadline and the server-side bounds cannot
+        be configured apart."""
+        assert (db_lookup.AUTH_DB_TIMEOUT_SECONDS ==
+                db_utils.get_auth_db_timeout_seconds())
+
 
 class TestTimeoutValues:
-    """The server-side bounds must be at or below the caller's deadline."""
+    """The server-side bounds derive from, and stay under, the deadline."""
 
-    def test_values_are_at_or_below_the_auth_deadline(self):
-        deadline_ms = db_lookup.AUTH_DB_TIMEOUT_SECONDS * 1000
-        assert global_user_state._USER_UPSERT_LOCK_TIMEOUT_MS <= deadline_ms
-        assert (global_user_state._USER_UPSERT_STATEMENT_TIMEOUT_MS <=
-                deadline_ms)
-        assert (global_user_state._USER_UPSERT_IDLE_IN_TRANSACTION_TIMEOUT_MS <=
-                deadline_ms)
+    def test_default_deadline_gives_exactly_3900_4000_5000(self, monkeypatch):
+        """The values a deployment running on the default deadline already
+        has; deriving them must not change them."""
+        monkeypatch.delenv(_DEADLINE_ENV, raising=False)
+        assert global_user_state._user_upsert_timeouts_ms() == (3900, 4000,
+                                                                5000)
 
-    def test_lock_timeout_wins_over_statement_timeout(self):
-        """Lower lock_timeout so a row-lock wait reports the distinct
-        'lock not available' error (55P03) rather than a generic cancel."""
-        assert (global_user_state._USER_UPSERT_LOCK_TIMEOUT_MS <
-                global_user_state._USER_UPSERT_STATEMENT_TIMEOUT_MS)
+    def test_deadline_of_8s_gives_6240_6400_8000(self, monkeypatch):
+        monkeypatch.setenv(_DEADLINE_ENV, '8')
+        lock_ms, statement_ms, idle_ms = (
+            global_user_state._user_upsert_timeouts_ms())
+        assert (lock_ms, statement_ms, idle_ms) == (6240, 6400, 8000)
+        assert lock_ms < statement_ms < idle_ms
 
-    def test_idle_in_transaction_is_the_largest(self):
-        """It terminates the session, so it must only fire for a session that
-        has really gone quiet mid-transaction, after the statement bounds."""
-        assert (global_user_state._USER_UPSERT_IDLE_IN_TRANSACTION_TIMEOUT_MS >=
-                global_user_state._USER_UPSERT_STATEMENT_TIMEOUT_MS)
+    @pytest.mark.parametrize('raw', [None, '8', '2.5', '0.05', '12.345'])
+    def test_values_are_at_or_below_the_auth_deadline(self, monkeypatch, raw):
+        if raw is None:
+            monkeypatch.delenv(_DEADLINE_ENV, raising=False)
+        else:
+            monkeypatch.setenv(_DEADLINE_ENV, raw)
+        deadline_ms = db_utils.get_auth_db_timeout_seconds() * 1000
+        for value_ms in global_user_state._user_upsert_timeouts_ms():
+            assert isinstance(value_ms, int)
+            assert 0 < value_ms <= deadline_ms
+
+    @pytest.mark.parametrize('raw', [None, '8', '2.5', '0.05', '12.345'])
+    def test_lock_below_statement_below_idle(self, monkeypatch, raw):
+        """lock_timeout < statement_timeout so a row-lock wait reports the
+        distinct 'lock not available' error (55P03) rather than a generic
+        cancel; idle_in_transaction_session_timeout is the largest because it
+        terminates the session, so it must only fire for a session that has
+        really gone quiet mid-transaction, after the statement bounds."""
+        if raw is None:
+            monkeypatch.delenv(_DEADLINE_ENV, raising=False)
+        else:
+            monkeypatch.setenv(_DEADLINE_ENV, raw)
+        lock_ms, statement_ms, idle_ms = (
+            global_user_state._user_upsert_timeouts_ms())
+        assert lock_ms < statement_ms < idle_ms
+
+    def test_a_deadline_too_small_to_order_the_values_is_refused(
+            self, monkeypatch):
+        """10 ms would round to 8 / 8 / 10: lock and statement collide, and
+        a smaller deadline still could round a value to `0ms`, which Postgres
+        reads as *disabled*. Refuse rather than send that."""
+        monkeypatch.setenv(_DEADLINE_ENV, '0.01')
+        with pytest.raises(ValueError, match=_DEADLINE_ENV):
+            global_user_state._user_upsert_timeouts_ms()
+
+    @pytest.mark.parametrize('raw', ['abc', '0', '-1'])
+    def test_a_nonsensical_deadline_never_reaches_the_database(
+            self, postgres_session, monkeypatch, raw):
+        monkeypatch.setenv(_DEADLINE_ENV, raw)
+        with pytest.raises(ValueError, match=_DEADLINE_ENV):
+            global_user_state.add_or_update_user(
+                models.User(id='u-1', name='tester'))
+        assert not postgres_session.statements
+
+
+_IMPORT_DB_LOOKUP = ('from sky.server.auth import db_lookup; '
+                     'from sky import global_user_state; '
+                     'print(db_lookup.AUTH_DB_TIMEOUT_SECONDS, '
+                     'global_user_state._user_upsert_timeouts_ms())')
+
+
+def _import_db_lookup_in_a_fresh_process(env_value):
+    """`db_lookup` reads the deadline at import (server startup); run that
+    import in a child so this process's module state is untouched."""
+    env = dict(os.environ)
+    env.pop(_DEADLINE_ENV, None)
+    if env_value is not None:
+        env[_DEADLINE_ENV] = env_value
+    return subprocess.run([sys.executable, '-c', _IMPORT_DB_LOOKUP],
+                          env=env,
+                          capture_output=True,
+                          text=True,
+                          check=False)
+
+
+class TestServerStartupReadsTheSetting:
+
+    def test_override_is_seen_by_both_modules_at_import(self):
+        result = _import_db_lookup_in_a_fresh_process('8')
+        assert result.returncode == 0, result.stderr
+        # Last line only: the import may log to stdout before the print.
+        assert result.stdout.strip().splitlines()[-1] == ('8.0 (6240, 6400, '
+                                                          '8000)')
+
+    def test_a_nonsensical_value_fails_server_startup_with_its_name(self):
+        result = _import_db_lookup_in_a_fresh_process('0')
+        assert result.returncode != 0
+        assert 'ValueError' in result.stderr
+        assert _DEADLINE_ENV in result.stderr
 
 
 def _fresh_sqlite_db(tmp_path, monkeypatch):
@@ -240,7 +373,7 @@ def test_set_local_statement_text_is_valid_sql():
     compiled = [
         str(s.compile(dialect=postgresql.dialect())) for s in session.statements
     ]
-    assert compiled == list(_EXPECTED_SET_LOCAL)
+    assert compiled == _expected_set_local()
     for text in compiled:
         assert ';' not in text
         assert isinstance(sqlalchemy.text(text), elements.TextClause)


### PR DESCRIPTION
## Problem

The `users` upsert (`add_or_update_user`) runs on the request authentication path for every request, on the API server's bounded `auth_thread_executor` (32 threads per worker), under a 5 s `asyncio.wait_for` deadline in `db_lookup.call_with_deadline`.

That deadline frees the **caller** (the request gets a retryable 503) but never the **thread**: `wait_for` cannot cancel a thread parked in a blocking libpq call. A thread that waits on the `users` row lock, or a session that stops talking inside its open transaction, keeps its thread and its connection for as long as the database allows. Nothing on the server side bounded that today: no `lock_timeout`, no `statement_timeout`, no `idle_in_transaction_session_timeout` on this path.

On a production deployment this turned one orphaned idle-in-transaction session holding a single `users` row into a fleet-wide outage twice in one day: every later upsert of that row (any request from that user, including dashboard auto-refresh) queued behind the lock and pinned a thread, until all 32 auth threads on every uvicorn worker were pinned and every request from every user got `The server has exhausted its concurrent worker limit`. Only rolling the pods released the lock.

## Change

- **`global_user_state.add_or_update_user` (Postgres only):** issue three `SET LOCAL` statements as the first statements of the upsert transaction, with values derived from the configured auth deadline (`SKYPILOT_AUTH_DB_TIMEOUT_SECONDS`, default 5 s) so the database gives up before (or as) the caller does. At the default they are:
  - `lock_timeout = 3900ms` (78 % of the deadline) — a waiter on a held row lock fails with `55P03` and frees its thread;
  - `statement_timeout = 4000ms` (80 %) — bounds each statement itself;
  - `idle_in_transaction_session_timeout = 5000ms` (100 %) — a session that goes quiet inside the transaction (the orphan case) is terminated by the server, which releases the row lock (that session itself then sees SQLSTATE `25P03`, or more commonly just a closed connection).

  The deadline is parsed in one place, `db_utils.get_auth_db_timeout_seconds()` (env-var name and default in `skylet/constants.py`), and `db_lookup.AUTH_DB_TIMEOUT_SECONDS` reads through the same helper, so the client-side deadline and the server-side bounds cannot drift apart; no new setting is introduced. A value that is not a positive finite number, or too small to yield three distinct ordered timeouts (< 50 ms), is refused with a `ValueError` naming the variable — at server startup, since `db_lookup` reads it at import — rather than reaching the database (Postgres reads `0ms` as *disabled*); so is a deadline above Postgres' 32-bit millisecond range (2147483 s). The variable is server-side only: it is stripped from client request payloads and again from the server's per-request environment overlay, as `SKYPILOT_DB_CONNECTION_URI` already is, so a client cannot loosen or break the bounds on its own upsert.

  `SET LOCAL` is transaction-scoped: it applies to this transaction only and resets at `COMMIT`/`ROLLBACK`, so it is safe through a transaction-mode connection pooler (verified: no leakage into later transactions on the same server connection) and leaks nothing into other callers. It is issued explicitly through the Session, not from an engine event hook, so a failure goes through SQLAlchemy's normal error handling. SQLite is untouched.
- **`db_lookup.call_with_deadline` / `_call_on_request_pool`:** when the database cut an auth-path call off at one of these timeouts (`55P03`, `57014`, `25P03`), raise an `asyncio.TimeoutError` subclass so the auth middlewares return the existing retryable 503 (instead of a 500), with a warning naming the timeout. Any other DB error propagates unchanged.

Effect: a held `users` row lock can now delay one user's requests by at most ~4 s and an orphaned holder is cleared by the server in 5 s; the pool can no longer fill with lock waiters. The thread whose libpq socket was lost still stays pinned (one slot per event); the root cause of that is tracked separately in #10681.

## Tests

- `tests/unit_tests/test_sky/test_global_user_state_user_upsert_timeouts.py` (new): the three `SET LOCAL` statements are the first statements of the same session/transaction as the upsert (also ahead of the duplicate-name check), issued through the Session and not a hook, no bind parameters; the values are derived from the configured deadline — exactly `3900 / 4000 / 5000` ms at the default, `6240 / 6400 / 8000` at 8 s, always `lock_timeout < statement_timeout < idle_in_transaction_session_timeout <= deadline`, the statements the (fake) database receives carry the derived values, `db_lookup.AUTH_DB_TIMEOUT_SECONDS` comes from the same source (checked in-process and by importing `db_lookup` in a fresh process with the override), and a nonsensical or too-small setting is refused before any statement is issued; SQLite issues no `SET LOCAL`.
- `tests/unit_tests/test_sky/server/test_auth_db_deadline.py` (extended): an auth-proxy upsert cut off by `lock_timeout` and a bearer-token lookup cut off by `statement_timeout` both answer the retryable 503.
- `tests/unit_tests/test_sky/server/requests/test_payloads.py` and `test_executor.py` (extended): a client-supplied `SKYPILOT_AUTH_DB_TIMEOUT_SECONDS` is absent from the request payload (local and remote server) and, inside `override_request_env_and_config`, does not reach the worker's environment or its derived timeouts; the largest accepted deadline yields valid Postgres values and one more second is refused.
- 83 tests pass locally across those files (`pytest -o addopts="" -n 2`); `format.sh` clean.

Incident replay against a real Postgres + PgBouncer (transaction mode) with an orphaned holder and 40 same-row requests on the real 32-thread executor: results in the validation comment below.

Related: #10681

-Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)



