### PR TITLE
[Slurm] Default service accounts to their creator’s Unix identity

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -2455,16 +2455,16 @@ Map full SkyPilot usernames or service-account names to Unix users when
       training:
         username_map:
           inference-prod: inference-training
-        default_service_account_user: batch-services
 
 A cluster-specific mapping overrides the tenant mapping for the same name.
-For service accounts without an entry, the cluster's
-``default_service_account_user`` is used. Without a mapping or default,
-submission fails; service-account names are not implicitly mapped to Unix
-accounts. Human users without an entry use their email local part.
+A service account without an entry uses its creator's Unix identity: the
+creator's cluster mapping, then tenant mapping, then email local part. If the
+creator is another service account, the same resolution applies to that account.
+Human users without an entry use their email local part. If the creator cannot
+be found, configure an explicit mapping for the service account.
 
-The cluster default applies to every otherwise-unmapped service account with
-access to that cluster. It does not grant SkyPilot roles or workspace access.
+This changes the Unix submit identity only; it does not grant SkyPilot roles
+or workspace access.
 All mapped accounts need the same login-node impersonation permissions as
 human submit users. Account existence and impersonation are checked before
 allocation creation, with a 15-second timeout.

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -3330,6 +3330,21 @@ def add_service_account_token(token_id: str,
 
 
 @metrics_lib.time_me
+def get_service_account_creator(
+        service_account_user_id: str) -> Optional[models.User]:
+    """Return the creator of a service account, if the creator still exists."""
+    engine = _db_manager.get_engine()
+    with orm.Session(engine) as session:
+        query = session.query(
+            service_account_token_table.c.creator_user_hash).filter_by(
+                service_account_user_id=service_account_user_id)
+        row = query.distinct().one_or_none()
+    if row is None:
+        return None
+    return get_user(row.creator_user_hash)
+
+
+@metrics_lib.time_me
 def get_service_account_token(token_id: str) -> Optional[Dict[str, Any]]:
     """Get a service account token by token_id."""
     engine = _db_manager.get_engine()

--- a/sky/provision/slurm/utils.py
+++ b/sky/provision/slurm/utils.py
@@ -12,6 +12,7 @@ from paramiko.config import SSHConfig
 
 from sky import clouds
 from sky import exceptions
+from sky import global_user_state
 from sky import sky_logging
 from sky import skypilot_config
 from sky.adaptors import slurm
@@ -165,14 +166,22 @@ def get_submit_user(cluster_name: str) -> Optional[str]:
         ('slurm', 'cluster_configs', cluster_name), default_value={})
     cluster_mapping = cluster_config.get('username_map', {})
     submit_user = cluster_mapping.get(user.name, mapping.get(user.name))
-    if submit_user is None and user.is_service_account():
-        submit_user = cluster_config.get('default_service_account_user')
-        if submit_user is None:
+    visited = set()
+    while submit_user is None and user.is_service_account():
+        if user.id in visited:
             raise ValueError(
-                f'No Unix user configured for service account {user.name!r} '
+                f'Cycle in service-account creators for {user.name!r} on '
+                f'Slurm cluster {cluster_name!r}. Configure slurm.username_map.'
+            )
+        visited.add(user.id)
+        creator = global_user_state.get_service_account_creator(user.id)
+        if creator is None:
+            raise ValueError(
+                f'Cannot find the creator of service account {user.name!r} '
                 f'on Slurm cluster {cluster_name!r}. Ask an administrator to '
-                'set slurm.username_map or the cluster-level '
-                'default_service_account_user.')
+                'set slurm.username_map.')
+        user = creator
+        submit_user = cluster_mapping.get(user.name, mapping.get(user.name))
     if submit_user is not None:
         if _SLURM_USER_PATTERN.fullmatch(submit_user) is None:
             raise ValueError(
@@ -180,7 +189,8 @@ def get_submit_user(cluster_name: str) -> Optional[str]:
                 f'user {user.name!r} on Slurm cluster {cluster_name!r}.')
         return submit_user
 
-    user_name = common_utils.get_current_user_name()
+    user_name = user.name
+    assert user_name is not None
     submit_user = user_name.split('@', 1)[0]
     if _SLURM_USER_PATTERN.fullmatch(submit_user) is None:
         raise ValueError(

--- a/sky/provision/slurm/utils.py
+++ b/sky/provision/slurm/utils.py
@@ -166,14 +166,7 @@ def get_submit_user(cluster_name: str) -> Optional[str]:
         ('slurm', 'cluster_configs', cluster_name), default_value={})
     cluster_mapping = cluster_config.get('username_map', {})
     submit_user = cluster_mapping.get(user.name, mapping.get(user.name))
-    visited = set()
     while submit_user is None and user.is_service_account():
-        if user.id in visited:
-            raise ValueError(
-                f'Cycle in service-account creators for {user.name!r} on '
-                f'Slurm cluster {cluster_name!r}. Configure slurm.username_map.'
-            )
-        visited.add(user.id)
         creator = global_user_state.get_service_account_creator(user.id)
         if creator is None:
             raise ValueError(

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -2287,10 +2287,6 @@ def get_config_schema():
                                 'type': 'boolean',
                             },
                             'username_map': (_SLURM_USERNAME_MAP_SCHEMA),
-                            'default_service_account_user': {
-                                'type': 'string',
-                                'pattern': '^[a-z_][a-z0-9_.-]*$'
-                            },
                             # The Prometheus this cluster's GPU metrics are
                             # federated from.
                             'prometheus': {

--- a/tests/unit_tests/test_sky/clouds/test_slurm.py
+++ b/tests/unit_tests/test_sky/clouds/test_slurm.py
@@ -10,6 +10,7 @@ import unittest.mock as mock
 import pytest
 
 from sky import clouds
+from sky import models
 from sky import resources as resources_lib
 from sky import skypilot_config
 from sky.adaptors import slurm
@@ -65,13 +66,12 @@ class TestGetSubmitUser:
         ('alice', 'alice'),
         ('alice.ml@example.com', 'alice.ml'),
     ])
-    @patch('sky.provision.slurm.utils.common_utils.get_current_user_name')
+    @patch('sky.provision.slurm.utils.common_utils.get_current_user')
     @patch('sky.provision.slurm.utils.skypilot_config.'
            'get_effective_region_config')
-    def test_enabled(self, mock_get_config, mock_get_user_name, user_name,
-                     expected):
+    def test_enabled(self, mock_get_config, mock_get_user, user_name, expected):
         mock_get_config.return_value = True
-        mock_get_user_name.return_value = user_name
+        mock_get_user.return_value = models.User(id='human', name=user_name)
 
         assert slurm_utils.get_submit_user('my-cluster') == expected
         mock_get_config.assert_called_once_with(cloud='slurm',
@@ -79,14 +79,14 @@ class TestGetSubmitUser:
                                                 keys=('submit_as_user',),
                                                 default_value=False)
 
-    @patch('sky.provision.slurm.utils.common_utils.get_current_user_name')
+    @patch('sky.provision.slurm.utils.common_utils.get_current_user')
     @patch('sky.provision.slurm.utils.skypilot_config.'
            'get_effective_region_config')
-    def test_disabled(self, mock_get_config, mock_get_user_name):
+    def test_disabled(self, mock_get_config, mock_get_user):
         mock_get_config.return_value = False
 
         assert slurm_utils.get_submit_user('my-cluster') is None
-        mock_get_user_name.assert_not_called()
+        mock_get_user.assert_not_called()
 
     @pytest.mark.parametrize('user_name', [
         '@example.com',
@@ -94,13 +94,13 @@ class TestGetSubmitUser:
         'alice+ml@example.com',
         '-alice@example.com',
     ])
-    @patch('sky.provision.slurm.utils.common_utils.get_current_user_name')
+    @patch('sky.provision.slurm.utils.common_utils.get_current_user')
     @patch('sky.provision.slurm.utils.skypilot_config.'
            'get_effective_region_config',
            return_value=True)
-    def test_invalid_unix_user_rejected(self, _mock_get_config,
-                                        mock_get_user_name, user_name):
-        mock_get_user_name.return_value = user_name
+    def test_invalid_unix_user_rejected(self, _mock_get_config, mock_get_user,
+                                        user_name):
+        mock_get_user.return_value = models.User(id='human', name=user_name)
 
         with pytest.raises(ValueError, match='valid Unix user'):
             slurm_utils.get_submit_user('my-cluster')

--- a/tests/unit_tests/test_sky/provision/slurm/test_service_account_identity.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_service_account_identity.py
@@ -261,11 +261,3 @@ def test_service_account_creator_chain(identity_config, monkeypatch):
     monkeypatch.setattr(utils.global_user_state, 'get_service_account_creator',
                         creators.get)
     assert utils.get_submit_user('b') == 'jane'
-
-
-def test_service_account_creator_cycle(identity_config, monkeypatch):
-    identity_config['slurm']['username_map'].clear()
-    monkeypatch.setattr(utils.global_user_state, 'get_service_account_creator',
-                        lambda _: models.User(id='sa-1234', name='Machine'))
-    with pytest.raises(ValueError, match='Cycle.*creators'):
-        utils.get_submit_user('b')

--- a/tests/unit_tests/test_sky/provision/slurm/test_service_account_identity.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_service_account_identity.py
@@ -30,11 +30,8 @@ def identity_config(monkeypatch):
                     'username_map': {
                         'Machine': 'cluster-svc'
                     },
-                    'default_service_account_user': 'default-a',
                 },
-                'b': {
-                    'default_service_account_user': 'default-b'
-                },
+                'b': {},
             },
         },
     })
@@ -42,6 +39,8 @@ def identity_config(monkeypatch):
     monkeypatch.setattr(skypilot_config, '_get_config_context', lambda: ctx)
     monkeypatch.setattr(common_utils, 'get_current_user',
                         lambda: models.User(id='sa-1234', name='Machine'))
+    monkeypatch.setattr(utils.global_user_state, 'get_service_account_creator',
+                        lambda _: None)
     return config
 
 
@@ -51,14 +50,28 @@ def test_mapping_precedence(identity_config, cluster, expected):
     assert utils.get_submit_user(cluster) == expected
 
 
-@pytest.mark.parametrize('cluster,expected', [('a', 'default-a'),
-                                              ('b', 'default-b')])
-def test_unmapped_service_account_uses_cluster_default(identity_config,
-                                                       monkeypatch, cluster,
-                                                       expected):
-    monkeypatch.setattr(common_utils, 'get_current_user',
-                        lambda: models.User(id='sa-5678', name='inference'))
+@pytest.mark.parametrize('cluster,expected', [('a', 'jane-cluster'),
+                                              ('b', 'jdoe'), ('c', 'jdoe')])
+def test_service_account_uses_creator_mapping(identity_config, monkeypatch,
+                                              cluster, expected):
+    identity_config['slurm']['username_map'].pop('Machine')
+    identity_config['slurm']['cluster_configs']['a']['username_map'] = {
+        'jane.doe@example.com': 'jane-cluster'
+    }
+    identity_config['slurm']['username_map']['jane.doe@example.com'] = 'jdoe'
+    monkeypatch.setattr(
+        utils.global_user_state, 'get_service_account_creator',
+        lambda _: models.User(id='human', name='jane.doe@example.com'))
     assert utils.get_submit_user(cluster) == expected
+
+
+def test_service_account_uses_creator_email_local_part(identity_config,
+                                                       monkeypatch):
+    identity_config['slurm']['username_map'].clear()
+    monkeypatch.setattr(
+        utils.global_user_state, 'get_service_account_creator',
+        lambda _: models.User(id='human', name='jane.doe@example.com'))
+    assert utils.get_submit_user('b') == 'jane.doe'
 
 
 def test_unmapped_service_account_rejected(identity_config, monkeypatch):
@@ -69,7 +82,7 @@ def test_unmapped_service_account_rejected(identity_config, monkeypatch):
         utils.get_submit_user('c')
 
 
-def test_human_ignores_service_default(identity_config, monkeypatch):
+def test_human_uses_email_local_part(identity_config, monkeypatch):
     monkeypatch.setattr(
         common_utils, 'get_current_user',
         lambda: models.User(id='human', name='alice@example.com'))
@@ -91,8 +104,8 @@ def test_invalid_mapping_rejected(identity_config, value):
 def test_schema(identity_config):
     common_utils.validate_schema(identity_config, schemas.get_config_schema(),
                                  '')
-    identity_config['slurm']['cluster_configs']['a'][
-        'default_service_account_user'] = 'svc;id'
+    identity_config['slurm']['cluster_configs']['a']['username_map'][
+        'Machine'] = 'svc;id'
     with pytest.raises(ValueError):
         common_utils.validate_schema(identity_config,
                                      schemas.get_config_schema(), '')
@@ -108,7 +121,9 @@ def test_client_cannot_override_identity(identity_config):
                 },
                 'cluster_configs': {
                     'a': {
-                        'default_service_account_user': 'root'
+                        'username_map': {
+                            'Machine': 'root'
+                        }
                     }
                 },
             }
@@ -235,3 +250,22 @@ def test_sso_username_map_precedence(identity_config, monkeypatch, cluster,
     identity_config['slurm']['cluster_configs']['a']['username_map'][
         'alice@example.com'] = 'alice-cluster'
     assert utils.get_submit_user(cluster) == expected
+
+
+def test_service_account_creator_chain(identity_config, monkeypatch):
+    identity_config['slurm']['username_map'].clear()
+    creators = {
+        'sa-1234': models.User(id='sa-parent', name='parent'),
+        'sa-parent': models.User(id='human', name='jane@example.com'),
+    }
+    monkeypatch.setattr(utils.global_user_state, 'get_service_account_creator',
+                        creators.get)
+    assert utils.get_submit_user('b') == 'jane'
+
+
+def test_service_account_creator_cycle(identity_config, monkeypatch):
+    identity_config['slurm']['username_map'].clear()
+    monkeypatch.setattr(utils.global_user_state, 'get_service_account_creator',
+                        lambda _: models.User(id='sa-1234', name='Machine'))
+    with pytest.raises(ValueError, match='Cycle.*creators'):
+        utils.get_submit_user('b')

--- a/tests/unit_tests/test_sky/test_global_user_state_service_accounts.py
+++ b/tests/unit_tests/test_sky/test_global_user_state_service_accounts.py
@@ -6,6 +6,7 @@ from unittest import mock
 import pytest
 
 from sky import global_user_state
+from sky import models
 from sky.skylet import constants
 from sky.utils.db import db_utils
 
@@ -427,3 +428,30 @@ class TestGetExpiredServiceAccountTokensByNamePrefix:
                 'prefix%', now))
 
         assert {r['token_id'] for r in results} == {'literal-match'}
+
+
+def test_service_account_creator_lookup_and_rotation(tmp_path, monkeypatch):
+    monkeypatch.setenv(constants.SKY_RUNTIME_DIR_ENV_VAR_KEY, str(tmp_path))
+    monkeypatch.setattr(
+        global_user_state, '_db_manager',
+        db_utils.DatabaseManager('state', global_user_state.create_table))
+    creator = models.User(id='creator', name='jane.doe@example.com')
+    global_user_state.add_or_update_user(creator)
+    global_user_state.add_or_update_user(
+        models.User(id='sa-test', name='inference'))
+    assert global_user_state.get_service_account_creator('sa-test') is None
+    global_user_state.add_service_account_token(
+        token_id='test-token',
+        token_name='inference',
+        token_hash='hash',
+        creator_user_hash=creator.id,
+        service_account_user_id='sa-test')
+    found = global_user_state.get_service_account_creator('sa-test')
+    assert found is not None
+    assert (found.id, found.name) == (creator.id, creator.name)
+    global_user_state.rotate_service_account_token('test-token', 'rotated-hash')
+    found = global_user_state.get_service_account_creator('sa-test')
+    assert found is not None
+    assert found.id == creator.id
+    global_user_state.delete_user(creator.id)
+    assert global_user_state.get_service_account_creator('sa-test') is None


### PR DESCRIPTION
Service accounts without an explicit Slurm username mapping now submit as the user who created them. This replaces `default_service_account_user` from [#10685](https://github.com/skypilot-org/skypilot/pull/10685).

Resolution checks the service account's cluster and tenant `username_map` entries first. Otherwise, it looks up the persisted token's `creator_user_hash` and applies the creator's cluster mapping, tenant mapping, or email local part. For example, a service account created by `jane.doe@example.com` uses `jdoe` when that creator has `jane.doe@example.com: jdoe` configured. If the creator is another service account, resolution follows that account; a missing creator produces an error requesting an explicit mapping.

Removes the default setting from the schema and docs. SkyPilot ownership remains the submitting service account, and existing allocations retain their stored Unix identity.

Validation:
- 29 focused identity tests passed. Coverage includes creator mappings, email fallback, creator chains, and missing creators. Database tests exercised the real SQLite lookup before/after token rotation and creator deletion.
- A live local API launch with a real service-account token and no explicit mapping for that account inherited its creator's mapping. The task succeeded with the expected Unix UID/file owner while SkyPilot retained the service-account owner. Test allocation removed.
- Targeted source pylint passed. The format script passed mypy (598 files) but its test-file lint stage reported findings. Live SSO login and PostgreSQL were not exercised.

