### PR TITLE
[Docker] Allow the image's Python version to be overridden

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,14 @@
 # syntax=docker/dockerfile:1
 
+# The interpreter every stage builds on. Overridable so a deployment can
+# build this image on a newer Python: the API server's
+# SKYPILOT_API_SERVER_WORKER_MAX_TASKS_PER_CHILD worker recycling needs
+# ProcessPoolExecutor's max_tasks_per_child, which is 3.11+ only, so on the
+# default 3.10 base that setting is silently inert.
+ARG PYTHON_VERSION=3.10.19
+
 # Stage 1: Install Google Cloud SDK using APT
-FROM python:3.10.19-slim AS gcloud-apt-install
+FROM python:${PYTHON_VERSION}-slim AS gcloud-apt-install
 
 # Keep in sync with _GCLOUD_VERSION in sky/clouds/gcp.py. Pinned so the apt
 # install layer doesn't bake in a stale version via buildx registry caching
@@ -24,7 +31,7 @@ RUN apt-get update && \
 
 
 # Stage 2: Process the source code for INSTALL_FROM_SOURCE
-FROM python:3.10.19-slim AS process-source
+FROM python:${PYTHON_VERSION}-slim AS process-source
 
 # Control installation method - default to install from source
 ARG INSTALL_FROM_SOURCE=true
@@ -75,7 +82,7 @@ RUN cd /skypilot && \
 
 
 # Stage 3: Main image
-FROM python:3.10.19-slim
+FROM python:${PYTHON_VERSION}-slim
 
 ARG INSTALL_FROM_SOURCE=true
 


### PR DESCRIPTION
## Problem

`SKYPILOT_API_SERVER_WORKER_MAX_TASKS_PER_CHILD` (added in 1e95ee8) recycles guaranteed executor workers so their high-water-mark RSS is returned to the OS. It maps to `ProcessPoolExecutor`'s `max_tasks_per_child`, which Python added in 3.11, so `compute_server_config()` correctly declines it on older interpreters:

```python
if sys.version_info < (3, 11):
    logger.warning(
        '%s is set but worker recycling requires Python 3.11+; '
        'ignoring it on Python %d.%d.', ...)
    return None
```

Every published image is built on `python:3.10.19-slim` — all three stages of this Dockerfile. SkyPilot itself supports 3.9 through 3.13 (per the package classifiers), but a deployment running an official image is on 3.10, so the setting is silently inert for exactly the audience the feature targets: a long-lived remote API server under sustained load.

We hit the growth the recycling was written for — a server pod climbing steadily toward its container limit, with the pool's cumulative RSS as the cause — and found no supported way to enable the fix short of not using the official image.

## Change

Take the interpreter as a build argument:

```dockerfile
ARG PYTHON_VERSION=3.10.19
FROM python:${PYTHON_VERSION}-slim AS gcloud-apt-install
```

applied to all three stages. The default is the current pin, so published images and every existing build are byte-for-byte unchanged; a deployment that needs worker recycling can build the same image on 3.11+.

Happy to follow up with a docs note on the API server tuning page pointing at this, or to add a 3.12 variant to the publish matrix if that's the direction you'd prefer.

## Tested

- `docker buildx build --build-arg PYTHON_VERSION=3.10.19` — unchanged from current behavior.
- Confirmed the wheel is `py3-none-any`, so no per-interpreter artifact work is implied by the change.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10690" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->