### PR TITLE
[Slurm] Configure Unix submit usernames for users and service accounts

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -2436,6 +2436,44 @@ Example:
 :ref:`cluster_configs <config-yaml-slurm-cluster-configs>`. The per-cluster
 value overrides the global value.
 
+.. _config-yaml-slurm-service-account-user-mapping:
+
+``slurm.username_map``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Map full SkyPilot usernames or service-account names to Unix users when
+``slurm.submit_as_user`` is enabled. Use the name shown in the dashboard.
+
+.. code-block:: yaml
+
+  slurm:
+    submit_as_user: true
+    username_map:
+      alice@example.com: aliceabc
+      inference-prod: inference-svc
+    cluster_configs:
+      training:
+        username_map:
+          inference-prod: inference-training
+        default_service_account_user: batch-services
+
+A cluster-specific mapping overrides the tenant mapping for the same name.
+For service accounts without an entry, the cluster's
+``default_service_account_user`` is used. Without a mapping or default,
+submission fails; service-account names are not implicitly mapped to Unix
+accounts. Human users without an entry use their email local part.
+
+The cluster default applies to every otherwise-unmapped service account with
+access to that cluster. It does not grant SkyPilot roles or workspace access.
+All mapped accounts need the same login-node impersonation permissions as
+human submit users. Account existence and impersonation are checked before
+allocation creation, with a 15-second timeout.
+
+These are API-server settings and cannot be overridden by clients or tasks.
+They only apply when ``submit_as_user`` is enabled. SkyPilot ownership remains
+the authenticated service account; Slurm ownership uses the mapped Unix user.
+Existing allocation lifecycle operations use the stored submit identity.
+
 .. _config-yaml-slurm-provision-timeout:
 
 ``slurm.provision_timeout``

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -2449,7 +2449,7 @@ Map full SkyPilot usernames or service-account names to Unix users when
   slurm:
     submit_as_user: true
     username_map:
-      alice@example.com: aliceabc
+      jane.doe@example.com: jdoe
       inference-prod: inference-svc
     cluster_configs:
       training:

--- a/sky/adaptors/slurm.py
+++ b/sky/adaptors/slurm.py
@@ -6,6 +6,7 @@ import ipaddress
 import logging
 import re
 import shlex
+import subprocess
 from typing import Dict, List, NamedTuple, Optional, Sequence, Tuple
 
 from sky.adaptors import common
@@ -301,6 +302,25 @@ class SlurmClient:
                 disable_identities_only=not identities_only,
                 slurm_user=slurm_user,
             )
+
+    def validate_submit_user(self, cluster_name: str, submit_user: str) -> None:
+        """Check the Unix account through the submit runner."""
+        target = shlex.quote(submit_user)
+        command = (f'id -u -- {target} >/dev/null && '
+                   f'test "$(id -u)" = "$(id -u -- {target})"')
+        error = (f'Cannot submit to Slurm cluster {cluster_name!r} as Unix '
+                 f'user {submit_user!r} through SSH user {self.ssh_user!r}. ')
+        try:
+            rc, stdout, stderr = self._run_slurm_cmd(command, timeout=15)
+        except subprocess.TimeoutExpired as e:
+            raise RuntimeError(error + 'Account validation timed out after '
+                               '15 seconds.') from e
+        if rc != 0:
+            raise RuntimeError(
+                error + f'Account validation exited with code {rc}. '
+                'Check that the account exists and the SSH user can run '
+                'the submission shell as that account. '
+                f'{stdout}\n{stderr}')
 
     def _run_slurm_cmd(self,
                        cmd: str,

--- a/sky/clouds/slurm.py
+++ b/sky/clouds/slurm.py
@@ -295,7 +295,7 @@ class Slurm(clouds.Cloud):
                     partitions = [p for p in partitions if p == zone]
                 zones = [clouds.Zone(p) for p in partitions]
             except Exception as e:  # pylint: disable=broad-except
-                logger.debug(f'Failed to get partitions for {cluster}: {e}')
+                logger.warning(f'Failed to get partitions for {cluster}: {e}')
                 zones = []
 
             r = clouds.Region(cluster)

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -692,6 +692,9 @@ def _create_virtual_instance(
     provider_config = config.provider_config
     partition = slurm_utils.get_partition_from_config(provider_config)
     client = _make_slurm_client(provider_config)
+    submit_user = provider_config.get('slurm_user')
+    if submit_user is not None:
+        client.validate_submit_user(region, submit_user)
 
     slurm_cluster = slurm_utils.get_slurm_cluster_from_config(provider_config)
 

--- a/sky/provision/slurm/utils.py
+++ b/sky/provision/slurm/utils.py
@@ -158,6 +158,28 @@ def get_submit_user(cluster_name: str) -> Optional[str]:
     if not enabled:
         return None
 
+    user = common_utils.get_current_user()
+    mapping = skypilot_config.get_nested(('slurm', 'username_map'),
+                                         default_value={})
+    cluster_config = skypilot_config.get_nested(
+        ('slurm', 'cluster_configs', cluster_name), default_value={})
+    cluster_mapping = cluster_config.get('username_map', {})
+    submit_user = cluster_mapping.get(user.name, mapping.get(user.name))
+    if submit_user is None and user.is_service_account():
+        submit_user = cluster_config.get('default_service_account_user')
+        if submit_user is None:
+            raise ValueError(
+                f'No Unix user configured for service account {user.name!r} '
+                f'on Slurm cluster {cluster_name!r}. Ask an administrator to '
+                'set slurm.username_map or the cluster-level '
+                'default_service_account_user.')
+    if submit_user is not None:
+        if _SLURM_USER_PATTERN.fullmatch(submit_user) is None:
+            raise ValueError(
+                f'Invalid Unix user {submit_user!r} configured for SkyPilot '
+                f'user {user.name!r} on Slurm cluster {cluster_name!r}.')
+        return submit_user
+
     user_name = common_utils.get_current_user_name()
     submit_user = user_name.split('@', 1)[0]
     if _SLURM_USER_PATTERN.fullmatch(submit_user) is None:

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -649,6 +649,7 @@ SKIPPED_CLIENT_OVERRIDE_KEYS: List[Tuple[str, ...]] = [
     # Slurm submit identity and cluster settings are managed server-side.
     ('slurm', 'cluster_configs'),
     ('slurm', 'submit_as_user'),
+    ('slurm', 'username_map'),
 ]
 
 # Constants for Azure blob storage

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -134,7 +134,8 @@ def _ssh_control_path(ssh_control_filename: Optional[str]) -> Optional[str]:
     if ssh_control_filename is None:
         return None
     user_hash = common_utils.get_user_hash()
-    path = f'/tmp/skypilot_ssh_{user_hash}/{ssh_control_filename}'
+    # Leave room for OpenSSH's %C hash and temporary suffix on macOS.
+    path = f'/tmp/sky_ssh_{user_hash}/{ssh_control_filename}'
     os.makedirs(path, exist_ok=True)
     return path
 

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1865,6 +1865,17 @@ _CONTEXT_CONFIG_SCHEMA_KUBERNETES = {
     },
 }
 
+_SLURM_USERNAME_MAP_SCHEMA = {
+    'type': 'object',
+    'propertyNames': {
+        'minLength': 1
+    },
+    'additionalProperties': {
+        'type': 'string',
+        'pattern': '^[a-z_][a-z0-9_.-]*$'
+    }
+}
+
 
 def get_config_schema():
     # pylint: disable=import-outside-toplevel
@@ -2226,6 +2237,7 @@ def get_config_schema():
                 'submit_as_user': {
                     'type': 'boolean',
                 },
+                'username_map': (_SLURM_USERNAME_MAP_SCHEMA),
                 'pricing': _PRICING_SCHEMA,
                 'sbatch_options': _SBATCH_OPTIONS_SCHEMA,
                 'quota': _SLURM_QUOTA_SCHEMA,
@@ -2273,6 +2285,11 @@ def get_config_schema():
                             },
                             'submit_as_user': {
                                 'type': 'boolean',
+                            },
+                            'username_map': (_SLURM_USERNAME_MAP_SCHEMA),
+                            'default_service_account_user': {
+                                'type': 'string',
+                                'pattern': '^[a-z_][a-z0-9_.-]*$'
                             },
                             # The Prometheus this cluster's GPU metrics are
                             # federated from.

--- a/tests/unit_tests/test_sky/provision/slurm/test_service_account_identity.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_service_account_identity.py
@@ -1,0 +1,237 @@
+"""Service-account submit identity and server-owned configuration tests."""
+# pylint: disable=redefined-outer-name,unused-argument,protected-access
+import subprocess
+from unittest import mock
+
+import pytest
+
+from sky import models
+from sky import skypilot_config
+from sky.adaptors import slurm
+from sky.clouds import slurm as slurm_cloud
+from sky.provision.slurm import instance
+from sky.provision.slurm import utils
+from sky.utils import command_runner
+from sky.utils import common_utils
+from sky.utils import config_utils
+from sky.utils import schemas
+
+
+@pytest.fixture
+def identity_config(monkeypatch):
+    config = config_utils.Config.from_dict({
+        'slurm': {
+            'submit_as_user': True,
+            'username_map': {
+                'Machine': 'tenant-svc'
+            },
+            'cluster_configs': {
+                'a': {
+                    'username_map': {
+                        'Machine': 'cluster-svc'
+                    },
+                    'default_service_account_user': 'default-a',
+                },
+                'b': {
+                    'default_service_account_user': 'default-b'
+                },
+            },
+        },
+    })
+    ctx = skypilot_config.ConfigContext(config=config)
+    monkeypatch.setattr(skypilot_config, '_get_config_context', lambda: ctx)
+    monkeypatch.setattr(common_utils, 'get_current_user',
+                        lambda: models.User(id='sa-1234', name='Machine'))
+    return config
+
+
+@pytest.mark.parametrize('cluster,expected', [('a', 'cluster-svc'),
+                                              ('b', 'tenant-svc')])
+def test_mapping_precedence(identity_config, cluster, expected):
+    assert utils.get_submit_user(cluster) == expected
+
+
+@pytest.mark.parametrize('cluster,expected', [('a', 'default-a'),
+                                              ('b', 'default-b')])
+def test_unmapped_service_account_uses_cluster_default(identity_config,
+                                                       monkeypatch, cluster,
+                                                       expected):
+    monkeypatch.setattr(common_utils, 'get_current_user',
+                        lambda: models.User(id='sa-5678', name='inference'))
+    assert utils.get_submit_user(cluster) == expected
+
+
+def test_unmapped_service_account_rejected(identity_config, monkeypatch):
+    monkeypatch.setattr(
+        common_utils, 'get_current_user',
+        lambda: models.User(id='sa-5678', name='valid-unix-name'))
+    with pytest.raises(ValueError, match='valid-unix-name.*Slurm cluster'):
+        utils.get_submit_user('c')
+
+
+def test_human_ignores_service_default(identity_config, monkeypatch):
+    monkeypatch.setattr(
+        common_utils, 'get_current_user',
+        lambda: models.User(id='human', name='alice@example.com'))
+    assert utils.get_submit_user('a') == 'alice'
+
+
+def test_disabled(identity_config):
+    identity_config['slurm']['cluster_configs']['a']['submit_as_user'] = False
+    assert utils.get_submit_user('a') is None
+
+
+@pytest.mark.parametrize('value', ['Root', '-root', 'svc;id', '', 'svc\n'])
+def test_invalid_mapping_rejected(identity_config, value):
+    identity_config['slurm']['username_map']['Machine'] = value
+    with pytest.raises(ValueError, match='Invalid Unix user'):
+        utils.get_submit_user('b')
+
+
+def test_schema(identity_config):
+    common_utils.validate_schema(identity_config, schemas.get_config_schema(),
+                                 '')
+    identity_config['slurm']['cluster_configs']['a'][
+        'default_service_account_user'] = 'svc;id'
+    with pytest.raises(ValueError):
+        common_utils.validate_schema(identity_config,
+                                     schemas.get_config_schema(), '')
+
+
+def test_client_cannot_override_identity(identity_config):
+    with skypilot_config.override_skypilot_config({
+            'slurm': {
+                'provision_timeout': 123,
+                'submit_as_user': False,
+                'username_map': {
+                    'Machine': 'root'
+                },
+                'cluster_configs': {
+                    'a': {
+                        'default_service_account_user': 'root'
+                    }
+                },
+            }
+    }):
+        assert skypilot_config.get_nested(('slurm', 'provision_timeout'),
+                                          None) == 123
+        assert utils.get_submit_user('a') == 'cluster-svc'
+        assert utils.get_submit_user('b') == 'tenant-svc'
+
+
+@pytest.mark.parametrize('rc,stderr', [(1, 'unknown user'),
+                                       (1, 'sudo: a password is required'),
+                                       (255, 'connection refused')])
+def test_submit_validation_failure(rc, stderr):
+    with mock.patch(
+            'sky.adaptors.slurm.command_runner.SlurmLoginNodeCommandRunner'
+    ) as runner:
+        runner.return_value.run.return_value = (rc, '', stderr)
+        client = slurm.SlurmClient('host', 22, 'login', slurm_user='svc')
+        with pytest.raises(
+                RuntimeError,
+                match='cluster .*a.*user .*svc.*SSH user .*login') as exc:
+            client.validate_submit_user('a', 'svc')
+        assert stderr in str(exc.value)
+        assert f'code {rc}' in str(exc.value)
+
+
+def test_submit_validation_uses_bounded_submit_runner():
+    with mock.patch(
+            'sky.adaptors.slurm.command_runner.SlurmLoginNodeCommandRunner'
+    ) as runner:
+        runner.return_value.run.return_value = (0, '', '')
+        client = slurm.SlurmClient('host', 22, 'login', slurm_user='svc')
+        client.validate_submit_user('a', 'svc')
+        assert runner.call_args.kwargs['slurm_user'] == 'svc'
+        assert runner.return_value.run.call_args.kwargs['timeout'] == 15
+        assert 'id -u -- svc' in runner.return_value.run.call_args.args[0]
+
+
+def test_submit_validation_timeout():
+    with mock.patch(
+            'sky.adaptors.slurm.command_runner.SlurmLoginNodeCommandRunner'
+    ) as runner:
+        runner.return_value.run.side_effect = subprocess.TimeoutExpired(
+            'ssh', 15)
+        client = slurm.SlurmClient('host', 22, 'login', slurm_user='svc')
+        with pytest.raises(RuntimeError, match='timed out after 15 seconds'):
+            client.validate_submit_user('a', 'svc')
+
+
+def test_allocation_client_uses_stored_identity(identity_config):
+    identity_config['slurm']['username_map']['Machine'] = 'new-user'
+    with mock.patch('sky.provision.slurm.instance.slurm.SlurmClient') as client:
+        instance._make_slurm_client({
+            'ssh': {
+                'hostname': 'host',
+                'port': 22,
+                'user': 'login'
+            },
+            'slurm_user': 'original-user',
+        })
+        assert client.call_args.kwargs['slurm_user'] == 'original-user'
+
+
+def test_validation_failure_stops_allocation_creation():
+    config = mock.Mock()
+    config.provider_config = {
+        'partition': 'cpu',
+        'cluster': 'a',
+        'slurm_user': 'svc',
+        'ssh': {
+            'hostname': 'host',
+            'port': 22,
+            'user': 'login'
+        },
+    }
+    with mock.patch('sky.provision.slurm.instance.slurm.SlurmClient') as client:
+        client.return_value.validate_submit_user.side_effect = RuntimeError(
+            'denied')
+        with pytest.raises(RuntimeError, match='denied'):
+            instance.run_instances('a', 'test', 'test-on-cloud', config)
+        assert client.return_value.method_calls == [
+            mock.call.validate_submit_user('a', 'svc')
+        ]
+
+
+def test_service_account_ssh_socket_fits_macos(monkeypatch):
+    monkeypatch.setattr(common_utils, 'get_user_hash', lambda: 'sa-' + 'a' * 16)
+    with mock.patch('sky.utils.command_runner.os.makedirs'):
+        directory = command_runner._ssh_control_path('b' * 10)
+    socket_path = directory + '/' + 'c' * 40 + '.' + 'd' * 16
+    assert len(socket_path.encode()) < 104
+
+
+def test_missing_mapping_visible_during_resource_selection(identity_config):
+    identity_config['slurm']['username_map'] = {}
+    with mock.patch.object(slurm_cloud.Slurm,
+                           'existing_allowed_clusters',
+                           return_value=['c']), mock.patch.object(
+                               slurm_cloud.logger, 'warning') as warning:
+        regions = slurm_cloud.Slurm.regions_with_offering(
+            '1CPU--1GB', None, False, 'c', None)
+    assert not regions
+    message = warning.call_args.args[0]
+    assert 'Machine' in message
+    assert 'Slurm cluster' in message
+    assert 'username_map' in message
+
+
+def test_mapping_uses_name_independent_of_id(identity_config, monkeypatch):
+    monkeypatch.setattr(common_utils, 'get_current_user',
+                        lambda: models.User(id='sa-9999', name='Machine'))
+    assert utils.get_submit_user('a') == 'cluster-svc'
+
+
+@pytest.mark.parametrize('cluster,expected', [('a', 'alice-cluster'),
+                                              ('b', 'aliceabc')])
+def test_sso_username_map_precedence(identity_config, monkeypatch, cluster,
+                                     expected):
+    monkeypatch.setattr(
+        common_utils, 'get_current_user',
+        lambda: models.User(id='human', name='alice@example.com'))
+    identity_config['slurm']['username_map']['alice@example.com'] = 'aliceabc'
+    identity_config['slurm']['cluster_configs']['a']['username_map'][
+        'alice@example.com'] = 'alice-cluster'
+    assert utils.get_submit_user(cluster) == expected


### PR DESCRIPTION
With `slurm.submit_as_user` enabled, a user's email local part may differ from their Unix account, and a service-account name need not be a Unix login. Add server-managed `slurm.username_map`, keyed by full SkyPilot usernames or service-account names:

```yaml
slurm:
  submit_as_user: true
  username_map:
    jane.doe@example.com: jdoe
    inference-prod: inference-svc
  cluster_configs:
    training:
      default_service_account_user: batch-services
```

Cluster entries override tenant entries. Unmapped human users keep email-local-part derivation; service accounts require a mapping or a cluster default. Existing allocations retain their stored submit identity. Client/task config cannot override the mappings.

Validate account existence and impersonation through the submission runner before creating an allocation, with a 15-second timeout. Partition discovery previously hid mapping failures in debug logs, producing misleading capacity errors; surface the underlying error. Also shorten the SSH control-directory prefix: service-account IDs made the socket path exceed macOS's limit.

Validation:
- 480 Slurm unit tests passed, including SSO/name mapping precedence, defaults, client overrides, and validation failures.
- Live local API + service-account token: CPU task succeeded with the mapped Unix UID and file owner; SkyPilot retained service-account ownership. Allocation removed afterward.
- SSO mapping covered by unit tests; no live SSO login test.
- Targeted YAPF/isort and pylint passed. The format script's mypy stage passed; its initial lint findings were fixed and targeted pylint rerun.
- GPU usage and PostgreSQL multi-replica behavior were not exercised. Slurm accounting storage was disabled on the test system, so ownership was checked with task output and squeue, not sacct.
