### PR TITLE
[Server] Fix double close of the kubectl port-forward stdout fd under uvloop

### DIFF
--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -3428,10 +3428,13 @@ async def kubernetes_pod_ssh_proxy(websocket: fastapi.WebSocket,
     # `loop.connect_read_pipe(..., proc.stdout)` must not be used here: it
     # gives the loop an object that owns the fd. Under uvloop the pipe
     # transport then closes the fd twice on the same number when it is torn
-    # down (libuv `uv_close`, then `proc.stdout.close()` with the EBADF
-    # swallowed), with a GIL release in between. Any other thread that
-    # allocates an fd in that window (a DB connection, a /proc read, a
-    # socket) gets the freed number and has it closed under it.
+    # down: once through libuv (`uv_close`) and once through
+    # `proc.stdout.close()`; whichever runs second gets EBADF, which is
+    # swallowed. The order depends on whether the transport is closed
+    # explicitly or collected by the cyclic GC. CPython releases the GIL
+    # around its close(), so any other thread that allocates an fd in that
+    # window (a DB connection, a /proc read, a socket) gets the freed number
+    # and has it closed under it.
     # NonOwningPipeReader only watches the fd; `proc.stdout` stays its single
     # owner and is closed exactly once in the `finally` below.
     stdout_reader = asyncio_utils.NonOwningPipeReader(loop,
@@ -3490,31 +3493,36 @@ async def kubernetes_pod_ssh_proxy(websocket: fastapi.WebSocket,
             conn_gauge.dec()
         # Unregister the fd from the loop before anything closes it.
         stdout_reader.stop()
-        # poll() reaps the child if it already exited on its own (before the
-        # port-forward came up, or under an active session).
-        exited_on_its_own = proc.poll() is not None
-        if exited_on_its_own and proxying:
-            leftover = stdout_reader.drain()
-            logger.error('kubectl port-forward exited before the ssh '
-                         'websocket connection was closed. Remaining '
-                         f'output: {leftover!r}')
-        if not exited_on_its_own:
-            logger.info('Terminating kubectl port-forward process')
-            proc.terminate()
-            # Reap the kubectl child. `asyncio.create_subprocess_exec` had
-            # this handled by asyncio's child watcher; `subprocess.Popen` is
-            # outside that watcher so we must wait() ourselves or leave a
-            # zombie.
-            try:
-                await asyncio.wait_for(loop.run_in_executor(None, proc.wait),
-                                       timeout=5)
-            except asyncio.TimeoutError:
-                logger.warning(
-                    'kubectl did not exit 5s after SIGTERM; sending SIGKILL.')
-                proc.kill()
-                await loop.run_in_executor(None, proc.wait)
-        # The one and only close of the stdout pipe fd.
-        proc.stdout.close()
+        exited_on_its_own = False
+        try:
+            # poll() reaps the child if it already exited on its own (before
+            # the port-forward came up, or under an active session).
+            exited_on_its_own = proc.poll() is not None
+            if exited_on_its_own and proxying:
+                leftover = stdout_reader.drain()
+                logger.error('kubectl port-forward exited before the ssh '
+                             'websocket connection was closed. Remaining '
+                             f'output: {leftover!r}')
+            if not exited_on_its_own:
+                logger.info('Terminating kubectl port-forward process')
+                proc.terminate()
+                # Reap the kubectl child. `asyncio.create_subprocess_exec`
+                # had this handled by asyncio's child watcher;
+                # `subprocess.Popen` is outside that watcher so we must
+                # wait() ourselves or leave a zombie.
+                try:
+                    waiter = loop.run_in_executor(None, proc.wait)
+                    await asyncio.wait_for(waiter, timeout=5)
+                except asyncio.TimeoutError:
+                    logger.warning('kubectl did not exit 5s after SIGTERM; '
+                                   'sending SIGKILL.')
+                    proc.kill()
+                    await loop.run_in_executor(None, proc.wait)
+        finally:
+            # The one and only close of the stdout pipe fd. Unconditional, so
+            # a cancellation or an executor error while waiting for kubectl
+            # cannot skip it.
+            proc.stdout.close()
         if exited_on_its_own or stdout_eof:
             reason = 'KubectlPortForwardExit'
         elif ssh_failed:

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -3421,35 +3421,52 @@ async def kubernetes_pod_ssh_proxy(websocket: fastapi.WebSocket,
     loop = asyncio.get_running_loop()
     proc = await loop.run_in_executor(None, _spawn_sync)
     logger.info(f'Started kubectl port-forward with command: {kubectl_cmd}')
-
-    # Wrap the sync Popen's stdout pipe as an asyncio StreamReader so the
-    # rest of this handler can stay async.
     assert proc.stdout is not None
-    stdout_reader = asyncio.StreamReader(loop=loop)
-    await loop.connect_read_pipe(
-        lambda: asyncio.StreamReaderProtocol(stdout_reader, loop=loop),
-        proc.stdout)
 
-    # Wait for port-forward to be ready and get the local port
-    local_port = None
-    while True:
-        stdout_line = await stdout_reader.readline()
-        if stdout_line:
+    # Watch kubectl's stdout without handing its fd to the event loop.
+    #
+    # `loop.connect_read_pipe(..., proc.stdout)` must not be used here: it
+    # gives the loop an object that owns the fd. Under uvloop the pipe
+    # transport then closes the fd twice on the same number when it is torn
+    # down (libuv `uv_close`, then `proc.stdout.close()` with the EBADF
+    # swallowed), with a GIL release in between. Any other thread that
+    # allocates an fd in that window (a DB connection, a /proc read, a
+    # socket) gets the freed number and has it closed under it.
+    # NonOwningPipeReader only watches the fd; `proc.stdout` stays its single
+    # owner and is closed exactly once in the `finally` below.
+    stdout_reader = asyncio_utils.NonOwningPipeReader(loop,
+                                                      proc.stdout.fileno())
+    conn_gauge = metrics_utils.SKY_APISERVER_WEBSOCKET_CONNECTIONS.labels(
+        pid=os.getpid())
+    proxying = False
+    stdout_eof = False
+    ssh_failed = False
+    try:
+        stdout_reader.start()
+        # Wait for port-forward to be ready and get the local port
+        local_port = None
+        while True:
+            stdout_line = await stdout_reader.readline()
+            if not stdout_line:
+                # kubectl closed its stdout, i.e. it exited (or is exiting)
+                # before the port-forward came up, e.g. the pod is gone. The
+                # `finally` below reaps it.
+                stdout_eof = True
+                await websocket.close()
+                return
             decoded_line = stdout_line.decode()
             logger.info(f'kubectl port-forward stdout: {decoded_line}')
             if 'Forwarding from 127.0.0.1' in decoded_line:
                 port_str = decoded_line.split(':')[-1]
                 local_port = int(port_str.replace(' -> ', ':').split(':')[0])
                 break
-        else:
-            await websocket.close()
-            return
+        # Nothing consumes kubectl's stdout during the session. The little it
+        # prints ("Handling connection for <port>") stays in the kernel pipe
+        # buffer and is drained for logging when the session ends.
+        stdout_reader.stop()
 
-    logger.info(f'Starting port-forward to local port: {local_port}')
-    conn_gauge = metrics_utils.SKY_APISERVER_WEBSOCKET_CONNECTIONS.labels(
-        pid=os.getpid())
-    ssh_failed = False
-    try:
+        logger.info(f'Starting port-forward to local port: {local_port}')
+        proxying = True
         conn_gauge.inc()
         # Connect to the local port
         reader, writer = await asyncio.open_connection('127.0.0.1', local_port)
@@ -3469,37 +3486,43 @@ async def kubernetes_pod_ssh_proxy(websocket: fastapi.WebSocket,
             timestamps_supported=timestamps_supported,
         )
     finally:
-        conn_gauge.dec()
-        reason = ''
-        try:
+        if proxying:
+            conn_gauge.dec()
+        # Unregister the fd from the loop before anything closes it.
+        stdout_reader.stop()
+        # poll() reaps the child if it already exited on its own (before the
+        # port-forward came up, or under an active session).
+        exited_on_its_own = proc.poll() is not None
+        if exited_on_its_own and proxying:
+            leftover = stdout_reader.drain()
+            logger.error('kubectl port-forward exited before the ssh '
+                         'websocket connection was closed. Remaining '
+                         f'output: {leftover!r}')
+        if not exited_on_its_own:
             logger.info('Terminating kubectl port-forward process')
             proc.terminate()
-        except ProcessLookupError:
-            stdout = await stdout_reader.read()
-            logger.error('kubectl port-forward was terminated before the '
-                         'ssh websocket connection was closed. Remaining '
-                         f'output: {str(stdout)}')
+            # Reap the kubectl child. `asyncio.create_subprocess_exec` had
+            # this handled by asyncio's child watcher; `subprocess.Popen` is
+            # outside that watcher so we must wait() ourselves or leave a
+            # zombie.
+            try:
+                await asyncio.wait_for(loop.run_in_executor(None, proc.wait),
+                                       timeout=5)
+            except asyncio.TimeoutError:
+                logger.warning(
+                    'kubectl did not exit 5s after SIGTERM; sending SIGKILL.')
+                proc.kill()
+                await loop.run_in_executor(None, proc.wait)
+        # The one and only close of the stdout pipe fd.
+        proc.stdout.close()
+        if exited_on_its_own or stdout_eof:
             reason = 'KubectlPortForwardExit'
-            metrics_utils.SKY_APISERVER_WEBSOCKET_CLOSED_TOTAL.labels(
-                pid=os.getpid(), reason=reason).inc()
+        elif ssh_failed:
+            reason = 'SSHToPodDisconnected'
         else:
-            if ssh_failed:
-                reason = 'SSHToPodDisconnected'
-            else:
-                reason = 'ClientClosed'
+            reason = 'ClientClosed'
         metrics_utils.SKY_APISERVER_WEBSOCKET_CLOSED_TOTAL.labels(
             pid=os.getpid(), reason=reason).inc()
-        # Reap the kubectl child. `asyncio.create_subprocess_exec` had this
-        # handled by asyncio's child watcher; `subprocess.Popen` is outside
-        # that watcher so we must wait() ourselves or leave a zombie.
-        try:
-            await asyncio.wait_for(loop.run_in_executor(None, proc.wait),
-                                   timeout=5)
-        except asyncio.TimeoutError:
-            logger.warning(
-                'kubectl did not exit 5s after SIGTERM; sending SIGKILL.')
-            proc.kill()
-            await loop.run_in_executor(None, proc.wait)
 
 
 def _build_slurm_job_ssh_command(

--- a/sky/utils/asyncio_utils.py
+++ b/sky/utils/asyncio_utils.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import functools
+import os
 import random
 from typing import Set
 
@@ -118,3 +119,98 @@ def shield(func):
             raise
 
     return async_wrapper
+
+
+# Bytes read from the pipe per readiness callback in NonOwningPipeReader.
+_PIPE_READ_CHUNK = 65536
+
+
+class NonOwningPipeReader:
+    """Line reader for a pipe fd that never takes ownership of the fd.
+
+    Feeds an `asyncio.StreamReader` from `loop.add_reader()` readiness
+    callbacks. The caller keeps owning the fd (typically through
+    `subprocess.Popen.stdout`) and must close it exactly once, after `stop()`.
+
+    Why not `loop.connect_read_pipe(protocol_factory, pipe)`: it hands the
+    loop a file object that owns the fd. asyncio's pipe transport closes that
+    object once. uvloop's pipe transport first lets libuv close the fd and
+    then calls `pipe.close()` on the same, already-closed fd number (it
+    swallows the EBADF). CPython releases the GIL between those two closes,
+    so an fd allocated by another thread in that window takes the freed number
+    and is then closed under its owner: a DB socket, a /proc file, another
+    pipe. `add_reader()` / `remove_reader()` never close the fd on either loop
+    (asyncio selectors; libuv `uv_poll`), so with this class the fd has exactly
+    one owner.
+
+    `start()` switches the fd to non-blocking mode. Do not read it through the
+    owning file object while the reader is active.
+    """
+
+    def __init__(self, loop: asyncio.AbstractEventLoop, fd: int):
+        self._loop = loop
+        self._fd = fd
+        self._reader = asyncio.StreamReader(loop=loop)
+        self._watching = False
+
+    @property
+    def fd(self) -> int:
+        return self._fd
+
+    def start(self) -> None:
+        """Start watching the fd for readable data."""
+        os.set_blocking(self._fd, False)
+        self._loop.add_reader(self._fd, self._on_readable)
+        self._watching = True
+
+    def stop(self) -> None:
+        """Stop watching the fd. Idempotent.
+
+        Must be called before the owner closes the fd: closing a watched fd
+        leaves the loop with a watcher for a number the next pipe or socket
+        can reuse.
+        """
+        if self._watching:
+            self._watching = False
+            self._loop.remove_reader(self._fd)
+
+    def _on_readable(self) -> None:
+        try:
+            data = os.read(self._fd, _PIPE_READ_CHUNK)
+        except (BlockingIOError, InterruptedError):
+            return
+        except OSError as e:
+            self.stop()
+            self._reader.set_exception(e)
+            return
+        if data:
+            self._reader.feed_data(data)
+        else:
+            self.stop()
+            self._reader.feed_eof()
+
+    async def readline(self) -> bytes:
+        """Read one line. Returns b'' at EOF (the writer closed the pipe)."""
+        return await self._reader.readline()
+
+    def drain(self, max_bytes: int = _PIPE_READ_CHUNK) -> bytes:
+        """Return what the pipe holds right now, without blocking.
+
+        Stops watching first. Meant for logging leftover output after the
+        writer has exited; bytes already consumed by `readline()` are not
+        included.
+        """
+        self.stop()
+        chunks = []
+        total = 0
+        while total < max_bytes:
+            try:
+                data = os.read(self._fd, min(_PIPE_READ_CHUNK,
+                                             max_bytes - total))
+            except OSError:
+                break
+            if not data:
+                break
+            chunks.append(data)
+            total += len(data)
+        return b''.join(chunks)

--- a/sky/utils/asyncio_utils.py
+++ b/sky/utils/asyncio_utils.py
@@ -134,14 +134,15 @@ class NonOwningPipeReader:
 
     Why not `loop.connect_read_pipe(protocol_factory, pipe)`: it hands the
     loop a file object that owns the fd. asyncio's pipe transport closes that
-    object once. uvloop's pipe transport first lets libuv close the fd and
-    then calls `pipe.close()` on the same, already-closed fd number (it
-    swallows the EBADF). CPython releases the GIL between those two closes,
-    so an fd allocated by another thread in that window takes the freed number
-    and is then closed under its owner: a DB socket, a /proc file, another
-    pipe. `add_reader()` / `remove_reader()` never close the fd on either loop
-    (asyncio selectors; libuv `uv_poll`), so with this class the fd has exactly
-    one owner.
+    object once. uvloop's pipe transport closes the fd number twice: once
+    through libuv (`uv_close`) and once through `pipe.close()`; whichever
+    runs second gets EBADF, which is swallowed. The order depends on whether
+    the transport is closed explicitly or torn down by the cyclic GC. CPython
+    releases the GIL around its close(), so an fd allocated by another thread
+    in that window takes the freed number and is then closed under its owner:
+    a DB socket, a /proc file, another pipe. `add_reader()` /
+    `remove_reader()` never close the fd on either loop (asyncio selectors;
+    libuv `uv_poll`), so with this class the fd has exactly one owner.
 
     `start()` switches the fd to non-blocking mode. Do not read it through the
     owning file object while the reader is active.

--- a/tests/unit_tests/test_sky/server/test_ssh_proxy_ws.py
+++ b/tests/unit_tests/test_sky/server/test_ssh_proxy_ws.py
@@ -235,6 +235,22 @@ def loop(request):
 
 
 @pytest.fixture
+def sky_caplog(caplog, monkeypatch):
+    """`caplog` that also sees records from `sky.*` loggers.
+
+    `sky_logging` sets `propagate = False` on the `sky` logger, so its
+    records never reach the root logger, which is where pytest installs the
+    caplog handler. pytest >= 9.1 attaches that handler to non-propagating
+    loggers as well (pytest-dev/pytest#3697); older releases, e.g. the 8.x
+    that Python 3.9 still resolves to, do not, and `caplog.records` stays
+    empty. Let `sky` propagate for the duration of the test so both behave
+    the same.
+    """
+    monkeypatch.setattr(logging.getLogger('sky'), 'propagate', True)
+    return caplog
+
+
+@pytest.fixture
 def fake_kubectl(tmp_path):
     path = tmp_path / 'kubectl'
     path.write_text(f'#!{sys.executable}\n' + _FAKE_KUBECTL)
@@ -366,15 +382,24 @@ def test_ssh_proxy_kubectl_exit_before_forwarding_reaps_child(
 
 
 def test_ssh_proxy_kubectl_death_mid_session_logs_leftover(
-        loop, fake_kubectl, caplog):
+        loop, fake_kubectl, sky_caplog):
     before = _closed_total('KubectlPortForwardExit')
-    with caplog.at_level(logging.ERROR, logger='sky.server.server'):
+    with sky_caplog.at_level(logging.ERROR, logger='sky.server.server'):
         _, captured = _run_handler(loop, fake_kubectl, 'die',
                                    _wait_for_kubectl_death)
     proc = captured.procs[0]
     assert captured.echoed == b''
+    # Reaped by poll(), not terminated (the fake exits 0 on SIGTERM).
     assert proc.returncode == 1
     assert _closed_total('KubectlPortForwardExit') == before + 1
-    assert any('lost connection to pod' in rec.getMessage()
-               for rec in caplog.records), caplog.text
+    # The kubectl-died-first branch logged what kubectl printed after the
+    # port-forward came up, including its last line before exiting.
+    exit_messages = [
+        rec.getMessage()
+        for rec in sky_caplog.records
+        if 'kubectl port-forward exited before' in rec.getMessage()
+    ]
+    assert exit_messages, sky_caplog.text
+    assert all(
+        'lost connection to pod' in msg for msg in exit_messages), exit_messages
     _assert_pipe_fd_released(loop, proc)

--- a/tests/unit_tests/test_sky/server/test_ssh_proxy_ws.py
+++ b/tests/unit_tests/test_sky/server/test_ssh_proxy_ws.py
@@ -6,6 +6,7 @@ unhandled RuntimeError traceback) when cluster validation fails.
 """
 
 import asyncio
+import contextlib
 import gc
 import logging
 import os
@@ -234,20 +235,30 @@ def loop(request):
         asyncio.set_event_loop(None)
 
 
-@pytest.fixture
-def sky_caplog(caplog, monkeypatch):
-    """`caplog` that also sees records from `sky.*` loggers.
+@contextlib.contextmanager
+def _capture_sky_logs(caplog, name: str, level: int):
+    """Capture records emitted by the `sky` logger `name` in `caplog`.
 
-    `sky_logging` sets `propagate = False` on the `sky` logger, so its
-    records never reach the root logger, which is where pytest installs the
-    caplog handler. pytest >= 9.1 attaches that handler to non-propagating
-    loggers as well (pytest-dev/pytest#3697); older releases, e.g. the 8.x
-    that Python 3.9 still resolves to, do not, and `caplog.records` stays
-    empty. Let `sky` propagate for the duration of the test so both behave
-    the same.
+    pytest installs the caplog handler on the root logger, but `sky_logging`
+    sets `propagate = False` on the `sky` logger and the API server's logging
+    setup (`sky.server.uvicorn.add_timestamp_prefix_for_server_logs`, run
+    when another test starts the app in-process in the same worker) does the
+    same for `sky.server`. Records from `sky.server.*` never reach the root
+    logger, so `caplog.records` stays empty. pytest >= 9.1 also attaches its
+    handler to non-propagating loggers (pytest-dev/pytest#3697); the 8.x that
+    Python 3.9 still resolves to does not. Attach the handler to the emitting
+    logger itself so every pytest version and worker history behaves the
+    same. Enter this from the test body: pytest swaps `caplog.handler`
+    between the setup and call phases, so a fixture would attach the wrong
+    one.
     """
-    monkeypatch.setattr(logging.getLogger('sky'), 'propagate', True)
-    return caplog
+    emitter = logging.getLogger(name)
+    with caplog.at_level(level, logger=name):
+        emitter.addHandler(caplog.handler)
+        try:
+            yield caplog
+        finally:
+            emitter.removeHandler(caplog.handler)
 
 
 @pytest.fixture
@@ -382,9 +393,9 @@ def test_ssh_proxy_kubectl_exit_before_forwarding_reaps_child(
 
 
 def test_ssh_proxy_kubectl_death_mid_session_logs_leftover(
-        loop, fake_kubectl, sky_caplog):
+        loop, fake_kubectl, caplog):
     before = _closed_total('KubectlPortForwardExit')
-    with sky_caplog.at_level(logging.ERROR, logger='sky.server.server'):
+    with _capture_sky_logs(caplog, 'sky.server.server', logging.ERROR):
         _, captured = _run_handler(loop, fake_kubectl, 'die',
                                    _wait_for_kubectl_death)
     proc = captured.procs[0]
@@ -396,10 +407,10 @@ def test_ssh_proxy_kubectl_death_mid_session_logs_leftover(
     # port-forward came up, including its last line before exiting.
     exit_messages = [
         rec.getMessage()
-        for rec in sky_caplog.records
+        for rec in caplog.records
         if 'kubectl port-forward exited before' in rec.getMessage()
     ]
-    assert exit_messages, sky_caplog.text
+    assert exit_messages, caplog.text
     assert all(
         'lost connection to pod' in msg for msg in exit_messages), exit_messages
     _assert_pipe_fd_released(loop, proc)

--- a/tests/unit_tests/test_sky/server/test_ssh_proxy_ws.py
+++ b/tests/unit_tests/test_sky/server/test_ssh_proxy_ws.py
@@ -5,13 +5,20 @@ gracefully (rather than raising an HTTPException, which would surface as an
 unhandled RuntimeError traceback) when cluster validation fails.
 """
 
+import asyncio
+import gc
+import logging
+import os
 import shlex
+import subprocess
+import sys
 from unittest import mock
 
 import fastapi
 import pytest
 
 from sky import clouds
+from sky.metrics import utils as metrics_utils
 from sky.server import server
 
 
@@ -158,3 +165,216 @@ async def test_validate_cluster_for_ssh_proxy_ws_truncates_long_reason():
 
     assert result is None
     websocket.close.assert_awaited_once_with(code=1008, reason='x' * 123)
+
+
+# ---------------------------------------------------------------------------
+# kubernetes_pod_ssh_proxy: kubectl stdout pipe ownership and child reaping.
+#
+# These drive the real handler with a fake `kubectl` (a small Python script)
+# and a stubbed websocket proxy, on asyncio and on uvloop when installed. They
+# guard the fd lifecycle: the stdout pipe fd has exactly one owner
+# (`proc.stdout`), is closed exactly once, is unregistered from the loop before
+# that close, and the kubectl child is always reaped -- including when kubectl
+# exits before the port-forward is up.
+# ---------------------------------------------------------------------------
+
+_FAKE_KUBECTL = """\
+import os
+import signal
+import socket
+import sys
+import time
+
+mode = sys.argv[-1]
+if mode == 'exit':
+    print('Error from server (NotFound): pods "ghost" not found', flush=True)
+    sys.exit(1)
+
+srv = socket.socket()
+srv.bind(('127.0.0.1', 0))
+srv.listen(8)
+port = srv.getsockname()[1]
+print(f'Forwarding from 127.0.0.1:{port} -> 22', flush=True)
+print(f'Forwarding from [::1]:{port} -> 22', flush=True)
+signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
+conn, _ = srv.accept()
+print(f'Handling connection for {port}', flush=True)
+if mode == 'die':
+    conn.close()
+    print('E0908 lost connection to pod', flush=True)
+    sys.exit(1)
+while True:
+    data = conn.recv(1024)
+    if not data:
+        sys.exit(0)
+    conn.sendall(data)
+"""
+
+
+def _loop_factories():
+    factories = [asyncio.new_event_loop]
+    try:
+        import uvloop  # pylint: disable=import-outside-toplevel
+        factories.append(uvloop.new_event_loop)
+    except ImportError:
+        pass
+    return factories
+
+
+@pytest.fixture(params=_loop_factories(),
+                ids=lambda f: f.__module__.split('.')[0])
+def loop(request):
+    the_loop = request.param()
+    asyncio.set_event_loop(the_loop)
+    try:
+        yield the_loop
+    finally:
+        the_loop.run_until_complete(asyncio.sleep(0))
+        the_loop.close()
+        asyncio.set_event_loop(None)
+
+
+@pytest.fixture
+def fake_kubectl(tmp_path):
+    path = tmp_path / 'kubectl'
+    path.write_text(f'#!{sys.executable}\n' + _FAKE_KUBECTL)
+    path.chmod(0o755)
+    return str(path)
+
+
+def _fd_is_open(fd: int) -> bool:
+    try:
+        os.fstat(fd)
+        return True
+    except OSError:
+        return False
+
+
+def _closed_total(reason: str) -> float:
+    return metrics_utils.SKY_APISERVER_WEBSOCKET_CLOSED_TOTAL.labels(
+        pid=os.getpid(), reason=reason)._value.get()  # pylint: disable=protected-access
+
+
+class _Captured:
+    """What the patched Popen and proxy stub saw."""
+
+    def __init__(self):
+        self.procs = []
+        self.echoed = None
+
+
+def _run_handler(loop, fake_kubectl, mode, proxy_stub):
+    captured = _Captured()
+    real_popen = subprocess.Popen
+
+    def capturing_popen(*args, **kwargs):
+        proc = real_popen(*args, **kwargs)
+        captured.procs.append(proc)
+        return proc
+
+    handle = mock.MagicMock()
+    handle.head_ssh_port = 22
+    handle.get_command_runners.return_value[0].port_forward_command.\
+        return_value = ['kubectl', 'port-forward', 'pod/x', ':22', mode]
+    websocket = _make_websocket()
+    websocket.accept = mock.AsyncMock()
+
+    async def stub(websocket, read_from_backend, write_to_backend,
+                   close_backend, timestamps_supported):
+        del websocket, timestamps_supported
+        return await proxy_stub(captured, read_from_backend, write_to_backend,
+                                close_backend)
+
+    with mock.patch.object(server, '_KUBECTL_PATH', fake_kubectl), \
+            mock.patch.object(server, '_validate_cluster_for_ssh_proxy_ws',
+                              new=mock.AsyncMock(return_value=handle)), \
+            mock.patch.object(server.websocket_utils, 'run_websocket_proxy',
+                              new=stub), \
+            mock.patch.object(subprocess, 'Popen', capturing_popen):
+        loop.run_until_complete(
+            server.kubernetes_pod_ssh_proxy(websocket, 'my-cluster'))
+    assert len(captured.procs) == 1
+    return websocket, captured
+
+
+async def _echo_once(captured, read_from_backend, write_to_backend,
+                     close_backend):
+    await write_to_backend(b'ping')
+    captured.echoed = await read_from_backend()
+    await close_backend()
+    return False
+
+
+async def _wait_for_kubectl_death(captured, read_from_backend, write_to_backend,
+                                  close_backend):
+    del write_to_backend
+    captured.echoed = await read_from_backend()  # b'' once kubectl closes
+    proc = captured.procs[0]
+    for _ in range(500):
+        if proc.poll() is not None:
+            break
+        await asyncio.sleep(0.01)
+    await close_backend()
+    return True
+
+
+def _assert_pipe_fd_released(loop, proc):
+    """The stdout fd is closed once, unwatched, and safe to reuse."""
+    assert proc.stdout.closed
+    fd = proc.stdout.raw.fileno() if not proc.stdout.raw.closed else None
+    assert fd is None
+    # Not registered with the loop any more (must not raise on either loop).
+    # We do not know the number any more; instead reuse the lowest free
+    # numbers and check nothing closes them behind our back.
+    canary_r, canary_w = os.pipe()
+
+    async def spin():
+        for _ in range(50):
+            await asyncio.sleep(0)
+        gc.collect()
+        await asyncio.sleep(0.02)
+
+    loop.run_until_complete(spin())
+    os.write(canary_w, b'x')
+    assert os.read(canary_r, 1) == b'x'
+    os.close(canary_r)
+    os.close(canary_w)
+
+
+def test_ssh_proxy_forwarding_session_releases_pipe_once(loop, fake_kubectl):
+    before = _closed_total('ClientClosed')
+    websocket, captured = _run_handler(loop, fake_kubectl, 'forward',
+                                       _echo_once)
+    proc = captured.procs[0]
+    assert captured.echoed == b'ping'
+    assert proc.returncode is not None  # reaped
+    websocket.close.assert_not_awaited()
+    assert _closed_total('ClientClosed') == before + 1
+    _assert_pipe_fd_released(loop, proc)
+
+
+def test_ssh_proxy_kubectl_exit_before_forwarding_reaps_child(
+        loop, fake_kubectl):
+    before = _closed_total('KubectlPortForwardExit')
+    websocket, captured = _run_handler(loop, fake_kubectl, 'exit', _echo_once)
+    proc = captured.procs[0]
+    websocket.close.assert_awaited_once()
+    # Previously left as a zombie until the next Popen(); now reaped.
+    assert proc.returncode == 1
+    assert _closed_total('KubectlPortForwardExit') == before + 1
+    _assert_pipe_fd_released(loop, proc)
+
+
+def test_ssh_proxy_kubectl_death_mid_session_logs_leftover(
+        loop, fake_kubectl, caplog):
+    before = _closed_total('KubectlPortForwardExit')
+    with caplog.at_level(logging.ERROR, logger='sky.server.server'):
+        _, captured = _run_handler(loop, fake_kubectl, 'die',
+                                   _wait_for_kubectl_death)
+    proc = captured.procs[0]
+    assert captured.echoed == b''
+    assert proc.returncode == 1
+    assert _closed_total('KubectlPortForwardExit') == before + 1
+    assert any('lost connection to pod' in rec.getMessage()
+               for rec in caplog.records), caplog.text
+    _assert_pipe_fd_released(loop, proc)

--- a/tests/unit_tests/test_sky/utils/test_asyncio_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_asyncio_utils.py
@@ -1,0 +1,167 @@
+"""Unit tests for sky.utils.asyncio_utils.NonOwningPipeReader.
+
+The reader watches a pipe fd through `loop.add_reader()` and must never close
+the fd itself. That property is what keeps the API server's kubectl stdout
+pipe from being closed twice under uvloop (one close by libuv, one by the
+`Popen.stdout` file object), which frees the fd number for another thread and
+then closes it under that thread. The tests run on asyncio and, when
+installed, on uvloop.
+"""
+
+import asyncio
+import gc
+import io
+import os
+from typing import Callable, List
+
+import pytest
+
+from sky.utils import asyncio_utils
+
+
+def _loop_factories() -> List[Callable[[], asyncio.AbstractEventLoop]]:
+    factories: List[Callable[[], asyncio.AbstractEventLoop]] = [
+        asyncio.new_event_loop
+    ]
+    try:
+        import uvloop  # pylint: disable=import-outside-toplevel
+        factories.append(uvloop.new_event_loop)
+    except ImportError:
+        pass
+    return factories
+
+
+def _loop_id(factory: Callable[[], asyncio.AbstractEventLoop]) -> str:
+    return factory.__module__.split('.')[0]
+
+
+@pytest.fixture(params=_loop_factories(), ids=_loop_id)
+def loop(request):
+    the_loop = request.param()
+    asyncio.set_event_loop(the_loop)
+    try:
+        yield the_loop
+    finally:
+        the_loop.run_until_complete(asyncio.sleep(0))
+        the_loop.close()
+        asyncio.set_event_loop(None)
+
+
+def _fd_is_open(fd: int) -> bool:
+    try:
+        os.fstat(fd)
+        return True
+    except OSError:
+        return False
+
+
+async def _spin(loop: asyncio.AbstractEventLoop, iterations: int = 20):
+    del loop  # unused
+    for _ in range(iterations):
+        await asyncio.sleep(0)
+    gc.collect()
+    await asyncio.sleep(0.01)
+
+
+def test_reads_lines_without_owning_fd(loop):
+    """readline() works and stop() leaves the fd open for its owner."""
+    read_fd, write_fd = os.pipe()
+    # Mirror subprocess.Popen.stdout: a BufferedReader that owns read_fd.
+    owner = io.open(read_fd, 'rb', closefd=True)
+    ident = os.fstat(read_fd)
+
+    async def scenario():
+        reader = asyncio_utils.NonOwningPipeReader(loop, owner.fileno())
+        reader.start()
+        os.write(
+            write_fd, b'Handling connection for 1\n'
+            b'Forwarding from 127.0.0.1:4242 -> 22\n')
+        assert await reader.readline() == b'Handling connection for 1\n'
+        assert (await
+                reader.readline()) == b'Forwarding from 127.0.0.1:4242 -> 22\n'
+        reader.stop()
+        reader.stop()  # idempotent
+        await _spin(loop)
+
+    loop.run_until_complete(scenario())
+    # The reader did not close the fd: same open file, same inode.
+    assert _fd_is_open(read_fd)
+    after = os.fstat(read_fd)
+    assert (after.st_dev, after.st_ino) == (ident.st_dev, ident.st_ino)
+    # The owner closes it exactly once.
+    owner.close()
+    assert not _fd_is_open(read_fd)
+    os.close(write_fd)
+
+
+def test_eof_stops_watching_and_owner_closes_once(loop):
+    """EOF unregisters the fd; the closed number is safe to reuse."""
+    read_fd, write_fd = os.pipe()
+    owner = io.open(read_fd, 'rb', closefd=True)
+
+    async def scenario():
+        reader = asyncio_utils.NonOwningPipeReader(loop, owner.fileno())
+        reader.start()
+        os.write(write_fd, b'Error from server (NotFound)\n')
+        os.close(write_fd)
+        assert await reader.readline() == b'Error from server (NotFound)\n'
+        assert await reader.readline() == b''  # EOF
+        # Still open: EOF only stopped the watch.
+        assert _fd_is_open(read_fd)
+        # remove_reader on an fd that EOF already unregistered must not raise
+        # on either loop (the handler's `finally` calls stop() again).
+        reader.stop()
+        loop.remove_reader(read_fd)
+        owner.close()
+        assert not _fd_is_open(read_fd)
+
+        # fd-reuse canary: the next pipe takes the lowest free number, i.e.
+        # the one just closed. Nothing may close it behind our back once the
+        # loop runs its pending callbacks and the GC collects the reader.
+        canary_r, canary_w = os.pipe()
+        assert read_fd in (canary_r, canary_w)
+        del reader
+        await _spin(loop)
+        os.write(canary_w, b'x')
+        assert os.read(canary_r, 1) == b'x'
+        os.close(canary_r)
+        os.close(canary_w)
+
+    loop.run_until_complete(scenario())
+
+
+def test_drain_is_non_blocking(loop):
+    read_fd, write_fd = os.pipe()
+    owner = io.open(read_fd, 'rb', closefd=True)
+
+    async def scenario():
+        reader = asyncio_utils.NonOwningPipeReader(loop, owner.fileno())
+        reader.start()
+        os.write(
+            write_fd, b'Forwarding from 127.0.0.1:4242 -> 22\n'
+            b'Forwarding from [::1]:4242 -> 22\n')
+        assert (await
+                reader.readline()) == b'Forwarding from 127.0.0.1:4242 -> 22\n'
+        reader.stop()
+        # Writer still alive, pipe possibly empty: must return immediately.
+        os.write(write_fd, b'E0908 lost connection to pod\n')
+        assert reader.drain() == b'E0908 lost connection to pod\n'
+        assert reader.drain() == b''
+        os.close(write_fd)
+        assert reader.drain() == b''
+        assert _fd_is_open(read_fd)
+
+    loop.run_until_complete(scenario())
+    owner.close()
+
+
+def test_drain_caps_bytes(loop):
+    read_fd, write_fd = os.pipe()
+    owner = io.open(read_fd, 'rb', closefd=True)
+    reader = asyncio_utils.NonOwningPipeReader(loop, owner.fileno())
+    os.set_blocking(read_fd, False)
+    os.write(write_fd, b'x' * 1000)
+    assert len(reader.drain(max_bytes=100)) == 100
+    assert len(reader.drain()) == 900
+    os.close(write_fd)
+    owner.close()

--- a/tests/unit_tests/test_sky/utils/test_asyncio_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_asyncio_utils.py
@@ -115,11 +115,12 @@ def test_eof_stops_watching_and_owner_closes_once(loop):
         owner.close()
         assert not _fd_is_open(read_fd)
 
-        # fd-reuse canary: the next pipe takes the lowest free number, i.e.
-        # the one just closed. Nothing may close it behind our back once the
-        # loop runs its pending callbacks and the GC collects the reader.
+        # fd-reuse canary: the next pipe normally takes the lowest free
+        # number, i.e. the one just closed (another thread may grab it first,
+        # so this is not asserted). Nothing may close the canary behind our
+        # back once the loop runs its pending callbacks and the GC collects
+        # the reader.
         canary_r, canary_w = os.pipe()
-        assert read_fd in (canary_r, canary_w)
         del reader
         await _spin(loop)
         os.write(canary_w, b'x')


### PR DESCRIPTION
## Problem

`kubernetes_pod_ssh_proxy` (the WebSocket handler behind ssh into Kubernetes pods) spawns `kubectl port-forward` with `subprocess.Popen` in a worker thread (#9431) and hands `proc.stdout` to `loop.connect_read_pipe()`. `proc.stdout` is a file object that **owns** the pipe fd. Under uvloop, the pipe transport left behind by every ssh-proxy session closes that fd **number twice** when it is torn down.

The second close is not harmless. CPython releases the GIL around `close()`, and Linux always hands out the lowest free fd number, so any fd that another thread allocates between the two closes takes the freed number and is then closed under its owner. On an API server that runs thousands of short ssh-proxy sessions per day, this hits whatever the other threads happen to be opening at that moment. Observed on a production deployment over several days:

- psycopg2 connections: `could not receive data from server: Bad file descriptor`, `Socket operation on non-socket`, and protocol cross-talk where one DB connection read another connection's bytes (or an SSH banner, or a TLS record). About 1,200 events in 5 days.
- The per-process metrics thread: its `/proc` read returned a Postgres protocol packet and the thread died (dozens of times, freezing that worker's CPU gauge).
- The handler's own next `kubectl`: `FileExistsError` from `connect_read_pipe` (libuv `uv__fd_exists` on a stale watcher) and `OSError: [Errno 9] Bad file descriptor` from `posix_spawn`, leaving an orphaned `kubectl`.
- Worst case: a DB connection whose fd was stolen while a transaction was open. The thread that owned it stayed parked in libpq `poll()` forever, the row lock it held on the server was never released, and every later request that needed the same row pinned another thread until the auth thread pool was exhausted on every replica and the deployment returned "The server has exhausted its concurrent worker limit" to everyone (#10681).

The bug is uvloop-only. asyncio's own `_UnixReadPipeTransport` closes the pipe object exactly once (`Lib/asyncio/unix_events.py`, `_call_connection_lost`).

## Mechanism

The handler hands `proc.stdout` (a `BufferedReader` whose `FileIO` owns the pipe fd) to `loop.connect_read_pipe()`; uvloop opens the same fd number in libuv (`uv_pipe_open`, no dup) and keeps a reference to the file object (`UVSocketHandle._attach_fileobj`). When `kubectl` exits, uvloop does not close the transport: `UVStream._on_eof` (uvloop 0.22.1, `uvloop/handles/stream.pyx:608-625`) only stops reading, because `asyncio.StreamReaderProtocol.eof_received()` returns `True` (CPython 3.10 `Lib/asyncio/streams.py:268`). The handler never called `transport.close()`, so the transport and its protocol survive in a reference cycle until the cyclic GC collects them, on whichever thread happens to trigger that collection, at a time unrelated to the session end. During that collection `tp_clear` drops the transport's reference to the file object, and CPython's `FileIO` finalizer closes the fd (`Modules/_io/fileio.c`, `internal_close`, which releases the GIL around the `close()` syscall). Then `UVHandle.__dealloc__` (`uvloop/handles/handle.pyx:27-70`) calls `uv_close`, and libuv closes the same fd number a second time with a raw `syscall(SYS_close)` (`src/unix/core.c`, `uv__close_nocancel`); in strace this is `epoll_ctl(EPOLL_CTL_DEL, N) = -1 EBADF` followed by `close(N) = -1 EBADF` when nobody reused the number, or `close(N) = 0` on someone else's fd when they did. Because the GIL is released between the two closes and Linux reuses the lowest free number, any fd another thread opens in that gap takes number N and is closed under its owner. An explicit `transport.close()` would not fix this: `UVSocketHandle._close` (`handle.pyx`) runs libuv's close first and then `self._fileobj.close()` with `EBADF` swallowed, and it only `detach()`es `socket.socket` objects, so a pipe file object is still closed twice. The window is milliseconds per collected transport, but the handler runs once per ssh-proxy session, dead transports are collected in batches on arbitrary threads, and the other threads allocate fds constantly (a new DB socket per pooled call, `/proc` reads once per second, outbound sockets, pipes), so hits are routine rather than rare.

## Fix

- New `sky.utils.asyncio_utils.NonOwningPipeReader`: feeds an `asyncio.StreamReader` from `loop.add_reader()` readiness callbacks (`os.read` when readable). `add_reader`/`remove_reader` never close the fd on either loop (asyncio: selector registration; uvloop: libuv `uv_poll`, whose close path `uv__poll_close` only stops the watcher, `src/unix/poll.c:103-109,158-160`). `proc.stdout` stays the single owner of the fd and the handler closes it exactly once, in `finally`, after `stop()` (unregister before close, so the loop never keeps a watcher for a number the next pipe can reuse). The close is inside an inner `try/finally`, so a cancellation or executor error while waiting for `kubectl` cannot skip it.
- The handler's `try/finally` now spans the readline loop. The EOF-before-"Forwarding" branch (`kubectl` exits at once, e.g. pod not found) falls through to the same `finally`, which reaps the child (`poll()`) and closes stdout; previously it returned early and left a zombie until the next `Popen()` ran `subprocess._cleanup()`.
- `kubectl` exiting first is detected with `proc.poll()`; the old `except ProcessLookupError` branch was unreachable since Python 3.9 (`send_signal` polls first, bpo-38630), so the `KubectlPortForwardExit` close reason was never reported. It now is, and the leftover stdout is drained non-blocking for the log line.
- #9431's property is kept: `Popen` still runs in a worker thread; nothing goes through libuv's `uv_spawn`/fork.

### Why `add_reader` and not the alternatives

- `os.dup()` + `io.FileIO(dup_fd, closefd=False)` + `connect_read_pipe`: who closes the dup'd fd depends on the loop (asyncio closes only through the file object, uvloop closes through libuv), so it needs an `isinstance(loop, uvloop.Loop)` branch and still relies on GC timing for the teardown. Rejected.
- Explicit `transport.close()` at session end: under uvloop that still runs both closes (see Mechanism), just at a predictable time. Rejected.
- Blocking `proc.stdout.readline()` in `run_in_executor`: pins a default-executor thread per in-flight handshake; `kubectl` can stall for 30-60 s when the cluster API or the pod is unreachable, so a burst of bad sessions saturates a pool that other handlers share. Rejected.
- `add_reader` on the raw fd is loop-agnostic, thread-free, and keeps one owner. After the port-forward is up nothing consumes `kubectl`'s stdout; the little it prints ("Handling connection for <port>") sits in the 64 KiB kernel pipe buffer and is drained when the session ends (before: buffered in the `StreamReader` up to 128 KiB, then the transport was paused).

## Tests

- `tests/unit_tests/test_sky/utils/test_asyncio_utils.py`: the reader never closes the fd (same inode after `stop()` and after EOF), the owner closes once, an fd-reuse canary survives loop iterations + GC, `drain()` is non-blocking. Parametrized over asyncio and uvloop.
- `tests/unit_tests/test_sky/server/test_ssh_proxy_ws.py`: drives the real handler with a fake `kubectl` script (prints the `Forwarding from 127.0.0.1:<port> -> 22` line, listens, echoes) and a stubbed proxy body: forwarding session, `kubectl` exit before forwarding (child reaped, `KubectlPortForwardExit` counted), `kubectl` death mid-session (leftover output logged). Both loops. On unfixed master 5 of the 6 handler tests fail (stdout left open under uvloop; zombie and missing counter on the EOF branch); the asyncio forwarding case passes there, as expected for a uvloop-only bug.
- Existing `tests/unit_tests/test_sky/server/test_server.py` and `tests/unit_tests/test_sky/users/test_rbac.py` pass. `format.sh` clean (yapf, isort, mypy, pylint 10/10).

### Double-close detector (out of tree, runs the real handler without a cluster)

An `LD_PRELOAD` interposer on libc `close()` and `syscall()` (libuv closes through `syscall(SYS_close)`) plus an independent strace cross-check, driving `kubernetes_pod_ssh_proxy` with a fake `kubectl`: 200 forwarding + 20 EOF-before-Forwarding sessions per run, 8 concurrent threads allocating and using `socketpair` fds the way DB and `/proc` readers do, Python 3.10.21, uvloop 0.22.1. Before/after on the same host:

| tree | loop | second-close events (same fd, same thread) | of which `EBADF` | landed on another thread's live fd (first-order / cascade) | allocator threads hit (`EBADF` / `ENOTSOCK` / cross-talk) | handler exceptions | zombie `kubectl` |
|---|---|---|---|---|---|---|---|
| master | uvloop | **226** | 209 | 14 / 3 | 7 / 1 / 29 | 2 (`OSError: [Errno 9] Bad file descriptor`) | 21 |
| this branch | uvloop | **0** | 0 | 0 / 0 | 0 / 0 / 0 | 0 | 0 |
| master | asyncio (control) | **0** | 0 | 0 / 0 | 0 / 0 / 0 | 0 | 20 |
| this branch | asyncio (control) | **0** | 0 | 0 / 0 | 0 / 0 / 0 | 0 | 0 |

- strace cross-check (uvloop, no allocator threads, so every second close must return `EBADF`): master 220 `close() = -1 EBADF` in 220 sessions, this branch 0. With `strace -k`, every one of master's `EBADF` closes comes from `uv__close_nocancel <- uv_close <- UVHandle tp_dealloc <- gc_collect_main`, each preceded on the same fd and thread by `_io_FileIO_close <- iobase_finalize <- gc_collect_main`; the fixed tree has no `uv__poll_close -> close` path anywhere.
- `ResourceWarning: unclosed resource <ReadUnixTransport>` at GC: master 218-220 per run, this branch 0.
- With a 300 us delay inserted before each close as a window amplifier, 4 of 220 unfixed sessions hung on the first `readline()` of `kubectl`'s stdout (the pipe's fd number had been closed and reused under the handler; cut off by a 30 s harness timeout), with 229 second-close events; this branch: 0 hangs, 0 second-close events.

## Validation on a real deployment

Done. Same test server (2 API-server pods, 60 uvicorn workers each, uvloop 0.22.1, Python 3.10, psycopg2 2.9.12 through a PgBouncer sidecar to Postgres), same load generator, same 90-minute profile, three runs back to back: unfixed build, this fix, unfixed build again (A/B/A). The fix was applied to the running image as an overlay of exactly the two changed files (`sky/server/server.py`, `sky/utils/asyncio_utils.py`); nothing else changed between runs. The load was the pattern that reproduced the outage in #10681 on this server: 4 users each opening 12 ssh-proxy WebSocket sessions within 0.4 s every 15 s (about 11,000 sessions per hour), plus concurrent same-user HTTP requests and 20 background users.

| run (90 min each) | build | ssh-proxy sessions | fd-corruption incidents in the server log (psycopg2 `Bad file descriptor` / `Socket operation on non-socket` / `lost synchronization`, `FileExistsError` from `connect_read_pipe`, `OSError: [Errno 9]` from `posix_spawn`) | per 1,000 sessions (95 % CI) | metrics-thread (`process_monitor`) deaths | DB threads pinned in `poll()` on a stolen fd | sessions that reached forwarding | HTTP 503 seen by clients |
|---|---|---|---|---|---|---|---|
| 1 | unfixed | 12,455 | **20** | 1.61 (0.98-2.48) | 3 | **1** (row lock held 35 min, auth pool 32/32 on 10 workers, ~14,000 503s) | 12,444 / 17,280 (handshakes rejected during the outage) | 14,430 |
| 2 | **this PR** | 17,280 | **0** | 0.00 (0-0.21) | **0** | **0** | **17,280 / 17,280** | **0** |
| 3 | unfixed | 17,269 | **31** | 1.80 (1.22-2.55) | 4 | 0 (+1 worker whose event loop hung in libpq `poll()` on a reused pipe fd for 34 min) | 17,256 / 17,280 | 0 |

- Chance that run 2's zero is luck at the unfixed rate (51 incidents in 29,724 unfixed sessions): Poisson expected 29.6, P(0) ~ 1e-13; rate-free exact test 7e-11. Metrics-thread deaths alone: expected 4.1, P(0) = 0.017.
- Open fds per hot worker returned to the starting value (38) at the end of run 2; on the unfixed runs the hot workers ended 8-42 fds above their start, and 4 leaked `kubectl port-forward` processes (1-2 h old) were found on the unfixed pods after ~23,000 sessions. Threads per hot worker: 71 -> 73 on the fix, 72 -> 105 on run 1 (the pinned auth threads).
- `PYTHONWARNINGS=always::ResourceWarning` canary (two extra 20-minute cells, same profile, unfixed then fixed): unfixed 3,584 `ResourceWarning: unclosed resource <ReadUnixTransport …>` for 3,839 sessions (about one per session, emitted at GC time); fixed **0** for 3,840 sessions.
- `kubectl` exit handling (same two cells, `kubectl port-forward` processes SIGKILLed inside the container for 2x90 s, so sessions saw kubectl die both before "Forwarding" and mid-session): unfixed: 297 kills, 149 sessions ended before forwarding, 4 transient zombie `kubectl` seen (reaped only by the next `Popen`), `KubectlPortForwardExit` never counted (mid-session deaths were labelled `SSHToPodDisconnected`, the `except ProcessLookupError` branch is dead code); fixed: 903 kills, 493 before forwarding, 5 transient (each gone within 1 s, reaped by the handler itself) zombies, `websocket_closed_total{reason="KubectlPortForwardExit"}` = **890**, 0 leaked or zombie `kubectl` at the end.
- No new exception classes, no `Exception in ASGI application`, on the fixed build in any cell.

Caveats: the test server's load has higher same-user concurrency than the production deployment and its DB round trip is shorter, so its absolute event rates are not the production rates; the comparison is within one server. A silent pin is rare (about one per 90 minutes here), so run 2's zero pins is expected-but-not-conclusive on its own (P(0) ~ 0.4-0.6); the loud classes share the cause and are the statistically strong result.

## Not in this PR

- When `kubectl` dies between printing `Forwarding` and the handler's `open_connection`, the connect fails with `ConnectionRefusedError` and the session ends as an ASGI exception (pre-existing; seen on both builds only when `kubectl` was killed deliberately; the `finally` still reaps and closes). Could be caught and turned into a WebSocket close reason. Follow-up.
- The handshake `readline()` loop has no timeout (pre-existing): a `kubectl` that never prints `Forwarding` holds the WebSocket and the child until the client goes away. Follow-up.
- Hardening of the auth path itself (the per-request `users` upsert with no lock or statement timeout, and the 5 s deadline that frees the caller but not the thread) is being addressed separately (#10684, #10687).
- Upstream: uvloop should `detach()`-equivalent non-socket file objects instead of closing them, and asyncio's `StreamReaderProtocol.eof_received()` returning `True` keeps uvloop pipe transports alive until GC. Not filed here.

Fixes #10681

-Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)

