### PR TITLE
[Core] Bound idle-in-transaction time on every Postgres engine transaction

### DIFF
--- a/sky/utils/db/db_utils.py
+++ b/sky/utils/db/db_utils.py
@@ -620,6 +620,98 @@ def _pooler_configured() -> bool:
 # database would otherwise hang the caller for the OS default.
 _NO_POOL_CONNECT_TIMEOUT_SECONDS = 10
 
+# Server-side bound on how long one of our transactions may sit idle (no
+# statement in flight) before Postgres terminates the session, rolling the
+# transaction back and releasing every lock it held.
+#
+# Why: a client that opens a transaction and then never speaks again (a
+# thread parked forever on a dead socket, a process frozen mid-transaction)
+# leaves its backend `idle in transaction` holding its row locks until
+# something closes the session. Postgres' default for this timeout is 0
+# (never), and a transaction-mode pooler in front of the database never
+# touches a live-but-silent client either. Every later writer of the same
+# row then blocks on the lock; on a hot row (e.g. the per-request `users`
+# upsert) that turns one orphaned transaction into a stalled thread pool.
+#
+# Why 60 s: every transaction in this codebase runs DB statements with only
+# in-process Python between them, so legitimate idle-in-transaction time is
+# milliseconds — low seconds under GIL starvation on a saturated process.
+# Anything idle for a minute is a fault, and cutting it is the desired
+# outcome: the transaction is rolled back atomically and the caller sees an
+# OperationalError on its next statement (most writers retry via
+# db_retries). Only IDLE time counts: a long-running statement (a slow
+# query, a lock wait, a big DDL) never trips it, nor does a transaction
+# that keeps issuing statements. Session-scoped advisory locks (see
+# sky/utils/locks.py) are held on autocommit connections, which are `idle`,
+# not `idle in transaction`, so they are unaffected.
+#
+# Why per transaction (`SET LOCAL`) rather than a connection option: a
+# libpq startup `options=-c ...` is dropped or rejected by transaction-mode
+# poolers (PgBouncer ignores it when `options` is in
+# ignore_startup_parameters and refuses the connection otherwise), and a
+# plain `SET` on connect leaks onto whichever client next borrows that
+# server connection. `SET LOCAL` inside the transaction reaches the server
+# on a direct connection AND through a transaction-mode pooler, and is
+# scoped to that one transaction. Cost: one extra round trip per
+# transaction.
+#
+# Why "lower, never raise": the statement only applies the bound when the
+# value in effect is 0 (unbounded) or looser than ours, so a tighter bound
+# is always kept no matter where it came from or when it ran -- a stricter
+# server/role/database default set by a DBA, a caller's own tighter
+# `SET LOCAL` issued after this one (the usual case: the later `SET LOCAL`
+# wins anyway), and a caller's tighter `SET LOCAL` that ran BEFORE this
+# statement. The last case matters for event hooks: this listener's
+# statement is the first cursor execute of every transaction, so a hook that
+# prepends its own `SET LOCAL ...;` to "the first statement of the
+# transaction" (a `before_cursor_execute` listener with retval=True) attaches
+# them to this statement; a plain `SET LOCAL 60000` would then run last and
+# silently undo the tighter bound. The conditional form makes the ordering
+# irrelevant, so no coordination flag is needed between hooks.
+_IDLE_IN_TRANSACTION_TIMEOUT_MS = 60_000
+# `set_config(name, value, is_local => true)` is `SET LOCAL` in function
+# form. The guard reads the value in effect for this session and transaction
+# with `current_setting()`, a direct GUC lookup (microseconds). It must NOT
+# go through `pg_settings`: that view calls pg_show_all_settings(), which
+# formats every GUC (~360 rows) on each call -- measured 0.8 ms of server CPU
+# per transaction on Postgres 16, ~20x the statement's own cost. The GUC's
+# text form is always `0` or a number with one unit (`30s`, `90500ms`, `1d`),
+# which `::interval` parses, so the comparison is unit-safe.
+_IDLE_IN_TRANSACTION_TIMEOUT_SQL = (
+    'SELECT pg_catalog.set_config('
+    '\'idle_in_transaction_session_timeout\', '
+    f'\'{_IDLE_IN_TRANSACTION_TIMEOUT_MS}\', true) '
+    'WHERE pg_catalog.current_setting('
+    '\'idle_in_transaction_session_timeout\')::interval = interval \'0\' '
+    'OR pg_catalog.current_setting('
+    '\'idle_in_transaction_session_timeout\')::interval '
+    f'> interval \'{_IDLE_IN_TRANSACTION_TIMEOUT_MS} ms\'')
+
+
+def _install_idle_in_transaction_timeout(engine: Any) -> None:
+    """Bound idle_in_transaction_session_timeout on every transaction of a
+    Postgres engine (sync or async) to at most
+    ``_IDLE_IN_TRANSACTION_TIMEOUT_MS``. No-op for other dialects. See the
+    constant's comment for the rationale and the lower-never-raise rule."""
+    target = getattr(engine, 'sync_engine', engine)
+    if target.dialect.name != 'postgresql':
+        return
+
+    @sqlalchemy.event.listens_for(target, 'begin')
+    def _set_idle_in_transaction_timeout(conn):
+        # A transaction-local setting outside a transaction block is a no-op,
+        # and a connection in DBAPI autocommit mode (e.g. isolation_level=
+        # 'AUTOCOMMIT') never has one, so skip it there. Advisory-lock
+        # holders bypass SQLAlchemy Connections entirely
+        # (engine.raw_connection()) and never reach this listener.
+        if getattr(conn.connection.dbapi_connection, 'autocommit', False):
+            return
+        # Runs inside the connection's begin(): SQLAlchemy does not
+        # re-enter begin for statements issued from this event, and the
+        # driver sends its BEGIN before this statement, so the setting lands
+        # inside the transaction it bounds.
+        conn.exec_driver_sql(_IDLE_IN_TRANSACTION_TIMEOUT_SQL).close()
+
 
 @typing.overload
 def get_engine(db_name: Optional[str],
@@ -741,6 +833,8 @@ def get_engine(
                             pool_pre_ping=True,
                             pool_recycle=1800))
                 sql_metrics.install(_postgres_engine_cache[cache_key], role)
+                _install_idle_in_transaction_timeout(
+                    _postgres_engine_cache[cache_key])
             engine = _postgres_engine_cache[cache_key]
     else:
         assert db_name is not None, 'db_name must be provided for SQLite'

--- a/tests/unit_tests/test_sky/utils/test_db_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_db_utils.py
@@ -6,6 +6,7 @@ from unittest import mock
 import pytest
 import pytest_asyncio
 import sqlalchemy
+from sqlalchemy.ext import asyncio as sqlalchemy_async
 
 from sky.utils.db import db_utils
 
@@ -694,3 +695,140 @@ class TestConnStringResolution:
             'postgresql://u:p@pooler:6432/db?sslmode=verify-full')
         assert db_utils._resolve_conn_string(direct=False) == (
             'postgresql://u:p@pooler:6432/db?sslmode=verify-full')
+
+
+class TestIdleInTransactionTimeout:
+    """Tests for the per-transaction idle_in_transaction_session_timeout
+    bound that get_engine installs on Postgres engines."""
+
+    @staticmethod
+    def _begin_listeners(engine):
+        return list(engine.dispatch.begin)
+
+    def test_not_installed_on_sqlite(self, tmp_path):
+        engine = sqlalchemy.create_engine(
+            f'sqlite:///{tmp_path}/idle_tx_sqlite.db')
+        before = len(self._begin_listeners(engine))
+        db_utils._install_idle_in_transaction_timeout(engine)
+        assert len(self._begin_listeners(engine)) == before
+        # A real sqlite transaction runs no SET statement.
+        statements = []
+
+        @sqlalchemy.event.listens_for(engine, 'before_cursor_execute')
+        def _spy(conn, cursor, statement, parameters, context, executemany):
+            del conn, cursor, parameters, context, executemany
+            statements.append(statement)
+
+        with engine.begin() as conn:
+            conn.execute(sqlalchemy.text('select 1'))
+        assert not any(s.startswith('SET LOCAL') for s in statements)
+
+    def test_installed_on_postgres_engine_emits_set_local(self):
+        # create_engine does not connect, so a Postgres URL is safe here.
+        engine = sqlalchemy.create_engine('postgresql+psycopg2://u:p@h/db',
+                                          poolclass=sqlalchemy.NullPool)
+        before = len(self._begin_listeners(engine))
+        db_utils._install_idle_in_transaction_timeout(engine)
+        listeners = self._begin_listeners(engine)
+        assert len(listeners) == before + 1
+        listener = listeners[-1]
+
+        conn = self._fake_connection(autocommit=False)
+        listener(conn)
+        conn.exec_driver_sql.assert_called_once_with(
+            db_utils._IDLE_IN_TRANSACTION_TIMEOUT_SQL)
+        # The result is closed so nothing is left unconsumed on the cursor
+        # (matters for the asyncpg adapter).
+        conn.exec_driver_sql.return_value.close.assert_called_once_with()
+
+    @staticmethod
+    def _fake_connection(autocommit: bool) -> mock.MagicMock:
+        """A stand-in for sqlalchemy.engine.Connection as the listener sees
+        it: a DBAPI connection with an ``autocommit`` attribute."""
+        conn = mock.MagicMock()
+        conn.connection.dbapi_connection.autocommit = autocommit
+        return conn
+
+    def _installed_listener(self):
+        engine = sqlalchemy.create_engine('postgresql+psycopg2://u:p@h/db',
+                                          poolclass=sqlalchemy.NullPool)
+        db_utils._install_idle_in_transaction_timeout(engine)
+        return self._begin_listeners(engine)[-1]
+
+    def test_skipped_on_autocommit_connection(self):
+        """A transaction-local setting outside a transaction block is a
+        no-op, so an autocommit DBAPI connection gets no statement."""
+        listener = self._installed_listener()
+        conn = self._fake_connection(autocommit=True)
+        listener(conn)
+        conn.exec_driver_sql.assert_not_called()
+
+    def test_statement_only_lowers_the_timeout(self):
+        """The bound is applied only when the value in effect is 0 or looser
+        than ours, so a tighter bound is kept whether it came from a
+        server/role default, from a caller's SET LOCAL issued before this
+        statement (e.g. prepended to it by a before_cursor_execute hook), or
+        from one issued after it. That is what makes the statement safe to
+        run first in every transaction regardless of other hooks' order."""
+        sql = db_utils._IDLE_IN_TRANSACTION_TIMEOUT_SQL
+        value = db_utils._IDLE_IN_TRANSACTION_TIMEOUT_MS
+        # Transaction-local (SET LOCAL semantics): reset at COMMIT/ROLLBACK,
+        # so it cannot leak through a transaction-mode pooler.
+        assert ('set_config(\'idle_in_transaction_session_timeout\', '
+                f'\'{value}\', true)') in sql
+        # Conditional on the value currently in effect for this session, read
+        # with current_setting() and compared as an interval (the GUC's text
+        # form carries a unit: '0', '30s', '90500ms', '1d').
+        assert ('current_setting(\'idle_in_transaction_session_timeout\')'
+                '::interval = interval \'0\'') in sql
+        assert ('current_setting(\'idle_in_transaction_session_timeout\')'
+                f'::interval > interval \'{value} ms\'') in sql
+        # Never through pg_settings: that view formats every GUC on each call
+        # (~0.8 ms of server CPU per transaction on Postgres 16, ~20x the
+        # statement itself), and this runs once per transaction fleet-wide.
+        assert 'pg_settings' not in sql
+        assert ' FROM ' not in sql.upper()
+        # One statement: no `;`, so it is safe for the asyncpg adapter too
+        # (extended protocol rejects multi-statement strings).
+        assert ';' not in sql
+
+    def test_statement_is_transaction_local_not_session_wide(self):
+        # A session-wide SET would leak onto the next client that borrows
+        # the server connection through a transaction-mode pooler.
+        sql = db_utils._IDLE_IN_TRANSACTION_TIMEOUT_SQL.upper()
+        assert 'SET_CONFIG(' in sql and ', TRUE)' in sql
+        assert not sql.startswith('SET ')
+
+    def test_installed_on_async_engine_sync_side(self):
+        """For an AsyncEngine the listener goes on sync_engine, where
+        SQLAlchemy emits connection events."""
+        pytest.importorskip('asyncpg')
+        engine = sqlalchemy_async.create_async_engine(
+            'postgresql+asyncpg://u:p@h/db', poolclass=sqlalchemy.NullPool)
+        before = len(self._begin_listeners(engine.sync_engine))
+        db_utils._install_idle_in_transaction_timeout(engine)
+        assert len(self._begin_listeners(engine.sync_engine)) == before + 1
+
+    def test_timeout_value_is_a_sane_default(self):
+        # A minute: far above the milliseconds of in-process work any of our
+        # transactions does between statements, far below the time an
+        # orphaned row lock needs to stall a thread pool.
+        assert db_utils._IDLE_IN_TRANSACTION_TIMEOUT_MS == 60_000
+
+    def test_get_engine_installs_on_postgres(self, monkeypatch):
+        monkeypatch.setenv('IS_SKYPILOT_SERVER', 'true')
+        monkeypatch.setenv('SKYPILOT_DB_CONNECTION_URI',
+                           'postgresql://u:p@h:5432/db')
+        monkeypatch.delenv('SKYPILOT_DB_POOL_HOSTPORT', raising=False)
+        monkeypatch.delenv('SKYPILOT_DB_POOL_CONNECTION_URI', raising=False)
+        db_utils._postgres_engine_cache.clear()
+        db_utils.set_max_connections(0)
+        try:
+            with mock.patch.object(
+                    db_utils, '_install_idle_in_transaction_timeout') as inst:
+                engine = db_utils.get_engine(None)
+                # cached on the second call: installed exactly once.
+                assert db_utils.get_engine(None) is engine
+            inst.assert_called_once_with(engine)
+        finally:
+            db_utils._postgres_engine_cache.clear()


### PR DESCRIPTION
## Summary

- Every transaction on a Postgres engine created by `db_utils.get_engine` (sync psycopg2 and async asyncpg) now bounds `idle_in_transaction_session_timeout` to 60 s for that transaction. A SQLAlchemy `begin` listener runs one transaction-local statement: `SELECT set_config('idle_in_transaction_session_timeout', '60000', true) WHERE current_setting('idle_in_transaction_session_timeout')::interval = interval '0' OR current_setting('idle_in_transaction_session_timeout')::interval > interval '60000 ms'`.
- The bound only ever lowers the timeout. A tighter value already in effect is kept, wherever it came from (a stricter server, database or role default; a caller's own `SET LOCAL` issued before or after this statement, including one prepended to it by another event hook).
- Autocommit connections are skipped (`SET LOCAL` outside a transaction block is a no-op); advisory-lock holders use `engine.raw_connection()` and never reach the listener; SQLite is untouched. No new config knob: reverting the PR is the rollback.

## Why

A client that opens a transaction and then never speaks again (a thread parked forever on a dead socket, a process frozen mid-transaction) leaves its Postgres backend `idle in transaction`, holding its row locks until something closes the session. Postgres' default for `idle_in_transaction_session_timeout` is 0 (never), and a transaction-mode pooler in front of the database never touches a live-but-silent client either. Every later writer of the same row then blocks on the lock. On a hot row such as the per-request `users` upsert, one orphaned transaction turned into a stalled auth thread pool and 503s for every request on a production deployment (#10681 describes the root cause that created the orphan; this PR bounds how long any such orphan can hold its locks).

## Why this shape

- **Per transaction, not a connection option.** A libpq startup `options=-c idle_in_transaction_session_timeout=...` is dropped by a PgBouncer that lists `options` in `ignore_startup_parameters` and refused (`FATAL: unsupported startup parameter in options`) by one that does not (checked on PgBouncer 1.20.1 and 1.25.2); asyncpg `server_settings` hit the same refusal. A plain `SET` on connect leaks onto whichever client next borrows that server connection through a transaction-mode pooler. A transaction-local setting reaches the server on a direct connection and through a pooler, and is scoped to the one transaction (verified: `'0'` on a plain session sharing the same pooled backend).
- **Conditional `set_config`, not a plain `SET LOCAL`.** The listener's statement is the first cursor execute of every transaction. Any hook that prepends its own tighter `SET LOCAL ...;` to "the first statement of the transaction" (a `before_cursor_execute` listener with `retval=True`) attaches it to this statement; a plain `SET LOCAL 60000` would then run last and silently undo the tighter bound. The conditional form makes hook order irrelevant. This composes with per-call bounds such as the auth-path `SET LOCAL` trio in #10684 (5 s wins in every ordering tested), and a future zero-round-trip prepend variant needs no coordination with this listener.
- **`current_setting()` guard, not `pg_settings`.** `pg_settings` is a view over `pg_show_all_settings()`, which formats every GUC (~360 rows) on each call. Measured on Postgres 16 inside an open transaction: a `... FROM pg_settings WHERE name = ...` guard executes in 0.75 ms (`EXPLAIN ANALYZE`: Function Scan, 363 rows removed by filter) and costs +0.65 ms wall over `select 1`; the `current_setting()::interval` guard executes in 0.014 ms (Result node, one-time filter) and costs +0.02 ms, with identical lower-never-raise outcomes on role defaults 0 / 30s / 90500ms / 3661s / 1d. At one to two thousand transactions per second the difference is about one continuous vCPU on the database server. The GUC's text form is always `0` or a number with one unit (`30s`, `90500ms`, `1d`), which `::interval` parses.
- **60 s.** Every transaction in this codebase runs DB statements with only in-process Python between them, so legitimate idle-in-transaction time is milliseconds, low seconds under GIL starvation on a saturated process. Only idle time counts: a long-running statement, a lock wait or a big DDL is never cut, nor is a transaction that keeps issuing statements. A caller cut at 60 s sees an `OperationalError` on its next statement; the transaction was rolled back atomically.

## Cost

- One extra statement per transaction. Server side: 0.014 ms of execution (`EXPLAIN ANALYZE`) and one round trip: about +0.02 ms over `select 1` at the median (+0.018 ms direct / +0.013 ms through PgBouncer in the quoted run; an independent re-run measured +0.029 / +0.016 ms, so run-to-run spread on a shared host is of that order), n=3000 per statement on loopback. End to end through SQLAlchemy (an extra `exec_driver_sql` + result close per transaction): +0.25 to +0.43 ms per transaction at the median across NullPool / QueuePool, direct / PgBouncer, two passes on a shared 16-vCPU host at load average 23-27 (e.g. QueuePool direct 0.50 -> 0.76 ms; NullPool direct 4.83 -> 5.27 ms including the connect) -- most of that is client-side Python, not database work. On a real deployment add one client-server RTT.
- Metrics: the extra driver-level statement has no compiled construct, so `sql_metrics` labels it `table=unknown, op=other`. DB statement-rate and latency panels gain exactly one statement per transaction; anything that derives connection rates from statement rates must subtract it.

## Tested

- `pytest tests/unit_tests/test_sky/utils/test_db_utils.py` (49 passed): not installed on sqlite and no `SET` statement in a sqlite transaction; installed on Postgres engines (sync and `AsyncEngine.sync_engine`), emits the exact statement and closes its result; skipped on autocommit connections; the statement is transaction-local, conditional (a `current_setting()::interval` guard; never `pg_settings`, no `FROM`) and a single statement (asyncpg's extended protocol rejects multi-statement strings); `get_engine` installs it once per cached engine.
- Against Postgres 16 directly and through PgBouncer 1.20.1 in transaction mode, using the real `get_engine`:
  - an orphaned transaction (upsert, never committed, silent) is terminated by the server 60.0 s after its last statement and a waiter on the same row proceeds — psycopg2 and asyncpg engines, both paths;
  - the setting reads `1min` inside our transactions and `0` from a plain session on the same pooled backend (no leak); an autocommit connection emits nothing;
  - a 75 s running `pg_sleep` inside a transaction, a transaction issuing a statement every 10 s for 80 s, an autocommit advisory-lock holder idle 75 s, and a DDL transaction with 5 s gaps are all unaffected;
  - ordering: an explicit `SET LOCAL ... = 5000` issued first -> `5s`; a tighter trio prepended to this listener's statement by a `before_cursor_execute` hook -> `5s`; `SET LOCAL 5000` issued after a real statement -> `5s`; `ALTER ROLE ... SET ... = '30s'` -> `30s` kept (and `1min` again after `RESET`);
  - statement cost and semantics: `EXPLAIN ANALYZE` 0.014 ms vs 0.745 ms for the `pg_settings` form; +0.018 / +0.013 ms over `select 1` (direct / pooled, n=3000, interleaved with a plain `SET LOCAL` at +0.00 and the `pg_settings` form at +0.65 / +0.70); role defaults `0` -> `1min`, `30s` -> `30s` kept (0 rows), `90500ms` / `3661s` / `1d` -> `1min`, each back to the default after rollback; also through asyncpg's extended protocol, direct and pooled.
- `format.sh` (yapf, isort, mypy, pylint) on both files.

Manual check on any Postgres-backed API server: `python -c "from sqlalchemy import orm, text; from sky.utils.db import db_utils; e = db_utils.get_engine(None); s = orm.Session(e); print(s.execute(text(\"select current_setting('idle_in_transaction_session_timeout')\")).scalar())"` prints `1min`; a transaction left idle for 60 s is terminated with `FATAL: terminating connection due to idle-in-transaction timeout` in the Postgres log; an `isolation_level='AUTOCOMMIT'` connection prints `0`.

## Not in this PR

- Tighter per-call bounds on the auth path (#10684).
- Pooler-side `idle_transaction_timeout` (deployment configuration, outside this repo).
- Freeing the client thread that is stuck on the orphaned connection; this PR releases the lock, which stops the fan-out.

## Review status

- Three internal review rounds. Rounds 1 and 2 came back "revise"; the round-2 blocking finding (the guard read `pg_settings`, which formats every GUC per call, and the published cost numbers came from an earlier form of the statement) is fixed on this head.
- Round 3 (2026-09-09) re-reviewed this exact head (`f27ba940c`) and accepted it with no blocking finding. It re-ran the unit tests, `format.sh` and every Postgres / PgBouncer check listed under "Tested", and added probes of its own: every SQLAlchemy entry point emits exactly one `set_config` per transaction (`engine.connect()` autobegin, `engine.begin()`, `Session` plus a `begin_nested()` savepoint; `raw_connection()` emits none), and extreme role defaults behave (`2147483647` and `2h` -> `1min`; `1500ms` and `59999` kept).
- Non-blocking notes from round 3, recorded here so a reviewer does not hunt for them: (a) the per-statement cost figure varies run to run on a shared host (about +0.02 ms; the "Cost" section now says so); (b) a sibling change that also installs a listener right after `sql_metrics.install(...)` in `get_engine` will meet a one-hunk textual conflict with this PR — whichever lands second resolves it, and a hook that prepends `SET LOCAL` to the first statement of a transaction should be installed before this listener (the values are correct in either order; the order only decides whether one redundant `SET LOCAL` is emitted).
- Still a draft pending a maintainer's review.

-Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
