### PR TITLE
[API] Count middleware rejections at the edge (no client-visible change)

### DIFF
--- a/sky/metrics/utils.py
+++ b/sky/metrics/utils.py
@@ -234,6 +234,34 @@ SKY_APISERVER_EVENT_LOOP_STALL_TOTAL = prom.Counter(
     ['source'],
 )
 
+# Requests a middleware answered itself with a canned rejection instead of
+# letting a route handler run: authentication failures, auth-path database
+# deadlines, auth executor exhaustion, RBAC denials. These responses never
+# reach a route handler, so they are only visible to the request counters
+# because the metrics middleware is the outermost one; this counter says
+# *why* they were rejected. Bounded on purpose: `reason` is a closed set (see
+# sky/server/middleware_utils.py), `status` is the HTTP status the middleware
+# answered with and `kind` is `http` or `websocket` (a rejected WebSocket
+# handshake). No path label: the paths of rejected requests are chosen by
+# unauthenticated clients.
+SKY_APISERVER_REQUEST_REJECTIONS_TOTAL = prom.Counter(
+    'sky_apiserver_request_rejections_total',
+    'Requests a middleware rejected with a canned response, by reason',
+    ['reason', 'status', 'kind'],
+)
+
+# WebSocket handshakes refused by a middleware, by the decision that refused
+# them (the close-code set in sky/server/middleware_utils.websocket_aware:
+# unauthorized / forbidden / error). Handshakes are not HTTP requests from
+# the request counter's point of view, so without this counter a storm of
+# refused handshakes is invisible: it only shows up as fewer connections.
+# `path` is restricted to the registered WebSocket routes, else `other`.
+SKY_APISERVER_WEBSOCKET_HANDSHAKE_REJECTIONS_TOTAL = prom.Counter(
+    'sky_apiserver_websocket_handshake_rejections_total',
+    'WebSocket handshakes refused by a middleware, by decision',
+    ['path', 'outcome'],
+)
+
 SKY_APISERVER_WEBSOCKET_CONNECTIONS = prom.Gauge(
     'sky_apiserver_websocket_connections',
     'Number of websocket connections',

--- a/sky/server/auth/db_lookup.py
+++ b/sky/server/auth/db_lookup.py
@@ -21,6 +21,14 @@ Both timeout and executor exhaustion must be converted to responses
 *inside* the middleware: app-level exception handlers wrap the router
 only, so an exception raised in a middleware surfaces as a bare 500,
 which clients do not retry.
+
+Every response helper here accepts the request it answers and, when given
+one, stamps the rejection reason on it (``middleware_utils.mark_rejection``)
+so the metrics middleware can count these 503s by cause: a middleware
+answering a request itself is otherwise invisible to request-level metrics.
+The request is optional so that callers outside this repository, which call
+the helpers with no arguments, keep getting the same 503; they only lose the
+per-reason attribution until they pass the request too.
 """
 import asyncio
 import os
@@ -30,6 +38,7 @@ import fastapi
 
 from sky import exceptions
 from sky import sky_logging
+from sky.server import middleware_utils
 from sky.server.requests import executor
 from sky.users import permission
 from sky.utils import common_utils
@@ -73,9 +82,18 @@ async def _call_on_request_pool(func: Callable[..., Any], *args: Any) -> Any:
                                   timeout=AUTH_DB_TIMEOUT_SECONDS)
 
 
+def _mark(request: Optional[fastapi.Request], reason: str) -> None:
+    """Attribute a canned rejection for the metrics layer, if we know which
+    request it answers."""
+    if request is not None:
+        middleware_utils.mark_rejection(request, reason)
+
+
 async def ensure_role_for_authenticated_user(
-        user_id: str,
-        newly_added: bool) -> Optional[fastapi.responses.JSONResponse]:
+    user_id: str,
+    newly_added: bool,
+    request: Optional[fastapi.Request] = None
+) -> Optional[fastapi.responses.JSONResponse]:
     """Give an authenticated principal a role. A response to send, or None.
 
     Both auth front-ends (the auth-proxy middleware and the oauth2-proxy one)
@@ -103,7 +121,7 @@ async def ensure_role_for_authenticated_user(
             logger.error(f'Concurrent worker exhausted seeding a role for '
                          f'{user_id}: {e}')
             permission.permission_service.queue_role_repair(user_id)
-            return worker_exhausted_response()
+            return worker_exhausted_response(request=request)
         except asyncio.TimeoutError:
             # Separated from the clause below for the log, not the answer: the
             # deadline elapsed but the seed is still running in its thread and
@@ -114,7 +132,7 @@ async def ensure_role_for_authenticated_user(
                          f'finish within {AUTH_DB_TIMEOUT_SECONDS}s; queueing '
                          f'it off the request')
             permission.permission_service.queue_role_repair(user_id)
-            return role_seed_unavailable_response()
+            return role_seed_unavailable_response(request=request)
         except Exception as e:  # pylint: disable=broad-except
             # Everything else, because an exception raised in a middleware
             # surfaces as a bare 500, which clients do not retry (see this
@@ -126,14 +144,16 @@ async def ensure_role_for_authenticated_user(
                          f'queueing it off the request: '
                          f'{common_utils.format_exception(e)}')
             permission.permission_service.queue_role_repair(user_id)
-            return role_seed_unavailable_response()
+            return role_seed_unavailable_response(request=request)
         return None
     if not permission.permission_service.probably_has_role(user_id):
         permission.permission_service.queue_role_repair(user_id)
     return None
 
 
-def db_timeout_response() -> fastapi.responses.JSONResponse:
+def db_timeout_response(
+    request: Optional[fastapi.Request] = None
+) -> fastapi.responses.JSONResponse:
     """503 for an auth lookup that timed out on a degraded database.
 
     503 (not 504/429) because the client maps exactly 503 to
@@ -142,6 +162,7 @@ def db_timeout_response() -> fastapi.responses.JSONResponse:
     The detail message is distinct from the worker-exhausted 503 so
     operators can tell the two apart in logs.
     """
+    _mark(request, middleware_utils.REJECT_REASON_AUTH_DB_TIMEOUT)
     return fastapi.responses.JSONResponse(
         status_code=503,
         headers={'Retry-After': str(max(1, int(AUTH_DB_TIMEOUT_SECONDS)))},
@@ -151,7 +172,9 @@ def db_timeout_response() -> fastapi.responses.JSONResponse:
         })
 
 
-def role_seed_unavailable_response() -> fastapi.responses.JSONResponse:
+def role_seed_unavailable_response(
+    request: Optional[fastapi.Request] = None
+) -> fastapi.responses.JSONResponse:
     """503 for a new user whose role could not be assigned in time.
 
     Not `db_timeout_response`: that one names a slow database, and the reason
@@ -159,6 +182,7 @@ def role_seed_unavailable_response() -> fastapi.responses.JSONResponse:
     healthy database doing exactly what it should. Same 503 so the client
     retries with backoff, and by then the queued repair has normally landed.
     """
+    _mark(request, middleware_utils.REJECT_REASON_ROLE_SEED_UNAVAILABLE)
     return fastapi.responses.JSONResponse(
         status_code=503,
         headers={'Retry-After': str(max(1, int(AUTH_DB_TIMEOUT_SECONDS)))},
@@ -169,13 +193,16 @@ def role_seed_unavailable_response() -> fastapi.responses.JSONResponse:
         })
 
 
-def jwt_secret_unavailable_response() -> fastapi.responses.JSONResponse:
+def jwt_secret_unavailable_response(
+    request: Optional[fastapi.Request] = None
+) -> fastapi.responses.JSONResponse:
     """503 for service-account auth that cannot load its signing secret.
 
     Not a 401: the token is well-formed and the server simply cannot reach the
     secret to check it. A 401 reads as "this credential is bad" and pushes
     operators to rotate tokens over what is a transient database problem.
     """
+    _mark(request, middleware_utils.REJECT_REASON_JWT_SECRET_UNAVAILABLE)
     return fastapi.responses.JSONResponse(
         status_code=503,
         headers={'Retry-After': str(max(1, int(AUTH_DB_TIMEOUT_SECONDS)))},
@@ -187,7 +214,9 @@ def jwt_secret_unavailable_response() -> fastapi.responses.JSONResponse:
         })
 
 
-def worker_exhausted_response() -> fastapi.responses.JSONResponse:
+def worker_exhausted_response(
+    request: Optional[fastapi.Request] = None
+) -> fastapi.responses.JSONResponse:
     """503 for auth-path work rejected by a saturated thread executor.
 
     Either pool: the auth executor for lookups, or the request executor for a
@@ -198,6 +227,7 @@ def worker_exhausted_response() -> fastapi.responses.JSONResponse:
     exceptions raised in middlewares, so middlewares must convert the
     error themselves or it surfaces as a bare 500.
     """
+    _mark(request, middleware_utils.REJECT_REASON_AUTH_WORKER_EXHAUSTED)
     return fastapi.responses.JSONResponse(
         status_code=503,
         content={

--- a/sky/server/auth/oauth2_proxy.py
+++ b/sky/server/auth/oauth2_proxy.py
@@ -169,13 +169,13 @@ class OAuth2ProxyMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
                         global_user_state.add_or_update_user, auth_user)
                 except asyncio.TimeoutError:
                     logger.error('oauth2-proxy user upsert timed out')
-                    return db_lookup.db_timeout_response()
+                    return db_lookup.db_timeout_response(request)
                 except exceptions.ConcurrentWorkerExhaustedError as e:
                     logger.error(f'Concurrent worker exhausted during '
                                  f'oauth2-proxy user upsert: {e}')
-                    return db_lookup.worker_exhausted_response()
+                    return db_lookup.worker_exhausted_response(request)
                 failed = await db_lookup.ensure_role_for_authenticated_user(
-                    auth_user.id, newly_added)
+                    auth_user.id, newly_added, request=request)
                 if failed is not None:
                     return failed
                 request.state.auth_user = auth_user

--- a/sky/server/auth/oauth2_proxy.py
+++ b/sky/server/auth/oauth2_proxy.py
@@ -160,7 +160,7 @@ class OAuth2ProxyMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
                 if not auth_user:
                     middleware_utils.mark_rejection(
                         request,
-                        middleware_utils.REJECT_REASON_AUTH_PROXY_UNAVAILABLE)
+                        middleware_utils.REJECT_REASON_AUTH_PROXY_BAD_RESPONSE)
                     return fastapi.responses.JSONResponse(
                         status_code=http.HTTPStatus.INTERNAL_SERVER_ERROR,
                         content={
@@ -221,7 +221,7 @@ class OAuth2ProxyMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
                              f'{auth_response.status}: {auth_response.text}')
                 middleware_utils.mark_rejection(
                     request,
-                    middleware_utils.REJECT_REASON_AUTH_PROXY_UNAVAILABLE)
+                    middleware_utils.REJECT_REASON_AUTH_PROXY_BAD_RESPONSE)
                 return fastapi.responses.JSONResponse(
                     status_code=auth_response.status,
                     content={'detail': 'oauth2-proxy error'})

--- a/sky/server/auth/oauth2_proxy.py
+++ b/sky/server/auth/oauth2_proxy.py
@@ -108,6 +108,9 @@ class OAuth2ProxyMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
                     return fastapi_response
             except (aiohttp.ClientError, asyncio.TimeoutError) as e:
                 logger.error(f'Error forwarding to OAuth2 proxy: {e}')
+                middleware_utils.mark_rejection(
+                    request,
+                    middleware_utils.REJECT_REASON_AUTH_PROXY_UNAVAILABLE)
                 return fastapi.responses.JSONResponse(
                     status_code=http.HTTPStatus.BAD_GATEWAY,
                     content={'detail': 'oauth2-proxy service unavailable'})
@@ -126,6 +129,9 @@ class OAuth2ProxyMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
             except (aiohttp.ClientError, asyncio.TimeoutError) as e:
                 logger.error(f'Error communicating with OAuth2 proxy: {e}'
                              f'{traceback.format_exc()}')
+                middleware_utils.mark_rejection(
+                    request,
+                    middleware_utils.REJECT_REASON_AUTH_PROXY_UNAVAILABLE)
                 return fastapi.responses.JSONResponse(
                     status_code=http.HTTPStatus.BAD_GATEWAY,
                     content={'detail': 'oauth2-proxy service unavailable'})
@@ -152,6 +158,9 @@ class OAuth2ProxyMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
                 # User is authenticated, extract user info from headers
                 auth_user = self.get_auth_user(auth_response)
                 if not auth_user:
+                    middleware_utils.mark_rejection(
+                        request,
+                        middleware_utils.REJECT_REASON_AUTH_PROXY_UNAVAILABLE)
                     return fastapi.responses.JSONResponse(
                         status_code=http.HTTPStatus.INTERNAL_SERVER_ERROR,
                         content={
@@ -210,6 +219,9 @@ class OAuth2ProxyMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
             else:
                 logger.error('oauth2-proxy returned unexpected status '
                              f'{auth_response.status}: {auth_response.text}')
+                middleware_utils.mark_rejection(
+                    request,
+                    middleware_utils.REJECT_REASON_AUTH_PROXY_UNAVAILABLE)
                 return fastapi.responses.JSONResponse(
                     status_code=auth_response.status,
                     content={'detail': 'oauth2-proxy error'})

--- a/sky/server/metrics.py
+++ b/sky/server/metrics.py
@@ -8,7 +8,7 @@ import os
 import re
 import threading
 import time
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Dict, FrozenSet, List, Optional, Set, Tuple
 
 import fastapi
 from prometheus_client import core as prom_core
@@ -17,6 +17,7 @@ from prometheus_client import multiprocess
 import prometheus_client as prom
 import psutil
 import starlette.middleware.base
+import starlette.types
 import uvicorn
 
 from sky import core
@@ -27,6 +28,7 @@ from sky.adaptors import kubernetes as kubernetes_adaptor
 from sky.metrics import utils as metrics_utils
 from sky.server import constants as server_constants
 from sky.server import local_disk
+from sky.server import middleware_utils
 from sky.skylet import runtime_utils
 from sky.utils import annotations
 from sky.utils import common
@@ -1563,51 +1565,170 @@ def _get_user_label(request: fastapi.Request) -> str:
     return 'anonymous'
 
 
+# `path` label for a response produced by a middleware, i.e. a request that
+# never reached the router (an authentication 401/503, an RBAC 403, ...).
+# The metrics middleware is the outermost one, so these responses are
+# counted, and their paths are chosen by whoever sent them -- unauthenticated
+# scanners included -- so the raw path cannot be the label value. The raw
+# path is kept only when it is exactly a registered (parameterless) route;
+# anything else is folded into one of these fixed prefixes, as `<prefix>*`,
+# or into `other`. The prefixes are the routers mounted in
+# sky/server/server.py plus the plugin route root; the `*` form keeps the
+# prefix regexes dashboards and rules already use (e.g. `/api/.*`,
+# `/dashboard/.*`) matching. The bare prefix (`/users`, a router's root
+# route) folds into the same bucket. A request that did reach the router
+# keeps its raw path, 404s included, exactly as before.
+#
+# "Registered route" means a route on the app's own table: with current
+# FastAPI, `include_router` adds one opaque entry per router, so the routes
+# of the included core and plugin routers are not in it and fold into their
+# prefix bucket. Bounded either way.
+_MIDDLEWARE_REJECTED_PATH_PREFIXES = (
+    '/api/',
+    '/dashboard/',
+    '/internal/dashboard/',
+    '/plugins/',
+    '/jobs/',
+    '/serve/',
+    '/users/',
+    '/workspaces/',
+    '/volumes/',
+    '/ssh_node_pools/',
+    '/recipes/',
+    '/storage/',
+    '/debug/',
+)
+OTHER_PATH_LABEL = 'other'
+
+
+def _reached_router(request: fastapi.Request) -> bool:
+    """Whether the request got past every middleware to the router.
+
+    Starlette's router stamps itself on the scope when it runs
+    (`scope['router']`); a request a middleware answered itself never gets
+    there. This is what tells a route's own 4xx/5xx (raw path, as before)
+    from a middleware's canned rejection (bounded path).
+    """
+    return 'router' in request.scope
+
+
+def _literal_route_paths(app) -> FrozenSet[str]:
+    """The registered route paths without path parameters."""
+    routes = getattr(app, 'routes', None)
+    if not isinstance(routes, (list, tuple)):
+        return frozenset()
+    return frozenset(route.path
+                     for route in routes
+                     if isinstance(getattr(route, 'path', None), str) and
+                     '{' not in route.path)
+
+
+def _middleware_rejected_path_label(path: str,
+                                    literal_routes: FrozenSet[str]) -> str:
+    """Bounded `path` label for a response a middleware produced."""
+    if path in literal_routes:
+        return path
+    for prefix in _MIDDLEWARE_REJECTED_PATH_PREFIXES:
+        if path.startswith(prefix) or path == prefix[:-1]:
+            return prefix + '*'
+    return OTHER_PATH_LABEL
+
+
 class PrometheusMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
-    """Middleware to collect Prometheus metrics for HTTP requests."""
+    """Middleware to collect Prometheus metrics for HTTP requests.
+
+    Registered as the OUTERMOST middleware (added last in
+    sky/server/server.py), so it records the response the client actually
+    receives. An authentication, RBAC or shutdown middleware that answers a
+    request itself never calls the next layer; with this middleware inside
+    the stack those responses -- exactly the ones an outage produces -- were
+    never counted, and the only visible symptom was successful traffic
+    dropping.
+
+    The `path` label is read after the inner layers ran, so it is the path
+    the router saw (inner middlewares rewrite `scope['path']` in place, e.g.
+    the internal dashboard prefix): the same value as before. For a response
+    produced by a middleware the path is bounded instead; see
+    `_middleware_rejected_path_label`. When the middleware that answered
+    stamped a reason (`middleware_utils.mark_rejection`), the response is
+    also counted in `sky_apiserver_request_rejections_total`.
+
+    Duration is measured from entry into this layer, i.e. it includes the
+    time the authentication middlewares spend (DB lookups under their
+    deadline): it is the latency the client observed.
+
+    WebSocket scopes pass straight through, as for every BaseHTTPMiddleware;
+    refused handshakes are counted by `middleware_utils.websocket_aware`.
+    """
+
+    def __init__(self, app: starlette.types.ASGIApp):
+        super().__init__(app)
+        # (route count, literal route paths) of the app, rebuilt if routes
+        # were added since. Routes are all registered before the first
+        # request in practice; the count check keeps the memo honest anyway.
+        self._literal_routes: Optional[Tuple[int, FrozenSet[str]]] = None
+
+    def _literal_route_paths(self, app) -> FrozenSet[str]:
+        routes = getattr(app, 'routes', None)
+        count = len(routes) if isinstance(routes, (list, tuple)) else 0
+        if self._literal_routes is None or self._literal_routes[0] != count:
+            self._literal_routes = (count, _literal_route_paths(app))
+        return self._literal_routes[1]
 
     async def dispatch(self, request: fastapi.Request, call_next):
-        path = request.url.path
         logger.debug(f'PROM Middleware Request: {request}, {request.url.path}')
-        streaming = _is_streaming_api(path)
-        if not streaming:
-            # Exclude streaming APIs, the duration is not meaningful.
-            # TODO(aylei): measure the duration of async execution instead.
-            start_time = time.time()
+        start_time = time.time()
         method = request.method
-        status_code_group = ''
+        status_code = 0
 
         try:
             response = await call_next(request)
-            status_code_group = _get_status_code_group(response.status_code)
+            status_code = response.status_code
         except Exception:  # pylint: disable=broad-except
-            status_code_group = '5xx'
+            # Escaped every inner layer; Starlette's error handler (outside
+            # us) turns it into a bare 500. Count what the client sees.
+            status_code = 500
             raise
         finally:
-            metrics_utils.SKY_APISERVER_REQUESTS_TOTAL.labels(
-                path=path, method=method, status=status_code_group).inc()
-            # Record per-user metrics
-            user = _get_user_label(request)
-            metrics_utils.SKY_APISERVER_REQUESTS_BY_USER_TOTAL.labels(
-                user=user, method=method, status=status_code_group).inc()
-            if not streaming:
-                duration = time.time() - start_time
-                metrics_utils.SKY_APISERVER_REQUEST_DURATION_SECONDS.labels(
-                    path=path, method=method,
-                    status=status_code_group).observe(duration)
-                # /api/get long-polls until the underlying request is terminal,
-                # so its duration is the client-observed latency of that request
-                # type. The handler stamps request.state.request_name once it
-                # knows which request is being fetched; record it by name so
-                # bounded types can be alerted on separately from unbounded ones
-                # (launch/exec/...).
-                request_name = getattr(request.state, 'request_name', None)
-                if request_name is not None:
-                    metrics_utils.SKY_APISERVER_REQUEST_GET_DURATION_SECONDS \
-                        .labels(name=request_name,
-                                status=status_code_group).observe(duration)
+            self._record(request, method, status_code, start_time)
 
         return response
+
+    def _record(self, request: fastapi.Request, method: str, status_code: int,
+                start_time: float) -> None:
+        # Read after the inner layers ran: the scope dict is shared down the
+        # stack, so this is the (possibly rewritten) path the router saw.
+        raw_path = request.scope.get('path', '')
+        path = raw_path
+        if not _reached_router(request):
+            path = _middleware_rejected_path_label(
+                raw_path, self._literal_route_paths(request.scope.get('app')))
+        status_code_group = _get_status_code_group(status_code)
+        metrics_utils.SKY_APISERVER_REQUESTS_TOTAL.labels(
+            path=path, method=method, status=status_code_group).inc()
+        # Record per-user metrics
+        user = _get_user_label(request)
+        metrics_utils.SKY_APISERVER_REQUESTS_BY_USER_TOTAL.labels(
+            user=user, method=method, status=status_code_group).inc()
+        middleware_utils.record_rejection(request.scope, status_code,
+                                          middleware_utils.REJECTION_KIND_HTTP)
+        if _is_streaming_api(raw_path):
+            # Exclude streaming APIs, the duration is not meaningful.
+            # TODO(aylei): measure the duration of async execution instead.
+            return
+        duration = time.time() - start_time
+        metrics_utils.SKY_APISERVER_REQUEST_DURATION_SECONDS.labels(
+            path=path, method=method,
+            status=status_code_group).observe(duration)
+        # /api/get long-polls until the underlying request is terminal, so its
+        # duration is the client-observed latency of that request type. The
+        # handler stamps request.state.request_name once it knows which
+        # request is being fetched; record it by name so bounded types can be
+        # alerted on separately from unbounded ones (launch/exec/...).
+        request_name = getattr(request.state, 'request_name', None)
+        if request_name is not None:
+            metrics_utils.SKY_APISERVER_REQUEST_GET_DURATION_SECONDS.labels(
+                name=request_name, status=status_code_group).observe(duration)
 
 
 peak_rss_bytes = 0

--- a/sky/server/metrics.py
+++ b/sky/server/metrics.py
@@ -1590,7 +1590,15 @@ OTHER_PATH_LABEL = 'other'
 
 
 def warn_unless_outermost(app) -> bool:
-    """Warn at startup if this layer is not the outermost middleware.
+    """Warn at startup if this layer is installed but not outermost.
+
+    Returns whether the ordering invariant holds or does not apply. Reads
+    the answer out of the middleware stack rather than from the metrics
+    env-var: the registration below uses the variable's truthiness while
+    `metrics_utils.METRICS_ENABLED` requires the literal `true`, so a guard
+    with its own predicate would go silent under
+    `SKY_API_SERVER_METRICS_ENABLED=1` -- an enabled deployment, and one of
+    the configurations where a misordered stack would go unnoticed.
 
     Everything this middleware exists to count -- the 401/403/503s an
     authentication, RBAC, shutdown or plugin middleware answers itself -- is
@@ -1606,9 +1614,13 @@ def warn_unless_outermost(app) -> bool:
     reverse, and `add_middleware` inserts at the front.
     """
     stack = getattr(app, 'user_middleware', None) or []
-    outermost = stack[0].cls if stack else None
-    if outermost is PrometheusMiddleware:
+    classes = [m.cls for m in stack]
+    if PrometheusMiddleware not in classes:
+        # Metrics are off, or registration was skipped: nothing to check.
         return True
+    if classes[0] is PrometheusMiddleware:
+        return True
+    outermost = classes[0]
     logger.warning(
         f'{PrometheusMiddleware.__name__} is not the outermost middleware '
         f'({getattr(outermost, "__name__", outermost)} is). Responses that a '
@@ -1616,7 +1628,7 @@ def warn_unless_outermost(app) -> bool:
         'drains -- will not be counted in sky_apiserver_requests_total, so an '
         'outage on those paths shows up as a drop in successful traffic '
         'instead of as errors. Middleware order: '
-        f'{[m.cls.__name__ for m in stack]}')
+        f'{[c.__name__ for c in classes]}')
     return False
 
 
@@ -1634,11 +1646,13 @@ def _reached_router(request: fastapi.Request) -> bool:
 def _literal_route_paths(app) -> FrozenSet[str]:
     """The registered route paths without path parameters.
 
-    "Registered route" means a route on the app's own table: with current
-    FastAPI, `include_router` adds one opaque entry per router, so the
-    routes of the included core and plugin routers are not in it and fold
-    into their prefix bucket (see `_unrouted_path_label`). Bounded either
-    way.
+    `include_router` expands each sub-route onto `app.routes` with the
+    prefix applied, so the core and plugin routers' own routes are in here
+    too: on the real app, 132 routes of which 126 are parameterless
+    (`/jobs/queue`, `/users/update`, `/volumes/apply`, ...). An unrouted
+    request to any of them keeps its exact path; only a path that matches
+    no route at all falls back to a prefix bucket. Bounded either way --
+    126 literal routes plus 13 buckets plus `other`.
     """
     routes = getattr(app, 'routes', None)
     if not isinstance(routes, (list, tuple)):
@@ -1660,6 +1674,11 @@ def _unrouted_path_label(path: str, literal_routes: FrozenSet[str]) -> str:
     folded into one of the fixed `_UNROUTED_PATH_PREFIXES` buckets, as
     `<prefix>*`, or into `other`. A request that did reach the router keeps
     its raw path, 404s included, exactly as before.
+
+    Registered routes include the ones `include_router` expanded (see
+    `_literal_route_paths`), so the buckets catch what matches no route at
+    all: scanner probes, and the concrete values of the parameterised
+    routes (`/dashboard/_next/...`, `/ssh_node_pools/<name>/status`).
     """
     if path in literal_routes:
         return path

--- a/sky/server/metrics.py
+++ b/sky/server/metrics.py
@@ -1565,25 +1565,13 @@ def _get_user_label(request: fastapi.Request) -> str:
     return 'anonymous'
 
 
-# `path` label for a response produced by a middleware, i.e. a request that
-# never reached the router (an authentication 401/503, an RBAC 403, ...).
-# The metrics middleware is the outermost one, so these responses are
-# counted, and their paths are chosen by whoever sent them -- unauthenticated
-# scanners included -- so the raw path cannot be the label value. The raw
-# path is kept only when it is exactly a registered (parameterless) route;
-# anything else is folded into one of these fixed prefixes, as `<prefix>*`,
-# or into `other`. The prefixes are the routers mounted in
-# sky/server/server.py plus the plugin route root; the `*` form keeps the
-# prefix regexes dashboards and rules already use (e.g. `/api/.*`,
-# `/dashboard/.*`) matching. The bare prefix (`/users`, a router's root
-# route) folds into the same bucket. A request that did reach the router
-# keeps its raw path, 404s included, exactly as before.
-#
-# "Registered route" means a route on the app's own table: with current
-# FastAPI, `include_router` adds one opaque entry per router, so the routes
-# of the included core and plugin routers are not in it and fold into their
-# prefix bucket. Bounded either way.
-_MIDDLEWARE_REJECTED_PATH_PREFIXES = (
+# Prefixes that bound the `path` label of an unrouted request -- one a
+# middleware answered without the router running; see `_unrouted_path_label`.
+# The prefixes are the routers mounted in sky/server/server.py plus the
+# plugin route root; the `*` form keeps the prefix regexes dashboards and
+# rules already use (e.g. `/api/.*`, `/dashboard/.*`) matching, and a
+# router's bare root (`/users`) folds into the same bucket.
+_UNROUTED_PATH_PREFIXES = (
     '/api/',
     '/dashboard/',
     '/internal/dashboard/',
@@ -1607,13 +1595,20 @@ def _reached_router(request: fastapi.Request) -> bool:
     Starlette's router stamps itself on the scope when it runs
     (`scope['router']`); a request a middleware answered itself never gets
     there. This is what tells a route's own 4xx/5xx (raw path, as before)
-    from a middleware's canned rejection (bounded path).
+    from a middleware's canned response (bounded path).
     """
     return 'router' in request.scope
 
 
 def _literal_route_paths(app) -> FrozenSet[str]:
-    """The registered route paths without path parameters."""
+    """The registered route paths without path parameters.
+
+    "Registered route" means a route on the app's own table: with current
+    FastAPI, `include_router` adds one opaque entry per router, so the
+    routes of the included core and plugin routers are not in it and fold
+    into their prefix bucket (see `_unrouted_path_label`). Bounded either
+    way.
+    """
     routes = getattr(app, 'routes', None)
     if not isinstance(routes, (list, tuple)):
         return frozenset()
@@ -1623,12 +1618,21 @@ def _literal_route_paths(app) -> FrozenSet[str]:
                      '{' not in route.path)
 
 
-def _middleware_rejected_path_label(path: str,
-                                    literal_routes: FrozenSet[str]) -> str:
-    """Bounded `path` label for a response a middleware produced."""
+def _unrouted_path_label(path: str, literal_routes: FrozenSet[str]) -> str:
+    """Bounded `path` label for a response a middleware produced.
+
+    The request never reached the router (an authentication 401/503, an
+    RBAC 403, a CORS preflight, a sign-in redirect, ...), and its path is
+    chosen by whoever sent it -- unauthenticated scanners included -- so
+    the raw path cannot be the label value. The raw path is kept only when
+    it is exactly a registered (parameterless) route; anything else is
+    folded into one of the fixed `_UNROUTED_PATH_PREFIXES` buckets, as
+    `<prefix>*`, or into `other`. A request that did reach the router keeps
+    its raw path, 404s included, exactly as before.
+    """
     if path in literal_routes:
         return path
-    for prefix in _MIDDLEWARE_REJECTED_PATH_PREFIXES:
+    for prefix in _UNROUTED_PATH_PREFIXES:
         if path.startswith(prefix) or path == prefix[:-1]:
             return prefix + '*'
     return OTHER_PATH_LABEL
@@ -1649,7 +1653,7 @@ class PrometheusMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
     the router saw (inner middlewares rewrite `scope['path']` in place, e.g.
     the internal dashboard prefix): the same value as before. For a response
     produced by a middleware the path is bounded instead; see
-    `_middleware_rejected_path_label`. When the middleware that answered
+    `_unrouted_path_label`. When the middleware that answered
     stamped a reason (`middleware_utils.mark_rejection`), the response is
     also counted in `sky_apiserver_request_rejections_total`.
 
@@ -1701,7 +1705,7 @@ class PrometheusMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
         raw_path = request.scope.get('path', '')
         path = raw_path
         if not _reached_router(request):
-            path = _middleware_rejected_path_label(
+            path = _unrouted_path_label(
                 raw_path, self._literal_route_paths(request.scope.get('app')))
         status_code_group = _get_status_code_group(status_code)
         metrics_utils.SKY_APISERVER_REQUESTS_TOTAL.labels(

--- a/sky/server/metrics.py
+++ b/sky/server/metrics.py
@@ -1589,6 +1589,37 @@ _UNROUTED_PATH_PREFIXES = (
 OTHER_PATH_LABEL = 'other'
 
 
+def warn_unless_outermost(app) -> bool:
+    """Warn at startup if this layer is not the outermost middleware.
+
+    Everything this middleware exists to count -- the 401/403/503s an
+    authentication, RBAC, shutdown or plugin middleware answers itself -- is
+    invisible to it from anywhere else in the stack, and the symptom of being
+    wrong is silence: dashboards go quiet exactly as they did during the
+    outage this was written for. The ordering is asserted by a unit test on
+    the plugin-less app, which cannot see a deployment whose plugins register
+    middleware -- and the plugin API appends straight to `user_middleware`,
+    so it bypasses `add_middleware` and raises nothing. This says so in the
+    server's own log instead.
+
+    `user_middleware[0]` is the outermost layer: Starlette wraps the list in
+    reverse, and `add_middleware` inserts at the front.
+    """
+    stack = getattr(app, 'user_middleware', None) or []
+    outermost = stack[0].cls if stack else None
+    if outermost is PrometheusMiddleware:
+        return True
+    logger.warning(
+        f'{PrometheusMiddleware.__name__} is not the outermost middleware '
+        f'({getattr(outermost, "__name__", outermost)} is). Responses that a '
+        'middleware outside it produces -- authentication and RBAC failures, '
+        'drains -- will not be counted in sky_apiserver_requests_total, so an '
+        'outage on those paths shows up as a drop in successful traffic '
+        'instead of as errors. Middleware order: '
+        f'{[m.cls.__name__ for m in stack]}')
+    return False
+
+
 def _reached_router(request: fastapi.Request) -> bool:
     """Whether the request got past every middleware to the router.
 
@@ -1694,19 +1725,36 @@ class PrometheusMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
             status_code = 500
             raise
         finally:
-            self._record(request, method, status_code, start_time)
+            # This layer is outermost, so it sees 100% of responses: a
+            # recording fault must not turn a served request into a 500.
+            middleware_utils.record_safely('request', self._record, request,
+                                           method, status_code, start_time)
 
         return response
+
+    def _path_label(self, request: fastapi.Request, raw_path: str) -> str:
+        """`path` label, never raising: a fault must not lose the count.
+
+        Labelling an unrouted request reads the app's route table, so it is
+        the one part of recording that depends on state this layer does not
+        own. Falling back to the catch-all bucket keeps the request in
+        `sky_apiserver_requests_total`: mislabelled beats uncounted.
+        """
+        if _reached_router(request):
+            return raw_path
+        try:
+            return _unrouted_path_label(
+                raw_path, self._literal_route_paths(request.scope.get('app')))
+        except Exception as e:  # pylint: disable=broad-except
+            middleware_utils.note_recording_failure('the request path label', e)
+            return OTHER_PATH_LABEL
 
     def _record(self, request: fastapi.Request, method: str, status_code: int,
                 start_time: float) -> None:
         # Read after the inner layers ran: the scope dict is shared down the
         # stack, so this is the (possibly rewritten) path the router saw.
         raw_path = request.scope.get('path', '')
-        path = raw_path
-        if not _reached_router(request):
-            path = _unrouted_path_label(
-                raw_path, self._literal_route_paths(request.scope.get('app')))
+        path = self._path_label(request, raw_path)
         status_code_group = _get_status_code_group(status_code)
         metrics_utils.SKY_APISERVER_REQUESTS_TOTAL.labels(
             path=path, method=method, status=status_code_group).inc()

--- a/sky/server/middleware_utils.py
+++ b/sky/server/middleware_utils.py
@@ -1,7 +1,9 @@
 """Utilities for building middlewares."""
 import enum
 import http
-from typing import Optional, Tuple, Type
+import threading
+import time
+from typing import Any, Callable, Optional, Tuple, Type
 
 import fastapi
 import starlette.middleware.base
@@ -11,6 +13,82 @@ from sky import sky_logging
 from sky.metrics import utils as metrics_utils
 
 logger = sky_logging.init_logger(__name__)
+
+# The metrics middleware is the outermost one, so it observes 100% of
+# responses. A failure while *recording* -- a full or unwritable
+# PROMETHEUS_MULTIPROC_DIR, a label value the client library rejects -- must
+# never reach a client, or a monitoring bug becomes an outage on the very
+# path the metrics exist to watch. Recording on the request path runs through
+# `record_safely`: the observation is dropped, the response is returned
+# unchanged, and the failure is logged.
+#
+# The log is rate-limited per process. The first failure is logged at WARNING
+# with its traceback; later ones at most once per
+# `RECORDING_FAILURE_LOG_INTERVAL_SECONDS`, with a count of the failures
+# dropped silently in between, so a persistent fault cannot flood the log at
+# request rate.
+RECORDING_FAILURE_LOG_INTERVAL_SECONDS = 300.0
+
+
+class RecordingFailureLog:
+    """Rate-limited WARNING for metrics-recording failures."""
+
+    def __init__(
+            self,
+            interval_seconds: float = RECORDING_FAILURE_LOG_INTERVAL_SECONDS,
+            clock: Callable[[], float] = time.time):
+        self._interval_seconds = interval_seconds
+        self._clock = clock
+        self._lock = threading.Lock()
+        self._last_logged_at: Optional[float] = None
+        self._suppressed = 0
+        # Total failures noted in this process, logged or not.
+        self.failures = 0
+
+    def note(self, what: str, exc: BaseException) -> None:
+        """Log that recording `what` failed with `exc`, unless rate-limited."""
+        now = self._clock()
+        with self._lock:
+            self.failures += 1
+            if (self._last_logged_at is not None and
+                    now - self._last_logged_at < self._interval_seconds):
+                self._suppressed += 1
+                return
+            first = self._last_logged_at is None
+            suppressed = self._suppressed
+            self._suppressed = 0
+            self._last_logged_at = now
+        detail = (f' {suppressed} more failure(s) were dropped silently '
+                  'since the previous message.' if suppressed else '')
+        logger.warning(
+            f'Failed to record API server metrics for {what}: '
+            f'{type(exc).__name__}: {exc}. The request was served '
+            f'normally and this observation was dropped.{detail} Further '
+            f'failures are logged at most once every '
+            f'{self._interval_seconds:g} seconds.',
+            exc_info=exc if first else None)
+
+
+_recording_failure_log = RecordingFailureLog()
+
+
+def note_recording_failure(what: str, exc: BaseException) -> None:
+    """Log a metrics-recording failure through the process rate limiter."""
+    _recording_failure_log.note(what, exc)
+
+
+def record_safely(what: str, record: Callable[..., Any], *args: Any,
+                  **kwargs: Any) -> None:
+    """Call `record(*args, **kwargs)`; log and swallow any exception.
+
+    For metrics recording on the request path only: the caller must be able
+    to carry on exactly as if the call had succeeded.
+    """
+    try:
+        record(*args, **kwargs)
+    except Exception as e:  # pylint: disable=broad-except
+        note_recording_failure(what, e)
+
 
 # Reasons a middleware answers a request itself instead of letting a route
 # handler run. Stamped on the request with `mark_rejection` by the code that

--- a/sky/server/middleware_utils.py
+++ b/sky/server/middleware_utils.py
@@ -22,6 +22,12 @@ logger = sky_logging.init_logger(__name__)
 # `record_safely`: the observation is dropped, the response is returned
 # unchanged, and the failure is logged.
 #
+# These helpers live here, next to `record_rejection`, rather than in
+# sky/server/metrics.py: that module imports this one, so anything here that
+# needed them would close an import cycle. This module's dependency on
+# sky.metrics.utils is not new -- `record_rejection` and the handshake
+# counter already have it.
+#
 # The log is rate-limited per process. The first failure is logged at WARNING
 # with its traceback; later ones at most once per
 # `RECORDING_FAILURE_LOG_INTERVAL_SECONDS`, with a count of the failures
@@ -105,7 +111,15 @@ REJECT_REASON_UNAUTHORIZED = 'unauthorized'
 REJECT_REASON_FORBIDDEN = 'forbidden'
 REJECT_REASON_SHUTTING_DOWN = 'shutting_down'
 REJECT_REASON_API_VERSION = 'api_version'
+# Could not reach the auth proxy at all (connection error, timeout).
 REJECT_REASON_AUTH_PROXY_UNAVAILABLE = 'auth_proxy_unavailable'
+# Reached it, and the answer was unusable: authenticated but no user info, or
+# a status this server does not know how to act on. A different failure from
+# unavailability and a different fix, so it gets its own reason. Note that
+# the `status` recorded alongside it can be the proxy's own status code --
+# the one label value in this counter that upstream chooses rather than this
+# code (bounded by the HTTP status set).
+REJECT_REASON_AUTH_PROXY_BAD_RESPONSE = 'auth_proxy_bad_response'
 REJECT_REASON_REQUEST_WORKER_EXHAUSTED = 'request_worker_exhausted'
 
 # Key in `scope['state']` (i.e. `request.state`) the reason is stored under.

--- a/sky/server/middleware_utils.py
+++ b/sky/server/middleware_utils.py
@@ -74,6 +74,11 @@ def record_rejection(scope: starlette.types.Scope, status_code: int,
     reason = get_rejection_reason(scope)
     if reason is None:
         return
+    if int(status_code) < 400:
+        # A stamp without a refusal: the middleware marked a reason and then
+        # let the request through, and the route answered it. Not a
+        # rejection; this counter must never disagree with the status.
+        return
     # int() first: responses built with an `http.HTTPStatus` member would
     # otherwise label the series `HTTPStatus.SERVICE_UNAVAILABLE`.
     metrics_utils.SKY_APISERVER_REQUEST_REJECTIONS_TOTAL.labels(

--- a/sky/server/middleware_utils.py
+++ b/sky/server/middleware_utils.py
@@ -25,6 +25,10 @@ REJECT_REASON_ROLE_SEED_UNAVAILABLE = 'role_seed_unavailable'
 REJECT_REASON_JWT_SECRET_UNAVAILABLE = 'jwt_secret_unavailable'
 REJECT_REASON_UNAUTHORIZED = 'unauthorized'
 REJECT_REASON_FORBIDDEN = 'forbidden'
+REJECT_REASON_SHUTTING_DOWN = 'shutting_down'
+REJECT_REASON_API_VERSION = 'api_version'
+REJECT_REASON_AUTH_PROXY_UNAVAILABLE = 'auth_proxy_unavailable'
+REJECT_REASON_REQUEST_WORKER_EXHAUSTED = 'request_worker_exhausted'
 
 # Key in `scope['state']` (i.e. `request.state`) the reason is stored under.
 REJECT_REASON_STATE_KEY = 'reject_reason'

--- a/sky/server/middleware_utils.py
+++ b/sky/server/middleware_utils.py
@@ -1,15 +1,91 @@
 """Utilities for building middlewares."""
 import enum
 import http
-from typing import Type
+from typing import Optional, Tuple, Type
 
 import fastapi
 import starlette.middleware.base
 import starlette.types
 
 from sky import sky_logging
+from sky.metrics import utils as metrics_utils
 
 logger = sky_logging.init_logger(__name__)
+
+# Reasons a middleware answers a request itself instead of letting a route
+# handler run. Stamped on the request with `mark_rejection` by the code that
+# produces the response and read back by whoever records the response: the
+# metrics middleware for HTTP requests, `websocket_aware` for handshakes. This
+# is a closed set on purpose: the reason is a metric label
+# (`sky_apiserver_request_rejections_total{reason}`), so every value added
+# here is a new series per (status, kind).
+REJECT_REASON_AUTH_WORKER_EXHAUSTED = 'auth_worker_exhausted'
+REJECT_REASON_AUTH_DB_TIMEOUT = 'auth_db_timeout'
+REJECT_REASON_ROLE_SEED_UNAVAILABLE = 'role_seed_unavailable'
+REJECT_REASON_JWT_SECRET_UNAVAILABLE = 'jwt_secret_unavailable'
+REJECT_REASON_UNAUTHORIZED = 'unauthorized'
+REJECT_REASON_FORBIDDEN = 'forbidden'
+
+# Key in `scope['state']` (i.e. `request.state`) the reason is stored under.
+REJECT_REASON_STATE_KEY = 'reject_reason'
+
+# `kind` label values of the rejection counter.
+REJECTION_KIND_HTTP = 'http'
+REJECTION_KIND_WEBSOCKET = 'websocket'
+
+# `path` label of the handshake-rejection counter: the registered WebSocket
+# routes (sky/server/server.py) or this fixed value. Handshake paths are
+# chosen by the client, so the raw path cannot be a label value.
+WEBSOCKET_ROUTE_PATHS = frozenset((
+    '/kubernetes-pod-ssh-proxy',
+    '/slurm-job-ssh-proxy',
+    '/ssh-interactive-auth',
+))
+OTHER_WEBSOCKET_PATH_LABEL = 'other'
+
+
+def mark_rejection(request: fastapi.Request, reason: str) -> None:
+    """Record why this request is being answered with a canned response.
+
+    Call it right before returning the response from a middleware.
+    `request.state` is backed by the ASGI scope's `state` dict, which every
+    middleware layer shares, so the layer that records the response sees the
+    value. Explicit parameter on purpose: no contextvars.
+    """
+    setattr(request.state, REJECT_REASON_STATE_KEY, reason)
+
+
+def get_rejection_reason(scope: starlette.types.Scope) -> Optional[str]:
+    """The reason stamped by `mark_rejection`, from a raw ASGI scope."""
+    state = scope.get('state')
+    if not state:
+        return None
+    return state.get(REJECT_REASON_STATE_KEY)
+
+
+def record_rejection(scope: starlette.types.Scope, status_code: int,
+                     kind: str) -> None:
+    """Count a rejection in `sky_apiserver_request_rejections_total`.
+
+    A no-op when nothing stamped a reason on the request: the response was
+    not one of the canned rejections this counter is about (or came from
+    code that does not attribute its answers yet).
+    """
+    reason = get_rejection_reason(scope)
+    if reason is None:
+        return
+    # int() first: responses built with an `http.HTTPStatus` member would
+    # otherwise label the series `HTTPStatus.SERVICE_UNAVAILABLE`.
+    metrics_utils.SKY_APISERVER_REQUEST_REJECTIONS_TOTAL.labels(
+        reason=reason, status=str(int(status_code)), kind=kind).inc()
+
+
+def websocket_path_label(scope: starlette.types.Scope) -> str:
+    """Bounded `path` label for a WebSocket handshake."""
+    path = scope.get('path', '')
+    if path in WEBSOCKET_ROUTE_PATHS:
+        return path
+    return OTHER_WEBSOCKET_PATH_LABEL
 
 
 class WebSocketDecision(enum.Enum):
@@ -27,6 +103,15 @@ def websocket_aware(
     websocket handshake and then delegates it to the real HTTP middleware.
     The websocket connection will be rejected if the HTTP middleware returns
     a 4xx or 5xx status code.
+
+    A refused handshake is counted in
+    `sky_apiserver_websocket_handshake_rejections_total{path,outcome}` and,
+    when the HTTP middleware stamped a reason (`mark_rejection`), in
+    `sky_apiserver_request_rejections_total{kind="websocket"}` with the
+    status the middleware answered with. Only the outermost middleware that
+    refuses runs, so each refused handshake is counted once. What the client
+    receives is unchanged: the close codes below, which ASGI servers render
+    as an empty HTTP 403.
 
     Note: for websocket connection, the mutation made by the underlying HTTP
     middleware on the request and response will be discarded.
@@ -59,10 +144,12 @@ def websocket_aware(
                                     receive: starlette.types.Receive,
                                     send: starlette.types.Send):
             """Handle websocket connection by delegating to HTTP middleware."""
-            decision = await self._run_websocket_dispatch(scope)
+            decision, response = await self._run_websocket_dispatch(scope)
             if decision == WebSocketDecision.ACCEPT:
                 await self.app(scope, receive, send)
-            elif decision == WebSocketDecision.UNAUTHORIZED:
+                return
+            self._count_rejection(scope, decision, response)
+            if decision == WebSocketDecision.UNAUTHORIZED:
                 await send({
                     'type': 'websocket.close',
                     'code': 4401,
@@ -81,8 +168,28 @@ def websocket_aware(
                     'reason': 'Internal Server Error',
                 })
 
+        @staticmethod
+        def _count_rejection(scope: starlette.types.Scope,
+                             decision: WebSocketDecision,
+                             response: Optional[fastapi.Response]) -> None:
+            """Count a refused handshake; the client's answer is unchanged."""
+            metrics_utils.SKY_APISERVER_WEBSOCKET_HANDSHAKE_REJECTIONS_TOTAL \
+                .labels(path=websocket_path_label(scope),
+                        outcome=decision.value).inc()
+            if response is not None:
+                # The status the HTTP middleware answered with (e.g. 503 for
+                # an exhausted auth executor), not the 403 the client sees.
+                record_rejection(scope, response.status_code,
+                                 REJECTION_KIND_WEBSOCKET)
+
         async def _run_websocket_dispatch(
-                self, scope: starlette.types.Scope) -> WebSocketDecision:
+            self, scope: starlette.types.Scope
+        ) -> Tuple[WebSocketDecision, Optional[fastapi.Response]]:
+            """Run the HTTP middleware against the handshake.
+
+            Returns the decision and the response the middleware produced
+            (None when it raised).
+            """
             http_scope = self._build_http_scope(scope)
             http_receive = self._http_receive_adapter()
             request = fastapi.Request(http_scope, receive=http_receive)
@@ -103,7 +210,7 @@ def websocket_aware(
             except Exception as e:  # pylint: disable=broad-except
                 logger.error('Exception occurred in middleware dispatch for '
                              f'WebSocket scope: {e}')
-                return WebSocketDecision.ERROR
+                return WebSocketDecision.ERROR, None
 
             if response is None:
                 response = stub_response
@@ -111,12 +218,12 @@ def websocket_aware(
             status_code = response.status_code
 
             if call_next_called and 200 <= status_code < 400:
-                return WebSocketDecision.ACCEPT
+                return WebSocketDecision.ACCEPT, response
             if status_code == http.HTTPStatus.UNAUTHORIZED:
-                return WebSocketDecision.UNAUTHORIZED
+                return WebSocketDecision.UNAUTHORIZED, response
             if status_code == http.HTTPStatus.FORBIDDEN:
-                return WebSocketDecision.FORBIDDEN
-            return WebSocketDecision.ERROR
+                return WebSocketDecision.FORBIDDEN, response
+            return WebSocketDecision.ERROR, response
 
         @staticmethod
         def _build_http_scope(

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -1017,11 +1017,11 @@ async def schedule_on_boot_check_async():
 @contextlib.asynccontextmanager
 async def lifespan(app: fastapi.FastAPI):  # pylint: disable=redefined-outer-name
     """FastAPI lifespan context manager."""
-    if metrics_utils.METRICS_ENABLED:
-        # The metrics middleware only sees middleware-produced responses from
-        # the outermost position. Checked here, where the stack is final and
-        # plugin middlewares are registered, not just in the unit test.
-        metrics.warn_unless_outermost(app)
+    # The metrics middleware only sees middleware-produced responses from the
+    # outermost position. Checked here, where the stack is final and plugin
+    # middlewares are registered, not just in the unit test. Unconditional:
+    # the check reads the stack, so it is silent when metrics are off.
+    metrics.warn_unless_outermost(app)
 
     # Startup: Run background tasks. Delete any persisted daemon rows whose
     # ids are no longer in INTERNAL_REQUEST_DAEMONS first (daemon renamed /

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -1017,7 +1017,9 @@ async def schedule_on_boot_check_async():
 @contextlib.asynccontextmanager
 async def lifespan(app: fastapi.FastAPI):  # pylint: disable=redefined-outer-name
     """FastAPI lifespan context manager."""
-    del app  # unused; the middleware-order check runs at import (see below)
+    # Unused: the middleware-order check that used to live here runs at
+    # import instead, right after the metrics middleware registration.
+    del app
     # Startup: Run background tasks. Delete any persisted daemon rows whose
     # ids are no longer in INTERNAL_REQUEST_DAEMONS first (daemon renamed /
     # removed in code), then submit each current daemon.

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -1173,6 +1173,8 @@ class PathCleanMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
             parent = pathlib.Path('/dashboard')
             request_path = pathlib.Path(posixpath.normpath(request.url.path))
             if not _is_relative_to(request_path, parent):
+                middleware_utils.mark_rejection(
+                    request, middleware_utils.REJECT_REASON_FORBIDDEN)
                 return fastapi.responses.JSONResponse(
                     status_code=403, content={'detail': 'Forbidden'})
         return await call_next(request)
@@ -1188,6 +1190,8 @@ class GracefulShutdownMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
             # on-going requests but will not submit new requests.
             if not request.url.path.startswith('/api/'):
                 # Client will retry on 503 error.
+                middleware_utils.mark_rejection(
+                    request, middleware_utils.REJECT_REASON_SHUTTING_DOWN)
                 return fastapi.responses.JSONResponse(
                     status_code=503,
                     content={
@@ -1231,6 +1235,8 @@ class APIVersionMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
             versions.set_remote_version(version_info.version)
             response = await call_next(request)
         else:
+            middleware_utils.mark_rejection(
+                request, middleware_utils.REJECT_REASON_API_VERSION)
             response = fastapi.responses.JSONResponse(
                 status_code=400,
                 content={
@@ -1342,7 +1348,9 @@ resource.setrlimit(resource.RLIMIT_NOFILE, (hard, hard))
 @app.exception_handler(exceptions.ConcurrentWorkerExhaustedError)
 def handle_concurrent_worker_exhausted_error(
         request: fastapi.Request, e: exceptions.ConcurrentWorkerExhaustedError):
-    del request  # request is not used
+    # Let the metrics middleware count this 503 by cause.
+    middleware_utils.mark_rejection(
+        request, middleware_utils.REJECT_REASON_REQUEST_WORKER_EXHAUSTED)
     # Print detailed error message to server log
     logger.error('Concurrent worker exhausted: '
                  f'{common_utils.format_exception(e)}')

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -1017,12 +1017,7 @@ async def schedule_on_boot_check_async():
 @contextlib.asynccontextmanager
 async def lifespan(app: fastapi.FastAPI):  # pylint: disable=redefined-outer-name
     """FastAPI lifespan context manager."""
-    # The metrics middleware only sees middleware-produced responses from the
-    # outermost position. Checked here, where the stack is final and plugin
-    # middlewares are registered, not just in the unit test. Unconditional:
-    # the check reads the stack, so it is silent when metrics are off.
-    metrics.warn_unless_outermost(app)
-
+    del app  # unused; the middleware-order check runs at import (see below)
     # Startup: Run background tasks. Delete any persisted daemon rows whose
     # ids are no longer in INTERNAL_REQUEST_DAEMONS first (daemon renamed /
     # removed in code), then submit each current daemon.
@@ -1334,6 +1329,14 @@ if __name__ == 'sky.server.server':
 # errors. Use environment variable to make the metrics middleware optional.
 if os.environ.get(constants.ENV_VAR_SERVER_METRICS_ENABLED):
     app.add_middleware(metrics.PrometheusMiddleware)
+
+# The middleware stack is final here: plugins loaded above, the metrics layer
+# registered, and only `include_router` follows. Report a stack that would
+# make the metrics layer blind to middleware-produced responses -- which is
+# silent otherwise, and looks exactly like a quiet system. Called
+# unconditionally: the check reads the stack, so it says nothing when the
+# layer is not installed at all.
+metrics.warn_unless_outermost(app)
 
 app.include_router(jobs_rest.router, prefix='/jobs', tags=['jobs'])
 app.include_router(serve_rest.router, prefix='/serve', tags=['serve'])

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -146,8 +146,10 @@ _KUBECTL_PATH: Optional[str] = shutil.which('kubectl')
 # response will block other requests from being processed.
 
 
-def _basic_auth_401_response(content: str):
+def _basic_auth_401_response(request: fastapi.Request, content: str):
     """Return a 401 response with basic auth realm."""
+    middleware_utils.mark_rejection(request,
+                                    middleware_utils.REJECT_REASON_UNAUTHORIZED)
     return fastapi.responses.JSONResponse(
         status_code=401,
         headers={
@@ -160,8 +162,10 @@ def _basic_auth_401_response(content: str):
         content=content)
 
 
-def _bearer_auth_401_response(content):
+def _bearer_auth_401_response(request: fastapi.Request, content):
     """Return a 401 response for bearer token authentication failures."""
+    middleware_utils.mark_rejection(request,
+                                    middleware_utils.REJECT_REASON_UNAUTHORIZED)
     return fastapi.responses.JSONResponse(
         status_code=401,
         headers={
@@ -248,11 +252,13 @@ class RBACMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
                 request.url.path, request.method)
         except asyncio.TimeoutError:
             logger.error('RBAC check timed out, path: %s', request.url.path)
-            return db_lookup.db_timeout_response()
+            return db_lookup.db_timeout_response(request)
         except exceptions.ConcurrentWorkerExhaustedError as e:
             logger.error(f'Concurrent worker exhausted during RBAC check: {e}')
-            return db_lookup.worker_exhausted_response()
+            return db_lookup.worker_exhausted_response(request)
         if blocked:
+            middleware_utils.mark_rejection(
+                request, middleware_utils.REJECT_REASON_FORBIDDEN)
             return fastapi.responses.JSONResponse(
                 status_code=403, content={'detail': 'Forbidden'})
 
@@ -397,11 +403,12 @@ class BasicAuthMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
 
         auth_header = request.headers.get('authorization')
         if not auth_header:
-            return _basic_auth_401_response('Authentication required')
+            return _basic_auth_401_response(request, 'Authentication required')
 
         # Only handle basic auth
         if not auth_header.lower().startswith('basic '):
-            return _basic_auth_401_response('Invalid authentication method')
+            return _basic_auth_401_response(request,
+                                            'Invalid authentication method')
 
         # Check username and password
         encoded = auth_header.split(' ', 1)[1]
@@ -409,7 +416,7 @@ class BasicAuthMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
             decoded = base64.b64decode(encoded).decode()
             username, password = decoded.split(':', 1)
         except Exception:  # pylint: disable=broad-except
-            return _basic_auth_401_response('Invalid basic auth')
+            return _basic_auth_401_response(request, 'Invalid basic auth')
 
         # Offload the DB lookup + bcrypt verification to the bounded auth
         # thread executor under a deadline, so a slow DB (or the CPU-heavy
@@ -424,12 +431,12 @@ class BasicAuthMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
         except asyncio.TimeoutError:
             logger.error('Basic auth DB lookup timed out, path: %s',
                          request.url.path)
-            return db_lookup.db_timeout_response()
+            return db_lookup.db_timeout_response(request)
         except exceptions.ConcurrentWorkerExhaustedError as e:
             logger.error(f'Concurrent worker exhausted during basic auth: {e}')
-            return db_lookup.worker_exhausted_response()
+            return db_lookup.worker_exhausted_response(request)
         if user is None:
-            return _basic_auth_401_response('Invalid credentials')
+            return _basic_auth_401_response(request, 'Invalid credentials')
         request.state.auth_user = user
 
         return await call_next(request)
@@ -488,13 +495,13 @@ class BearerTokenMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
 
         if auth_header is None:
             return _bearer_auth_401_response(
-                {'detail': 'Authentication required'})
+                request, {'detail': 'Authentication required'})
 
         # Extract token
         split_header = auth_header.split(' ', 1)
         if split_header[0].lower() != 'bearer':
             return _bearer_auth_401_response(
-                {'detail': 'Invalid authentication method'})
+                request, {'detail': 'Invalid authentication method'})
         sa_token = split_header[1]
 
         # Handle SkyPilot service account tokens
@@ -509,7 +516,7 @@ class BearerTokenMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
                                     'false').lower()
         if sa_enabled != 'true':
             return _bearer_auth_401_response(
-                {'detail': 'Service account authentication disabled'})
+                request, {'detail': 'Service account authentication disabled'})
 
         service = token_service.token_service
 
@@ -536,6 +543,7 @@ class BearerTokenMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
             if payload is None:
                 logger.warning('Service account token verification failed')
                 return _bearer_auth_401_response(
+                    request,
                     {'detail': 'Invalid or expired service account token'})
 
             # Extract user information from JWT payload
@@ -547,7 +555,7 @@ class BearerTokenMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
                 logger.warning(
                     'Invalid token payload: missing user_id or token_id')
                 return _bearer_auth_401_response(
-                    {'detail': 'Invalid token payload'})
+                    request, {'detail': 'Invalid token payload'})
 
             # Look up the token row by its sha256 hash. This is what makes
             # revocation (row deleted) and rotation (row's hash replaced)
@@ -573,13 +581,14 @@ class BearerTokenMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
                     f'Service account token {token_id} not found in DB '
                     '(revoked or rotated)')
                 return _bearer_auth_401_response(
+                    request,
                     {'detail': 'Service account token revoked or rotated'})
 
             if (token_row['expires_at'] is not None and
                     token_row['expires_at'] < int(time.time())):
                 logger.warning(f'Service account token {token_id} has expired')
                 return _bearer_auth_401_response(
-                    {'detail': 'Service account token has expired'})
+                    request, {'detail': 'Service account token has expired'})
 
             # Verify user still exists in database
             user_info = await db_lookup.call_with_deadline(
@@ -588,6 +597,7 @@ class BearerTokenMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
                 logger.warning(
                     f'Service account user {user_id} no longer exists')
                 return _bearer_auth_401_response(
+                    request,
                     {'detail': 'Service account user no longer exists'})
 
             # Update last used timestamp for token tracking, skipped while
@@ -627,23 +637,24 @@ class BearerTokenMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
             # an exception raised in a middleware surfaces as a bare 500,
             # which clients do not retry.
             logger.error('Service account auth DB lookup timed out')
-            return db_lookup.db_timeout_response()
+            return db_lookup.db_timeout_response(request)
         except exceptions.ConcurrentWorkerExhaustedError as e:
             # Same reasoning as the timeout above: convert in-middleware so
             # the client sees a retryable 503 instead of a bare 500.
             logger.error(f'Concurrent worker exhausted during service account '
                          f'auth: {e}')
-            return db_lookup.worker_exhausted_response()
+            return db_lookup.worker_exhausted_response(request)
         except token_service.JWTSecretUnavailableError as e:
             # Above the catch-all on purpose: a 401 would tell the caller its
             # token is bad and send it off to rotate credentials, when the
             # token is fine and the database is not.
             logger.error(f'Service account auth unavailable: {e}')
-            return db_lookup.jwt_secret_unavailable_response()
+            return db_lookup.jwt_secret_unavailable_response(request)
         except Exception as e:  # pylint: disable=broad-except
             logger.error(f'Service account authentication failed: {e}',
                          exc_info=True)
             return _bearer_auth_401_response(
+                request,
                 {'detail': f'Service account authentication failed: {str(e)}'})
 
         return await call_next(request)
@@ -698,15 +709,15 @@ class AuthProxyMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
                     global_user_state.add_or_update_user, auth_user)
             except asyncio.TimeoutError:
                 logger.error('Auth proxy user upsert timed out')
-                return db_lookup.db_timeout_response()
+                return db_lookup.db_timeout_response(request)
             except exceptions.ConcurrentWorkerExhaustedError as e:
                 logger.error(f'Concurrent worker exhausted during auth proxy '
                              f'user upsert: {e}')
-                return db_lookup.worker_exhausted_response()
+                return db_lookup.worker_exhausted_response(request)
             # Same deadline as the upsert above; see the helper for why a new
             # user's seed is awaited while a returning one's repair is queued.
             failed = await db_lookup.ensure_role_for_authenticated_user(
-                auth_user.id, newly_added)
+                auth_user.id, newly_added, request=request)
             if failed is not None:
                 return failed
 
@@ -1241,9 +1252,7 @@ app = fastapi.FastAPI(prefix='/api/v1', debug=True, lifespan=lifespan)
 #   Middleware3(Middleware2(Middleware1(request)))
 # If MiddlewareN does something like print(n); call_next(); print(n), you'll get
 #   3; 2; 1; <request>; 1; 2; 3
-# Use environment variable to make the metrics middleware optional.
-if os.environ.get(constants.ENV_VAR_SERVER_METRICS_ENABLED):
-    app.add_middleware(metrics.PrometheusMiddleware)
+# The metrics middleware is added last, i.e. outermost; see below.
 # APIVersionMiddleware also records the dispatched endpoint for workspace-access
 # classification. Added near-first => inner to PathCleanMiddleware /
 # InternalDashboardPrefixMiddleware, so the path it records is the router-
@@ -1301,6 +1310,17 @@ if __name__ == 'sky.server.server':
     plugins.load_plugins(
         plugins.ExtensionContext(context=plugins.PluginContext.UVICORN,
                                  app=app))
+
+# The metrics middleware must be the OUTERMOST middleware, so it is added
+# after every core and plugin middleware: it counts the response the client
+# actually receives, including the 401/403/503s the authentication, RBAC,
+# shutdown and plugin middlewares answer themselves without calling the next
+# layer. Placed inside the stack (where it used to be, as the first
+# middleware added), none of those were counted and an authentication outage
+# showed up on dashboards as a drop in successful requests rather than as
+# errors. Use environment variable to make the metrics middleware optional.
+if os.environ.get(constants.ENV_VAR_SERVER_METRICS_ENABLED):
+    app.add_middleware(metrics.PrometheusMiddleware)
 
 app.include_router(jobs_rest.router, prefix='/jobs', tags=['jobs'])
 app.include_router(serve_rest.router, prefix='/serve', tags=['serve'])

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -1017,7 +1017,11 @@ async def schedule_on_boot_check_async():
 @contextlib.asynccontextmanager
 async def lifespan(app: fastapi.FastAPI):  # pylint: disable=redefined-outer-name
     """FastAPI lifespan context manager."""
-    del app  # unused
+    if metrics_utils.METRICS_ENABLED:
+        # The metrics middleware only sees middleware-produced responses from
+        # the outermost position. Checked here, where the stack is final and
+        # plugin middlewares are registered, not just in the unit test.
+        metrics.warn_unless_outermost(app)
 
     # Startup: Run background tasks. Delete any persisted daemon rows whose
     # ids are no longer in INTERNAL_REQUEST_DAEMONS first (daemon renamed /
@@ -1302,8 +1306,10 @@ app.add_middleware(BearerTokenMiddleware)
 # middleware above.
 app.add_middleware(InitializeRequestAuthUserMiddleware)
 app.add_middleware(RequestIDMiddleware)
-# SecurityHeadersMiddleware is the outermost middleware to ensure security
-# headers (CSP, X-Content-Type-Options, etc.) are added to all responses.
+# SecurityHeadersMiddleware is the outermost middleware that touches a
+# response, so its security headers (CSP, X-Content-Type-Options, etc.) are
+# added to all of them. The metrics middleware below is registered outside it
+# but only observes; it neither adds nor removes headers.
 app.add_middleware(SecurityHeadersMiddleware)
 
 # Load plugins after all the middlewares are added, to keep the core

--- a/tests/unit_tests/test_sky/server/test_auth_db_deadline.py
+++ b/tests/unit_tests/test_sky/server/test_auth_db_deadline.py
@@ -32,6 +32,7 @@ import pytest
 
 from sky import exceptions
 from sky import models
+from sky.server import middleware_utils
 from sky.server import server
 from sky.server.auth import db_lookup
 from sky.server.requests import threads
@@ -374,6 +375,17 @@ async def test_call_with_deadline_raises_timeout():
         await db_lookup.call_with_deadline(_slow(None))
 
 
+def _request() -> fastapi.Request:
+    """A bare request for the helpers to stamp their rejection reason on."""
+    return fastapi.Request({
+        'type': 'http',
+        'method': 'GET',
+        'path': '/',
+        'headers': [],
+        'state': {},
+    })
+
+
 class TestEnsureRoleForAuthenticatedUser:
     """The decision both auth front-ends share.
 
@@ -390,7 +402,7 @@ class TestEnsureRoleForAuthenticatedUser:
                                new=mock.AsyncMock()) as bounded, \
              mock.patch('sky.users.permission.permission_service') as perm:
             assert await db_lookup.ensure_role_for_authenticated_user(
-                'u-new', True) is None
+                'u-new', True, request=_request()) is None
         assert bounded.await_count == 1
         assert bounded.await_args[0][1] == 'u-new'
         perm.queue_role_repair.assert_not_called()
@@ -402,10 +414,15 @@ class TestEnsureRoleForAuthenticatedUser:
                                '_call_on_request_pool',
                                side_effect=asyncio.TimeoutError), \
              mock.patch('sky.users.permission.permission_service') as perm:
+            request = _request()
             response = await db_lookup.ensure_role_for_authenticated_user(
-                'u-slow', True)
+                'u-slow', True, request=request)
         assert response is not None and response.status_code == 503
         perm.queue_role_repair.assert_called_once_with('u-slow')
+        # The 503 is attributed for the metrics layer: a middleware answering a
+        # request itself is otherwise invisible to request counters.
+        assert request.state.reject_reason == \
+            middleware_utils.REJECT_REASON_ROLE_SEED_UNAVAILABLE
 
     @pytest.mark.asyncio
     async def test_a_saturated_executor_answers_503_and_queues(self):
@@ -414,10 +431,13 @@ class TestEnsureRoleForAuthenticatedUser:
                 '_call_on_request_pool',
                 side_effect=exceptions.ConcurrentWorkerExhaustedError('busy')
         ), mock.patch('sky.users.permission.permission_service') as perm:
+            request = _request()
             response = await db_lookup.ensure_role_for_authenticated_user(
-                'u-busy', True)
+                'u-busy', True, request=request)
         assert response is not None and response.status_code == 503
         perm.queue_role_repair.assert_called_once_with('u-busy')
+        assert request.state.reject_reason == \
+            middleware_utils.REJECT_REASON_AUTH_WORKER_EXHAUSTED
 
     @pytest.mark.asyncio
     async def test_a_returning_user_with_no_known_role_is_only_queued(self):
@@ -428,7 +448,7 @@ class TestEnsureRoleForAuthenticatedUser:
                                new=mock.AsyncMock()) as bounded:
             perm.probably_has_role.return_value = False
             assert await db_lookup.ensure_role_for_authenticated_user(
-                'u-old', False) is None
+                'u-old', False, request=_request()) is None
         perm.queue_role_repair.assert_called_once_with('u-old')
         bounded.assert_not_awaited()
 
@@ -437,7 +457,7 @@ class TestEnsureRoleForAuthenticatedUser:
         with mock.patch('sky.users.permission.permission_service') as perm:
             perm.probably_has_role.return_value = True
             assert await db_lookup.ensure_role_for_authenticated_user(
-                'u-fine', False) is None
+                'u-fine', False, request=_request()) is None
         perm.queue_role_repair.assert_not_called()
 
     @pytest.mark.asyncio
@@ -455,7 +475,8 @@ class TestEnsureRoleForAuthenticatedUser:
                                'get_auth_thread_executor') as auth_pool, \
              mock.patch.object(db_lookup.executor,
                                'get_request_thread_executor') as request_pool:
-            await db_lookup.ensure_role_for_authenticated_user('u-new', True)
+            await db_lookup.ensure_role_for_authenticated_user(
+                'u-new', True, request=_request())
         auth_pool.assert_not_called()
         request_pool.assert_called_once()
 
@@ -471,10 +492,50 @@ class TestEnsureRoleForAuthenticatedUser:
                                side_effect=RuntimeError('db is unhappy')), \
              mock.patch('sky.users.permission.permission_service') as perm:
             response = await db_lookup.ensure_role_for_authenticated_user(
-                'u-broken', True)
+                'u-broken', True, request=_request())
         assert response is not None and response.status_code == 503
         # And it says why it gave up. `db_timeout_response`'s text blames a slow
         # database, which is wrong for the reason this path usually fails:
         # contention on the policy lock, a healthy database doing its job.
         assert b'assigning roles' in response.body
         perm.queue_role_repair.assert_called_once_with('u-broken')
+
+
+class TestHelpersWithoutARequest:
+    """The response helpers keep working when called with no arguments.
+
+    Middlewares outside this repository call `db_timeout_response()` and
+    `worker_exhausted_response()` bare. Making `request` required would turn
+    their 503 -- the retryable answer on exactly the auth-pool-exhausted /
+    auth-DB-deadline path -- into a TypeError, which a middleware surfaces as
+    a bare 500 that clients do not retry. So: same 503 without a request, the
+    reason attribution is the only thing a caller gains by passing one.
+    """
+
+    @pytest.mark.parametrize('helper', [
+        db_lookup.db_timeout_response,
+        db_lookup.role_seed_unavailable_response,
+        db_lookup.jwt_secret_unavailable_response,
+        db_lookup.worker_exhausted_response,
+    ])
+    def test_no_argument_call_is_the_same_503(self, helper):
+        bare = helper()
+        request = _request()
+        attributed = helper(request)
+        assert bare.status_code == attributed.status_code == 503
+        assert bare.body == attributed.body
+        assert bare.headers.get('retry-after') == \
+            attributed.headers.get('retry-after')
+        # Only the attributed one carries a reason for the metrics layer.
+        assert hasattr(request.state, middleware_utils.REJECT_REASON_STATE_KEY)
+
+    @pytest.mark.asyncio
+    async def test_ensure_role_keeps_its_original_positional_signature(self):
+        with mock.patch.object(db_lookup,
+                               '_call_on_request_pool',
+                               side_effect=asyncio.TimeoutError), \
+             mock.patch('sky.users.permission.permission_service') as perm:
+            response = await db_lookup.ensure_role_for_authenticated_user(
+                'u-slow', True)
+        assert response is not None and response.status_code == 503
+        perm.queue_role_repair.assert_called_once_with('u-slow')

--- a/tests/unit_tests/test_sky/server/test_edge_error_counting.py
+++ b/tests/unit_tests/test_sky/server/test_edge_error_counting.py
@@ -1,0 +1,320 @@
+"""Responses produced by a middleware are counted at the edge.
+
+Regression tests for the metrics middleware being the OUTERMOST middleware.
+The production incident these come from: the auth executor saturated and
+every request got a 503 from the auth middleware; the request counter,
+sitting inside that middleware, never saw one of them, so dashboards showed
+successful traffic *dropping* instead of errors *rising*, and no error-rate
+alert fired. Rejected WebSocket handshakes were not counted at all.
+
+These tests wire the REAL auth-proxy middleware and the REAL metrics
+middleware in the production order onto a small FastAPI app, stub the auth
+DB call the way the incident broke it (executor exhausted / deadline hit),
+and check that what the client sees is unchanged and that the counters now
+record it.
+"""
+import asyncio
+import os
+import subprocess
+import sys
+from unittest import mock
+
+import fastapi
+from fastapi.testclient import TestClient
+import pytest
+import starlette.middleware.base
+from starlette.websockets import WebSocketDisconnect
+
+from sky import exceptions
+from sky.metrics import utils as metrics_utils
+from sky.server import config as server_config
+from sky.server import metrics
+from sky.server import middleware_utils
+from sky.server import server
+from sky.server.auth import db_lookup
+
+_AUTH_HEADER = {'X-Auth-Request-Email': 'bob@example.com'}
+_PROXY_CONFIG = server_config.ExternalProxyConfig(
+    enabled=True, header_name='X-Auth-Request-Email', header_format='plaintext')
+_COUNTERS = (
+    metrics_utils.SKY_APISERVER_REQUESTS_TOTAL,
+    metrics_utils.SKY_APISERVER_REQUESTS_BY_USER_TOTAL,
+    metrics_utils.SKY_APISERVER_REQUEST_REJECTIONS_TOTAL,
+    metrics_utils.SKY_APISERVER_WEBSOCKET_HANDSHAKE_REJECTIONS_TOTAL,
+)
+
+
+def _sample(counter, **labels) -> float:
+    """Current value of the `counter` children matching these labels."""
+    total = 0.0
+    for family in counter.collect():
+        for sample in family.samples:
+            if not sample.name.endswith('_total'):
+                continue
+            if all(sample.labels.get(k) == v for k, v in labels.items()):
+                total += sample.value
+    return total
+
+
+@pytest.fixture(autouse=True)
+def clear_metrics():
+    for counter in _COUNTERS:
+        counter.clear()
+    yield
+    for counter in _COUNTERS:
+        counter.clear()
+
+
+def _routes(app: fastapi.FastAPI) -> None:
+
+    @app.get('/status')
+    async def status():  # pylint: disable=unused-variable
+        return {'ok': True}
+
+    @app.websocket('/kubernetes-pod-ssh-proxy')
+    async def ssh_proxy(  # pylint: disable=unused-variable
+            websocket: fastapi.WebSocket):
+        await websocket.accept()
+        await websocket.send_text('hello')
+        await websocket.close()
+
+
+def _app(metrics_outermost: bool = True) -> fastapi.FastAPI:
+    """A small app with the production middleware order.
+
+    server.py adds the metrics middleware last, i.e. outermost; the auth
+    middlewares sit inside it. `InitializeRequestAuthUserMiddleware` is what
+    makes `request.state.auth_user` exist for `AuthProxyMiddleware`. With
+    `metrics_outermost=False` the metrics middleware is added first, i.e.
+    innermost: the order before this change.
+    """
+    app = fastapi.FastAPI()
+    _routes(app)
+
+    with mock.patch.object(server_config,
+                           'load_external_proxy_config',
+                           return_value=_PROXY_CONFIG):
+        if not metrics_outermost:
+            app.add_middleware(metrics.PrometheusMiddleware)
+        app.add_middleware(server.AuthProxyMiddleware)
+        app.add_middleware(server.InitializeRequestAuthUserMiddleware)
+        if metrics_outermost:
+            app.add_middleware(metrics.PrometheusMiddleware)
+        # Middleware classes are instantiated when the stack is built; force
+        # that now, while the config is patched.
+        app.build_middleware_stack()
+        with _healthy_auth():
+            TestClient(app).get('/status')
+    for counter in _COUNTERS:
+        counter.clear()
+    return app
+
+
+def _client(app: fastapi.FastAPI) -> TestClient:
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _healthy_auth():
+    return mock.patch.multiple(
+        db_lookup,
+        call_with_deadline=mock.AsyncMock(return_value=False),
+        ensure_role_for_authenticated_user=mock.AsyncMock(return_value=None))
+
+
+def _broken_auth(failure):
+    return mock.patch.object(db_lookup,
+                             'call_with_deadline',
+                             new=mock.AsyncMock(side_effect=failure))
+
+
+def test_baseline_success_is_counted_as_before():
+    app = _app()
+    with _healthy_auth():
+        response = _client(app).get('/status', headers=_AUTH_HEADER)
+    assert response.status_code == 200
+    assert _sample(metrics_utils.SKY_APISERVER_REQUESTS_TOTAL,
+                   path='/status',
+                   method='GET',
+                   status='2xx') == 1.0
+    assert _sample(metrics_utils.SKY_APISERVER_REQUESTS_BY_USER_TOTAL,
+                   user='bob@example.com',
+                   status='2xx') == 1.0
+    assert _sample(metrics_utils.SKY_APISERVER_REQUEST_REJECTIONS_TOTAL) == 0.0
+
+
+@pytest.mark.parametrize('failure, reason, detail_fragment, retry_after', [
+    (exceptions.ConcurrentWorkerExhaustedError('32 of 32'),
+     middleware_utils.REJECT_REASON_AUTH_WORKER_EXHAUSTED,
+     'exhausted its concurrent worker limit', False),
+    (asyncio.TimeoutError(), middleware_utils.REJECT_REASON_AUTH_DB_TIMEOUT,
+     'Authentication lookup timed out', True),
+])
+def test_a_middleware_503_is_counted_with_its_reason(failure, reason,
+                                                     detail_fragment,
+                                                     retry_after):
+    """The incident's shape: the auth upsert cannot get a thread (or its
+    deadline elapses), the auth middleware answers 503 itself, and the route
+    handler never runs. The client sees the same 503 as before; now the
+    counters see it too."""
+    app = _app()
+    with _broken_auth(failure):
+        response = _client(app).get('/status', headers=_AUTH_HEADER)
+
+    assert response.status_code == 503
+    assert detail_fragment in response.json()['detail']
+    # The helpers' headers are untouched: only the timeout 503 carries one.
+    assert ('retry-after' in response.headers) is retry_after
+    assert _sample(metrics_utils.SKY_APISERVER_REQUESTS_TOTAL,
+                   path='/status',
+                   method='GET',
+                   status='5xx') == 1.0
+    assert _sample(metrics_utils.SKY_APISERVER_REQUEST_REJECTIONS_TOTAL,
+                   reason=reason,
+                   status='503',
+                   kind='http') == 1.0
+    # Unauthenticated at the time of the answer: the per-user series says so.
+    assert _sample(metrics_utils.SKY_APISERVER_REQUESTS_BY_USER_TOTAL,
+                   user='anonymous',
+                   status='5xx') == 1.0
+
+
+def test_the_old_order_misses_the_middleware_503():
+    """Why the order matters: with the metrics middleware inside the auth
+    middleware (the previous order) the same 503 is never counted."""
+    app = _app(metrics_outermost=False)
+    with _broken_auth(exceptions.ConcurrentWorkerExhaustedError('32 of 32')):
+        response = _client(app).get('/status', headers=_AUTH_HEADER)
+    assert response.status_code == 503
+    assert _sample(metrics_utils.SKY_APISERVER_REQUESTS_TOTAL) == 0.0
+    assert _sample(metrics_utils.SKY_APISERVER_REQUEST_REJECTIONS_TOTAL) == 0.0
+
+
+def test_a_refused_websocket_handshake_is_counted():
+    """ssh goes over a WebSocket. During the incident every handshake was
+    refused and no counter moved. The client still gets the same refusal
+    (a pre-accept close, which servers render as an empty HTTP 403)."""
+    app = _app()
+    failure = exceptions.ConcurrentWorkerExhaustedError('32 of 32')
+    with _broken_auth(failure):
+        with pytest.raises(WebSocketDisconnect) as refused:
+            with _client(app).websocket_connect('/kubernetes-pod-ssh-proxy',
+                                                headers=_AUTH_HEADER):
+                pass
+
+    # Unchanged client-visible behaviour: the 1011 close for a 503 verdict.
+    assert refused.value.code == 1011
+    assert _sample(
+        metrics_utils.SKY_APISERVER_WEBSOCKET_HANDSHAKE_REJECTIONS_TOTAL,
+        path='/kubernetes-pod-ssh-proxy',
+        outcome='error') == 1.0
+    assert _sample(metrics_utils.SKY_APISERVER_REQUEST_REJECTIONS_TOTAL,
+                   reason=middleware_utils.REJECT_REASON_AUTH_WORKER_EXHAUSTED,
+                   status='503',
+                   kind='websocket') == 1.0
+    # Handshakes are not HTTP requests: the request counter is untouched.
+    assert _sample(metrics_utils.SKY_APISERVER_REQUESTS_TOTAL) == 0.0
+
+
+def test_an_accepted_websocket_handshake_is_not_counted_as_refused():
+    app = _app()
+    with _healthy_auth():
+        with _client(app).websocket_connect('/kubernetes-pod-ssh-proxy',
+                                            headers=_AUTH_HEADER) as websocket:
+            assert websocket.receive_text() == 'hello'
+    assert _sample(
+        metrics_utils.SKY_APISERVER_WEBSOCKET_HANDSHAKE_REJECTIONS_TOTAL) == 0.0
+    assert _sample(metrics_utils.SKY_APISERVER_REQUEST_REJECTIONS_TOTAL) == 0.0
+
+
+def test_unauthenticated_scanner_paths_do_not_create_series():
+    """Now that rejected requests are counted, their paths must not become
+    labels: an unauthenticated client can send any path it likes."""
+    app = _app()
+    failure = exceptions.ConcurrentWorkerExhaustedError('32 of 32')
+    with _broken_auth(failure):
+        client = _client(app)
+        for i in range(5):
+            assert client.get(f'/wp-admin/{i}.php',
+                              headers=_AUTH_HEADER).status_code == 503
+        assert client.get('/api/get', headers=_AUTH_HEADER).status_code == 503
+    assert _sample(metrics_utils.SKY_APISERVER_REQUESTS_TOTAL,
+                   path=metrics.OTHER_PATH_LABEL,
+                   status='5xx') == 5.0
+    for i in range(5):
+        assert _sample(metrics_utils.SKY_APISERVER_REQUESTS_TOTAL,
+                       path=f'/wp-admin/{i}.php') == 0.0
+    # `/api/get` is not a route of this small app, so it folds into the
+    # `/api/` prefix bucket, which the `/api/.*` exclusions still match.
+    assert _sample(metrics_utils.SKY_APISERVER_REQUESTS_TOTAL,
+                   path='/api/*',
+                   status='5xx') == 1.0
+
+
+def test_a_404_from_the_router_keeps_the_raw_path():
+    """Requests that reached the router are recorded exactly as before."""
+    app = _app()
+    with _healthy_auth():
+        assert _client(app).get('/no/such/route',
+                                headers=_AUTH_HEADER).status_code == 404
+    assert _sample(metrics_utils.SKY_APISERVER_REQUESTS_TOTAL,
+                   path='/no/such/route',
+                   status='4xx') == 1.0
+
+
+@pytest.mark.parametrize('helper', [
+    db_lookup.db_timeout_response,
+    db_lookup.worker_exhausted_response,
+])
+def test_a_middleware_calling_the_503_helpers_bare_still_answers_503(helper):
+    """Compatibility with middlewares that call the helpers with no request.
+
+    Out-of-tree middlewares do `return db_lookup.db_timeout_response()`. If the
+    request became a required argument, that line would raise inside the
+    middleware and reach the client as a bare 500 (not retried) on exactly the
+    failure path these helpers exist for. The 503 must survive; only the
+    per-reason attribution is missing until the caller passes the request.
+    """
+    app = fastapi.FastAPI()
+    _routes(app)
+
+    class BareCaller(starlette.middleware.base.BaseHTTPMiddleware):
+
+        async def dispatch(self, request, call_next):
+            del request, call_next
+            return helper()
+
+    app.add_middleware(BareCaller)
+    app.add_middleware(metrics.PrometheusMiddleware)
+
+    response = _client(app).get('/status')
+    assert response.status_code == 503
+    assert 'detail' in response.json()
+    assert _sample(metrics_utils.SKY_APISERVER_REQUESTS_TOTAL,
+                   path='/status',
+                   status='5xx') == 1.0
+    # Nothing attributed: the caller passed no request.
+    assert _sample(metrics_utils.SKY_APISERVER_REQUEST_REJECTIONS_TOTAL) == 0.0
+
+
+def test_the_real_server_registers_the_metrics_middleware_outermost():
+    """Order regression guard on sky.server.server itself.
+
+    Imported in a subprocess because the metrics gate is read at import time
+    and the module is imported once per process. `user_middleware[0]` is the
+    outermost layer (Starlette wraps the list in reverse).
+    """
+    code = (
+        'from sky.server import server\n'
+        'print(",".join(m.cls.__name__ for m in server.app.user_middleware))')
+    env = dict(os.environ)
+    env['SKY_API_SERVER_METRICS_ENABLED'] = 'true'
+    out = subprocess.run([sys.executable, '-c', code],
+                         env=env,
+                         check=True,
+                         capture_output=True,
+                         text=True,
+                         timeout=300).stdout.strip().splitlines()[-1]
+    names = out.split(',')
+    assert names[0] == 'PrometheusMiddleware', names
+    # ...and nothing else in the stack is a second copy of it.
+    assert names.count('PrometheusMiddleware') == 1, names

--- a/tests/unit_tests/test_sky/server/test_edge_error_counting.py
+++ b/tests/unit_tests/test_sky/server/test_edge_error_counting.py
@@ -14,6 +14,7 @@ and check that what the client sees is unchanged and that the counters now
 record it.
 """
 import asyncio
+import http
 import os
 import subprocess
 import sys
@@ -33,6 +34,7 @@ from sky.server import metrics
 from sky.server import middleware_utils
 from sky.server import server
 from sky.server.auth import db_lookup
+from sky.server.auth import oauth2_proxy
 
 _AUTH_HEADER = {'X-Auth-Request-Email': 'bob@example.com'}
 _PROXY_CONFIG = server_config.ExternalProxyConfig(
@@ -514,7 +516,154 @@ class TestOutermostGuard:
         assert 'InitializeRequestAuthUserMiddleware is' in message
         assert 'PrometheusMiddleware' in message
 
-    def test_no_middleware_at_all_is_reported(self):
+    def test_an_app_without_the_metrics_layer_is_not_reported(self):
+        """Metrics off (or registration skipped): there is no invariant to
+        hold, so the startup log must stay quiet."""
         with mock.patch.object(metrics.logger, 'warning') as warn:
-            assert metrics.warn_unless_outermost(fastapi.FastAPI()) is False
+            assert metrics.warn_unless_outermost(fastapi.FastAPI()) is True
+        warn.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_a_client_disconnect_is_counted_in_a_known_bucket():
+    """A `BaseException` (the cancellation a client disconnect produces)
+    unwinds past `except Exception`, so nothing sets a status and the request
+    records `0xx`. Counting it beats dropping it -- a disconnect is a real
+    request -- but it is a label value operators will see, so pin it
+    deliberately instead of leaving it to `_get_status_code_group(0)`."""
+    middleware = metrics.PrometheusMiddleware(app=mock.Mock())
+    request = fastapi.Request({
+        'type': 'http',
+        'method': 'GET',
+        'path': '/status',
+        'headers': [],
+        'query_string': b'',
+        'state': {},
+        'router': object(),
+    })
+
+    async def cancelled(_):
+        raise asyncio.CancelledError()
+
+    with pytest.raises(asyncio.CancelledError):
+        await middleware.dispatch(request, cancelled)
+
+    assert _sample(metrics_utils.SKY_APISERVER_REQUESTS_TOTAL,
+                   path='/status',
+                   status='0xx') == 1.0
+
+
+class TestOutermostGuardIsNotEnvGated:
+    """Regression: the guard used to read `metrics_utils.METRICS_ENABLED`
+    (`== 'true'`) while the registration used the env var's truthiness, so
+    `SKY_API_SERVER_METRICS_ENABLED=1` installed the layer and skipped the
+    check -- an enabled deployment with the check silently off. It now reads
+    the stack, so no predicate can drift."""
+
+    def test_no_metrics_layer_means_nothing_to_check(self):
+        app = fastapi.FastAPI()
+        app.add_middleware(server.InitializeRequestAuthUserMiddleware)
+        with mock.patch.object(metrics.logger, 'warning') as warn:
+            assert metrics.warn_unless_outermost(app) is True
+        warn.assert_not_called()
+
+    def test_an_installed_but_displaced_layer_is_reported(self):
+        app = fastapi.FastAPI()
+        app.add_middleware(metrics.PrometheusMiddleware)
+        app.user_middleware.insert(
+            0,
+            starlette.middleware.Middleware(
+                server.InitializeRequestAuthUserMiddleware))
+        with mock.patch.object(metrics.logger, 'warning') as warn:
+            assert metrics.warn_unless_outermost(app) is False
         warn.assert_called_once()
+
+    @pytest.mark.parametrize('value', ['1', 'true', 'True', 'yes'])
+    def test_the_check_runs_whatever_the_env_var_spelling(
+            self, monkeypatch, value):
+        """Any spelling the registration accepts must be checked too."""
+        monkeypatch.setenv('SKY_API_SERVER_METRICS_ENABLED', value)
+        app = fastapi.FastAPI()
+        app.add_middleware(metrics.PrometheusMiddleware)
+        app.user_middleware.insert(
+            0,
+            starlette.middleware.Middleware(
+                server.InitializeRequestAuthUserMiddleware))
+        with mock.patch.object(metrics.logger, 'warning') as warn:
+            assert metrics.warn_unless_outermost(app) is False
+        warn.assert_called_once()
+
+
+class _StubAuthResponse:
+    """The oauth2-proxy `/oauth2/auth` answer, as an async context manager."""
+
+    def __init__(self, status):
+        self.status = status
+        self.headers = {}
+        self.cookies = {}
+        self.text = ''
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _StubSession:
+
+    def __init__(self, status):
+        self._status = status
+
+    def request(self, **kwargs):
+        del kwargs
+        return _StubAuthResponse(self._status)
+
+
+class TestAuthProxyReasonsAreDistinct:
+    """`auth_proxy_unavailable` used to cover two different failures. They
+    need different fixes -- one is "the proxy is down", the other is "the
+    proxy answered and we cannot use it" -- so they are separate reasons.
+    """
+
+    @staticmethod
+    async def _run(status, get_auth_user):
+        request = fastapi.Request({
+            'type': 'http',
+            'method': 'GET',
+            'path': '/status',
+            'headers': [],
+            'query_string': b'',
+            'scheme': 'http',
+            'server': ('testserver', 80),
+            'state': {},
+        })
+        # `websocket_aware` wraps the class, so the real middleware -- the
+        # one carrying `get_auth_user` and `_authenticate` -- is the
+        # instance it holds.
+        middleware = oauth2_proxy.OAuth2ProxyMiddleware(
+            app=mock.Mock()).middleware
+        with mock.patch.object(middleware, 'get_auth_user', get_auth_user):
+            response = await middleware._authenticate(  # pylint: disable=protected-access
+                request, mock.AsyncMock(), _StubSession(status))
+        return request, response
+
+    @pytest.mark.asyncio
+    async def test_authenticated_without_user_info_is_a_bad_response(self):
+        """The proxy is reachable and says the user is authenticated; it just
+        did not send the user info. A setup problem, not an outage."""
+        request, response = await self._run(http.HTTPStatus.ACCEPTED,
+                                            lambda _: None)
+        assert response.status_code == 500
+        assert middleware_utils.get_rejection_reason(request.scope) == (
+            middleware_utils.REJECT_REASON_AUTH_PROXY_BAD_RESPONSE)
+
+    @pytest.mark.asyncio
+    async def test_an_unexpected_proxy_status_is_a_bad_response_too(self):
+        """The other half of the same axis, which the first pass missed: the
+        proxy answered something this server cannot act on."""
+        request, response = await self._run(http.HTTPStatus.IM_A_TEAPOT,
+                                            lambda _: None)
+        assert response.status_code == int(http.HTTPStatus.IM_A_TEAPOT)
+        assert middleware_utils.get_rejection_reason(request.scope) == (
+            middleware_utils.REJECT_REASON_AUTH_PROXY_BAD_RESPONSE)

--- a/tests/unit_tests/test_sky/server/test_edge_error_counting.py
+++ b/tests/unit_tests/test_sky/server/test_edge_error_counting.py
@@ -578,20 +578,35 @@ class TestOutermostGuardIsNotEnvGated:
             assert metrics.warn_unless_outermost(app) is False
         warn.assert_called_once()
 
-    @pytest.mark.parametrize('value', ['1', 'true', 'True', 'yes'])
-    def test_the_check_runs_whatever_the_env_var_spelling(
-            self, monkeypatch, value):
-        """Any spelling the registration accepts must be checked too."""
-        monkeypatch.setenv('SKY_API_SERVER_METRICS_ENABLED', value)
-        app = fastapi.FastAPI()
-        app.add_middleware(metrics.PrometheusMiddleware)
-        app.user_middleware.insert(
-            0,
-            starlette.middleware.Middleware(
-                server.InitializeRequestAuthUserMiddleware))
-        with mock.patch.object(metrics.logger, 'warning') as warn:
-            assert metrics.warn_unless_outermost(app) is False
-        warn.assert_called_once()
+    def test_the_call_site_is_not_gated_by_an_env_var(self):
+        """The defect was the call site, not the function: a gate on the
+        metrics env var meant the check never ran under
+        `SKY_API_SERVER_METRICS_ENABLED=1` (truthy for the registration,
+        not the literal `true` that `METRICS_ENABLED` requires). Patch the
+        guard, import the real server module in a fresh process, and assert
+        it was called -- any gate that is false in this environment, which
+        is every gate on that variable, fails this.
+        """
+        code = ('import unittest.mock as mock\n'
+                'from sky.server import metrics\n'
+                'with mock.patch.object(metrics, "warn_unless_outermost") '
+                'as guard:\n'
+                '    from sky.server import server\n'
+                '    del server\n'
+                'assert guard.call_count == 1, guard.call_count\n'
+                'print("called")')
+        env = {
+            k: v
+            for k, v in os.environ.items()
+            if k != 'SKY_API_SERVER_METRICS_ENABLED'
+        }
+        out = subprocess.run([sys.executable, '-c', code],
+                             env=env,
+                             check=True,
+                             capture_output=True,
+                             text=True,
+                             timeout=300)
+        assert out.stdout.strip().splitlines()[-1] == 'called', out.stdout
 
 
 class _StubAuthResponse:

--- a/tests/unit_tests/test_sky/server/test_edge_error_counting.py
+++ b/tests/unit_tests/test_sky/server/test_edge_error_counting.py
@@ -296,6 +296,31 @@ def test_a_middleware_calling_the_503_helpers_bare_still_answers_503(helper):
     assert _sample(metrics_utils.SKY_APISERVER_REQUEST_REJECTIONS_TOTAL) == 0.0
 
 
+def test_route_level_executor_exhaustion_is_counted_with_its_reason():
+    """The other exhaustion 503: raised inside a route handler and converted
+    by the app-level exception handler. Always was counted as a 5xx; now it
+    is attributed too."""
+    app = fastapi.FastAPI()
+    app.add_exception_handler(exceptions.ConcurrentWorkerExhaustedError,
+                              server.handle_concurrent_worker_exhausted_error)
+
+    @app.get('/logs')
+    async def logs():  # pylint: disable=unused-variable
+        raise exceptions.ConcurrentWorkerExhaustedError('128 of 128')
+
+    app.add_middleware(metrics.PrometheusMiddleware)
+    response = _client(app).get('/logs')
+    assert response.status_code == 503
+    assert _sample(
+        metrics_utils.SKY_APISERVER_REQUEST_REJECTIONS_TOTAL,
+        reason=middleware_utils.REJECT_REASON_REQUEST_WORKER_EXHAUSTED,
+        status='503',
+        kind='http') == 1.0
+    assert _sample(metrics_utils.SKY_APISERVER_REQUESTS_TOTAL,
+                   path='/logs',
+                   status='5xx') == 1.0
+
+
 def test_the_real_server_registers_the_metrics_middleware_outermost():
     """Order regression guard on sky.server.server itself.
 

--- a/tests/unit_tests/test_sky/server/test_edge_error_counting.py
+++ b/tests/unit_tests/test_sky/server/test_edge_error_counting.py
@@ -22,6 +22,7 @@ from unittest import mock
 import fastapi
 from fastapi.testclient import TestClient
 import pytest
+import starlette.middleware
 import starlette.middleware.base
 from starlette.websockets import WebSocketDisconnect
 
@@ -343,3 +344,177 @@ def test_the_real_server_registers_the_metrics_middleware_outermost():
     assert names[0] == 'PrometheusMiddleware', names
     # ...and nothing else in the stack is a second copy of it.
     assert names.count('PrometheusMiddleware') == 1, names
+
+
+import starlette.middleware
+
+
+def _break(target: str):
+    """Make one recording call site raise."""
+    return mock.patch(target, side_effect=RuntimeError('multiproc dir full'))
+
+
+@pytest.fixture
+def recording_log():
+    """A fresh rate limiter, so failure counts are per test."""
+    original = middleware_utils._recording_failure_log  # pylint: disable=protected-access
+    fresh = middleware_utils.RecordingFailureLog()
+    middleware_utils._recording_failure_log = fresh  # pylint: disable=protected-access
+    yield fresh
+    middleware_utils._recording_failure_log = original  # pylint: disable=protected-access
+
+
+@pytest.mark.parametrize('broken', [
+    'sky.metrics.utils.SKY_APISERVER_REQUESTS_TOTAL.labels',
+    'sky.metrics.utils.SKY_APISERVER_REQUESTS_BY_USER_TOTAL.labels',
+    'sky.metrics.utils.SKY_APISERVER_REQUEST_DURATION_SECONDS.labels',
+    'sky.metrics.utils.SKY_APISERVER_REQUEST_REJECTIONS_TOTAL.labels',
+])
+def test_a_recording_failure_never_reaches_the_client(broken, recording_log):
+    """This layer is outermost, so it sees 100% of responses: a fault while
+    recording must not turn a served request into a 500. Compared against the
+    same requests with recording healthy, byte for byte."""
+    app = _app()
+    failure = exceptions.ConcurrentWorkerExhaustedError('32 of 32')
+
+    def exchange():
+        client = _client(app)
+        ok = client.get('/status', headers=_AUTH_HEADER)
+        with _broken_auth(failure):
+            rejected = client.get('/status', headers=_AUTH_HEADER)
+        return [
+            (r.status_code, r.content, dict(r.headers)) for r in (ok, rejected)
+        ]
+
+    with _healthy_auth():
+        baseline = exchange()
+    with mock.patch.object(middleware_utils.logger, 'warning'):
+        with _break(broken):
+            with _healthy_auth():
+                faulted = exchange()
+
+    for (want, got) in zip(baseline, faulted):
+        assert want[0] == got[0]
+        assert want[1] == got[1]
+        # `date` moves between the two exchanges; everything else must not.
+        assert {k: v for k, v in want[2].items() if k != 'date'} == \
+               {k: v for k, v in got[2].items() if k != 'date'}
+    assert recording_log.failures > 0, 'the failure was not even noticed'
+
+
+def test_a_broken_path_resolver_still_counts_the_request(recording_log):
+    """The path label is the one part of recording that reads state this
+    layer does not own (the app's route table). Mislabelled beats uncounted:
+    the request must still land in the counter, in the catch-all bucket."""
+    app = _app()
+    with mock.patch.object(middleware_utils.logger, 'warning'):
+        with _break('sky.server.metrics._unrouted_path_label'):
+            with _broken_auth(
+                    exceptions.ConcurrentWorkerExhaustedError('32 of 32')):
+                response = _client(app).get('/status', headers=_AUTH_HEADER)
+
+    assert response.status_code == 503
+    assert _sample(metrics_utils.SKY_APISERVER_REQUESTS_TOTAL,
+                   path=metrics.OTHER_PATH_LABEL,
+                   status='5xx') == 1.0
+    assert recording_log.failures == 1
+
+
+def test_an_application_exception_still_propagates(recording_log):
+    """`record_safely` swallows recording faults only. A handler that raises
+    must still reach the client as a 500 and be counted as one."""
+
+    app = _app()
+
+    @app.get('/boom')
+    async def boom():  # pylint: disable=unused-variable
+        raise RuntimeError('handler exploded')
+
+    app.build_middleware_stack()
+    with _healthy_auth():
+        response = _client(app).get('/boom', headers=_AUTH_HEADER)
+
+    assert response.status_code == 500
+    assert _sample(metrics_utils.SKY_APISERVER_REQUESTS_TOTAL,
+                   path='/boom',
+                   status='5xx') == 1.0
+    assert recording_log.failures == 0, 'no recording call should have failed'
+
+
+class TestRecordingFailureLog:
+    """The rate limiter: a persistent fault must not log at request rate."""
+
+    @staticmethod
+    def _log(interval=300.0):
+        clock = {'now': 1000.0}
+        log = middleware_utils.RecordingFailureLog(interval_seconds=interval,
+                                                   clock=lambda: clock['now'])
+        return log, clock
+
+    def test_the_first_failure_is_logged_with_its_traceback(self):
+        log, _ = self._log()
+        with mock.patch.object(middleware_utils.logger, 'warning') as warn:
+            log.note('the request counter', RuntimeError('boom'))
+        assert warn.call_count == 1
+        assert warn.call_args.kwargs['exc_info'] is not None
+        assert log.failures == 1
+
+    def test_failures_inside_the_interval_are_counted_but_not_logged(self):
+        log, clock = self._log()
+        with mock.patch.object(middleware_utils.logger, 'warning') as warn:
+            log.note('x', RuntimeError('1'))
+            for _ in range(50):
+                clock['now'] += 1.0
+                log.note('x', RuntimeError('n'))
+        assert warn.call_count == 1, 'a persistent fault flooded the log'
+        assert log.failures == 51
+
+    def test_the_next_message_reports_what_was_dropped(self):
+        log, clock = self._log(interval=10.0)
+        with mock.patch.object(middleware_utils.logger, 'warning') as warn:
+            log.note('x', RuntimeError('1'))
+            for _ in range(3):
+                clock['now'] += 1.0
+                log.note('x', RuntimeError('n'))
+            clock['now'] += 100.0
+            log.note('x', RuntimeError('last'))
+        assert warn.call_count == 2
+        assert '3 more failure(s) were dropped' in warn.call_args.args[0]
+        # Only the first message carries a traceback.
+        assert warn.call_args.kwargs['exc_info'] is None
+
+
+class TestOutermostGuard:
+    """The runtime counterpart of the ordering test: a deployment whose
+    plugins register middleware is not covered by a unit test on the
+    plugin-less app, and being wrong is silent."""
+
+    def test_the_production_order_passes_without_a_warning(self):
+        app = _app()
+        with mock.patch.object(metrics.logger, 'warning') as warn:
+            assert metrics.warn_unless_outermost(app) is True
+        warn.assert_not_called()
+
+    def test_a_layer_outside_the_metrics_middleware_is_reported(self):
+        """How the invariant actually breaks in a deployment: the plugin API
+        (`add_middleware_last`) appends straight to `app.user_middleware`, so
+        it bypasses `add_middleware` -- which would refuse after startup --
+        and can seat a layer outside this one with no error anywhere."""
+        app = fastapi.FastAPI()
+        app.add_middleware(metrics.PrometheusMiddleware)
+        app.user_middleware.insert(
+            0,
+            starlette.middleware.Middleware(
+                server.InitializeRequestAuthUserMiddleware))
+
+        with mock.patch.object(metrics.logger, 'warning') as warn:
+            assert metrics.warn_unless_outermost(app) is False
+        assert warn.call_count == 1
+        message = warn.call_args.args[0]
+        assert 'InitializeRequestAuthUserMiddleware is' in message
+        assert 'PrometheusMiddleware' in message
+
+    def test_no_middleware_at_all_is_reported(self):
+        with mock.patch.object(metrics.logger, 'warning') as warn:
+            assert metrics.warn_unless_outermost(fastapi.FastAPI()) is False
+        warn.assert_called_once()

--- a/tests/unit_tests/test_sky/server/test_edge_error_counting.py
+++ b/tests/unit_tests/test_sky/server/test_edge_error_counting.py
@@ -587,14 +587,24 @@ class TestOutermostGuardIsNotEnvGated:
         it was called -- any gate that is false in this environment, which
         is every gate on that variable, fails this.
         """
-        code = ('import unittest.mock as mock\n'
-                'from sky.server import metrics\n'
-                'with mock.patch.object(metrics, "warn_unless_outermost") '
-                'as guard:\n'
-                '    from sky.server import server\n'
-                '    del server\n'
-                'assert guard.call_count == 1, guard.call_count\n'
-                'print("called")')
+        code = (
+            'import sys\n'
+            'import unittest.mock as mock\n'
+            'from sky.server import metrics\n'
+            # The patch has to be in place before the module-level call runs,
+            # so assert it has not been imported already: if the import graph
+            # ever pulls it in, say so instead of failing as though the call
+            # site had regressed.
+            "assert 'sky.server.server' not in sys.modules, (\n"
+            "    'importing sky.server.metrics now pulls in '\n"
+            "    'sky.server.server; this test can no longer observe the '\n"
+            "    'module-level call and needs rewriting')\n"
+            'with mock.patch.object(metrics, "warn_unless_outermost") '
+            'as guard:\n'
+            '    from sky.server import server\n'
+            '    del server\n'
+            'assert guard.call_count == 1, guard.call_count\n'
+            'print("called")')
         env = {
             k: v
             for k, v in os.environ.items()

--- a/tests/unit_tests/test_sky/server/test_metrics.py
+++ b/tests/unit_tests/test_sky/server/test_metrics.py
@@ -589,7 +589,7 @@ async def test_a_middleware_rejection_keeps_a_registered_route_path(
     ('/dashboard/_next/static/chunks/main.js', '/dashboard/*'),
     ('/internal/dashboard/clusters', '/internal/dashboard/*'),
     ('/plugins/api/foo/list', '/plugins/*'),
-    ('/jobs/queue', '/jobs/*'),
+    ('/jobs/no-such-thing', '/jobs/*'),
     ('/users', '/users/*'),
 ])
 async def test_a_middleware_rejection_on_an_unknown_path_is_bucketed(

--- a/tests/unit_tests/test_sky/server/test_metrics.py
+++ b/tests/unit_tests/test_sky/server/test_metrics.py
@@ -624,9 +624,9 @@ async def test_a_middleware_rejection_without_an_app_is_still_bounded(
     }) == 1.0
 
 
-def test_middleware_rejected_path_label():
+def test_unrouted_path_label():
     literal = frozenset(('/status', '/api/get'))
-    label = metrics._middleware_rejected_path_label
+    label = metrics._unrouted_path_label
     assert label('/status', literal) == '/status'
     assert label('/api/get', literal) == '/api/get'
     assert label('/api/stream', literal) == '/api/*'

--- a/tests/unit_tests/test_sky/server/test_metrics.py
+++ b/tests/unit_tests/test_sky/server/test_metrics.py
@@ -5,6 +5,7 @@ import os
 import socket
 import threading
 import time
+import types
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -21,6 +22,7 @@ import pytest
 
 from sky.metrics import utils as metrics_utils
 from sky.server import metrics
+from sky.server import middleware_utils
 from sky.server.server import BasicAuthMiddleware
 
 
@@ -343,6 +345,41 @@ async def test_metrics_endpoint_with_multiprocess():
             mock_gen.assert_called_once_with(mock_registry_instance)
 
 
+def _http_request(path,
+                  method='GET',
+                  *,
+                  reached_router=True,
+                  state=None,
+                  app=None,
+                  headers=None) -> fastapi.Request:
+    """A real Request on a minimal ASGI scope.
+
+    `reached_router` models whether the request got past every middleware to
+    the router: Starlette's router stamps `scope['router']` when it runs, and
+    a request a middleware answered itself never gets there.
+    """
+    scope = {
+        'type': 'http',
+        'method': method,
+        'path': path,
+        'headers': [(k.lower().encode(), v.encode())
+                    for k, v in (headers or {}).items()],
+        'query_string': b'',
+        'state': {} if state is None else state,
+    }
+    if reached_router:
+        scope['router'] = object()
+    if app is not None:
+        scope['app'] = app
+    return fastapi.Request(scope)
+
+
+def _response(status_code: int) -> MagicMock:
+    response = MagicMock()
+    response.status_code = status_code
+    return response
+
+
 @pytest.fixture
 def prometheus_middleware():
     """Create PrometheusMiddleware instance for testing."""
@@ -352,6 +389,7 @@ def prometheus_middleware():
     metrics_utils.SKY_APISERVER_REQUESTS_TOTAL.clear()
     metrics_utils.SKY_APISERVER_REQUEST_DURATION_SECONDS.clear()
     metrics_utils.SKY_APISERVER_REQUEST_GET_DURATION_SECONDS.clear()
+    metrics_utils.SKY_APISERVER_REQUEST_REJECTIONS_TOTAL.clear()
 
     return middleware
 
@@ -359,13 +397,8 @@ def prometheus_middleware():
 @pytest.mark.asyncio
 async def test_middleware_successful_request(prometheus_middleware):
     """Test middleware with successful non-streaming request."""
-    request = MagicMock()
-    request.url.path = "/api/v1/status"
-    request.method = "GET"
-
-    response = MagicMock()
-    response.status_code = 200
-
+    request = _http_request('/api/v1/status')
+    response = _response(200)
     call_next = AsyncMock(return_value=response)
 
     start_time = time.time()
@@ -405,13 +438,8 @@ async def test_middleware_successful_request(prometheus_middleware):
 @pytest.mark.asyncio
 async def test_middleware_streaming_request(prometheus_middleware):
     """Test middleware with streaming API request."""
-    request = MagicMock()
-    request.url.path = "/api/v1/logs"
-    request.method = "GET"
-
-    response = MagicMock()
-    response.status_code = 200
-
+    request = _http_request('/api/v1/logs')
+    response = _response(200)
     call_next = AsyncMock(return_value=response)
 
     result = await prometheus_middleware.dispatch(request, call_next)
@@ -439,10 +467,7 @@ async def test_middleware_streaming_request(prometheus_middleware):
 @pytest.mark.asyncio
 async def test_middleware_exception_handling(prometheus_middleware):
     """Test middleware handles exceptions properly."""
-    request = MagicMock()
-    request.url.path = "/api/v1/failing"
-    request.method = "POST"
-
+    request = _http_request('/api/v1/failing', 'POST')
     call_next = AsyncMock(side_effect=Exception("Test error"))
 
     with pytest.raises(Exception, match="Test error"):
@@ -467,14 +492,8 @@ async def test_middleware_different_status_codes(prometheus_middleware):
     ]
 
     for status_code, expected_group in test_cases:
-        request = MagicMock()
-        request.url.path = f"/test/{status_code}"
-        request.method = "GET"
-
-        response = MagicMock()
-        response.status_code = status_code
-
-        call_next = AsyncMock(return_value=response)
+        request = _http_request(f'/test/{status_code}')
+        call_next = AsyncMock(return_value=_response(status_code))
 
         await prometheus_middleware.dispatch(request, call_next)
 
@@ -486,6 +505,180 @@ async def test_middleware_different_status_codes(prometheus_middleware):
                 'status': expected_group
             })
         assert total_requests == 1.0
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# The metrics middleware is the outermost one, so it also sees the responses
+# other middlewares produce. Their paths are bounded; everything that reached
+# the router keeps the raw path as before.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _app_with_routes() -> fastapi.FastAPI:
+    app = fastapi.FastAPI()
+
+    @app.get('/status')
+    async def status():  # pylint: disable=unused-variable
+        return {}
+
+    @app.get('/api/get')
+    async def api_get():  # pylint: disable=unused-variable
+        return {}
+
+    @app.get('/dashboard/{full_path:path}')
+    async def dashboard(full_path: str):  # pylint: disable=unused-variable
+        return {'path': full_path}
+
+    return app
+
+
+@pytest.mark.asyncio
+async def test_path_label_is_read_after_the_inner_layers_ran(
+        prometheus_middleware):
+    """Inner middlewares rewrite `scope['path']` in place (the internal
+    dashboard prefix); the scope dict is shared down the stack, so reading it
+    after `call_next` gives the path the router saw, as before the move."""
+    request = _http_request('/internal/dashboard/status', reached_router=False)
+
+    async def call_next(req):
+        req.scope['path'] = '/status'
+        req.scope['router'] = object()
+        return _response(200)
+
+    await prometheus_middleware.dispatch(request, call_next)
+
+    assert _get_metric_value('sky_apiserver_requests_total', {
+        'path': '/status',
+        'status': '2xx'
+    }) == 1.0
+    assert _get_metric_value('sky_apiserver_requests_total',
+                             {'path': '/internal/dashboard/status'}) == 0.0
+
+
+@pytest.mark.asyncio
+async def test_a_404_from_the_router_keeps_the_raw_path(prometheus_middleware):
+    request = _http_request('/no/such/route')
+    await prometheus_middleware.dispatch(request,
+                                         AsyncMock(return_value=_response(404)))
+    assert _get_metric_value('sky_apiserver_requests_total', {
+        'path': '/no/such/route',
+        'status': '4xx'
+    }) == 1.0
+
+
+@pytest.mark.asyncio
+async def test_a_middleware_rejection_keeps_a_registered_route_path(
+        prometheus_middleware):
+    """A 503 an auth middleware answered for `/status` lands in the same
+    series as the successes of `/status`."""
+    app = _app_with_routes()
+    request = _http_request('/status', reached_router=False, app=app)
+    await prometheus_middleware.dispatch(request,
+                                         AsyncMock(return_value=_response(503)))
+    assert _get_metric_value('sky_apiserver_requests_total', {
+        'path': '/status',
+        'status': '5xx'
+    }) == 1.0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('raw_path, label', [
+    ('/wp-admin/setup.php', metrics.OTHER_PATH_LABEL),
+    ('/.env', metrics.OTHER_PATH_LABEL),
+    ('/api/no-such-endpoint', '/api/*'),
+    ('/dashboard/_next/static/chunks/main.js', '/dashboard/*'),
+    ('/internal/dashboard/clusters', '/internal/dashboard/*'),
+    ('/plugins/api/foo/list', '/plugins/*'),
+    ('/jobs/queue', '/jobs/*'),
+    ('/users', '/users/*'),
+])
+async def test_a_middleware_rejection_on_an_unknown_path_is_bucketed(
+        prometheus_middleware, raw_path, label):
+    """Rejected requests' paths are chosen by unauthenticated clients, so
+    anything that is not a registered route folds into a fixed prefix or
+    `other`. The `<prefix>*` form keeps the prefix regexes dashboards use
+    (`/api/.*`, `/dashboard/.*`) matching."""
+    app = _app_with_routes()
+    request = _http_request(raw_path, reached_router=False, app=app)
+    await prometheus_middleware.dispatch(request,
+                                         AsyncMock(return_value=_response(401)))
+    assert _get_metric_value('sky_apiserver_requests_total', {
+        'path': label,
+        'status': '4xx'
+    }) == 1.0
+    assert _get_metric_value('sky_apiserver_requests_total',
+                             {'path': raw_path}) == 0.0
+
+
+@pytest.mark.asyncio
+async def test_a_middleware_rejection_without_an_app_is_still_bounded(
+        prometheus_middleware):
+    """No app on the scope (bare ASGI callable): nothing to match against,
+    so every rejected path folds into a prefix or `other`."""
+    request = _http_request('/status', reached_router=False)
+    await prometheus_middleware.dispatch(request,
+                                         AsyncMock(return_value=_response(503)))
+    assert _get_metric_value('sky_apiserver_requests_total', {
+        'path': metrics.OTHER_PATH_LABEL,
+        'status': '5xx'
+    }) == 1.0
+
+
+def test_middleware_rejected_path_label():
+    literal = frozenset(('/status', '/api/get'))
+    label = metrics._middleware_rejected_path_label
+    assert label('/status', literal) == '/status'
+    assert label('/api/get', literal) == '/api/get'
+    assert label('/api/stream', literal) == '/api/*'
+    assert label('/dashboard/clusters', literal) == '/dashboard/*'
+    # A router's root route is the bare prefix.
+    assert label('/workspaces', literal) == '/workspaces/*'
+    assert label('/status/', literal) == metrics.OTHER_PATH_LABEL
+    assert label('/wp-admin', literal) == metrics.OTHER_PATH_LABEL
+    assert label('', literal) == metrics.OTHER_PATH_LABEL
+
+
+def test_literal_route_paths_skip_parameterized_routes():
+    paths = metrics._literal_route_paths(_app_with_routes())
+    assert '/status' in paths
+    assert '/api/get' in paths
+    assert not any('{' in path for path in paths)
+    assert metrics._literal_route_paths(None) == frozenset()
+    assert metrics._literal_route_paths(MagicMock()) == frozenset()
+
+
+def test_reached_router_uses_the_router_scope_key():
+    assert metrics._reached_router(_http_request('/x', reached_router=True))
+    assert not metrics._reached_router(_http_request('/x',
+                                                     reached_router=False))
+
+
+@pytest.mark.asyncio
+async def test_a_stamped_rejection_is_counted_by_reason(prometheus_middleware):
+    """The auth helpers stamp why they answered; the metrics middleware
+    turns the stamp into `sky_apiserver_request_rejections_total`."""
+    request = _http_request('/status', reached_router=False)
+    middleware_utils.mark_rejection(
+        request, middleware_utils.REJECT_REASON_AUTH_DB_TIMEOUT)
+    await prometheus_middleware.dispatch(request,
+                                         AsyncMock(return_value=_response(503)))
+    collectors = [metrics_utils.SKY_APISERVER_REQUEST_REJECTIONS_TOTAL]
+    assert _get_metric_value('sky_apiserver_request_rejections_total', {
+        'reason': middleware_utils.REJECT_REASON_AUTH_DB_TIMEOUT,
+        'status': '503',
+        'kind': 'http'
+    },
+                             collectors=collectors) == 1.0
+
+
+@pytest.mark.asyncio
+async def test_an_unstamped_response_is_not_a_rejection(prometheus_middleware):
+    request = _http_request('/status')
+    await prometheus_middleware.dispatch(request,
+                                         AsyncMock(return_value=_response(500)))
+    collectors = [metrics_utils.SKY_APISERVER_REQUEST_REJECTIONS_TOTAL]
+    assert _get_metric_value('sky_apiserver_request_rejections_total',
+                             collectors=collectors) == 0.0
 
 
 def test_get_user_label_with_auth_user():
@@ -575,16 +768,10 @@ def prometheus_middleware_user():
 @pytest.mark.asyncio
 async def test_middleware_records_user_metrics(prometheus_middleware_user):
     """Test that middleware records per-user metrics for authenticated user."""
-    request = MagicMock()
-    request.url.path = '/api/v1/status'
-    request.method = 'GET'
-    request.state.auth_user = MagicMock()
-    request.state.auth_user.name = 'alice@example.com'
-
-    response = MagicMock()
-    response.status_code = 200
-
-    call_next = AsyncMock(return_value=response)
+    request = _http_request(
+        '/api/v1/status',
+        state={'auth_user': types.SimpleNamespace(name='alice@example.com')})
+    call_next = AsyncMock(return_value=_response(200))
 
     await prometheus_middleware_user.dispatch(request, call_next)
 
@@ -603,15 +790,8 @@ async def test_middleware_records_user_metrics(prometheus_middleware_user):
 async def test_middleware_records_anonymous_user_metrics(
         prometheus_middleware_user):
     """Test that middleware records 'anonymous' for unauthenticated requests."""
-    request = MagicMock(spec=['url', 'method', 'state'])
-    request.url.path = '/api/v1/status'
-    request.method = 'GET'
-    request.state = MagicMock(spec=[])  # No auth_user attribute
-
-    response = MagicMock()
-    response.status_code = 200
-
-    call_next = AsyncMock(return_value=response)
+    request = _http_request('/api/v1/status')  # No auth_user in the state.
+    call_next = AsyncMock(return_value=_response(200))
 
     await prometheus_middleware_user.dispatch(request, call_next)
 
@@ -629,23 +809,23 @@ async def test_middleware_records_anonymous_user_metrics(
 @pytest.mark.asyncio
 async def test_middleware_user_metrics_with_basic_auth(
         prometheus_middleware_user):
-    """E2E test: BasicAuthMiddleware -> PrometheusMiddleware chain records
+    """E2E test: PrometheusMiddleware -> BasicAuthMiddleware chain records
     correct user label for basic auth.
 
-    Verifies that when BasicAuthMiddleware authenticates via Basic auth
-    and sets request.state.auth_user, PrometheusMiddleware records the
-    correct username in per-user metrics.
+    Verifies that when BasicAuthMiddleware (inside the metrics middleware, as
+    in production) authenticates via Basic auth and sets
+    request.state.auth_user, PrometheusMiddleware records the correct
+    username in per-user metrics.
     """
     # Create request with Basic Auth header (bob:secret)
-    request = MagicMock(spec=['url', 'method', 'headers', 'state'])
-    request.url = MagicMock()
-    request.url.path = '/api/v1/clusters'
-    request.method = 'POST'
-    request.headers = {
-        'authorization': 'Basic ' + base64.b64encode(b'bob:secret').decode(),
-    }
-    request.state = MagicMock()
-    request.state.auth_user = None  # As InitializeRequestAuthUserMiddleware
+    request = _http_request(
+        '/api/v1/clusters',
+        'POST',
+        headers={
+            'authorization': 'Basic ' +
+                             base64.b64encode(b'bob:secret').decode(),
+        },
+        state={'auth_user': None})  # As InitializeRequestAuthUserMiddleware
 
     # Final handler returning success
     async def final_handler(_req):
@@ -653,9 +833,9 @@ async def test_middleware_user_metrics_with_basic_auth(
 
     basic_auth_middleware = BasicAuthMiddleware(app=MagicMock())
 
-    # Chain: BasicAuth -> Prometheus -> final_handler
-    async def prometheus_call_next(req):
-        return await prometheus_middleware_user.dispatch(req, final_handler)
+    # Chain: Prometheus -> BasicAuth -> final_handler
+    async def basic_auth_call_next(req):
+        return await basic_auth_middleware.dispatch(req, final_handler)
 
     mock_user = MagicMock()
     mock_user.name = 'bob'
@@ -668,8 +848,8 @@ async def test_middleware_user_metrics_with_basic_auth(
                return_value=False), \
          patch('sky.jobs.utils.is_consolidation_mode', return_value=False):
 
-        response = await basic_auth_middleware.dispatch(request,
-                                                        prometheus_call_next)
+        response = await prometheus_middleware_user.dispatch(
+            request, basic_auth_call_next)
 
     assert response.status_code == 200
     # BasicAuth should have set auth_user
@@ -687,21 +867,58 @@ async def test_middleware_user_metrics_with_basic_auth(
 
 
 @pytest.mark.asyncio
+async def test_middleware_user_metrics_with_basic_auth_rejection(
+        prometheus_middleware_user):
+    """A 401 BasicAuthMiddleware answers itself is counted, attributed, and
+    recorded as anonymous."""
+    request = _http_request('/api/v1/clusters',
+                            'POST',
+                            reached_router=False,
+                            state={'auth_user': None})
+
+    basic_auth_middleware = BasicAuthMiddleware(app=MagicMock())
+    final_handler = AsyncMock()
+
+    async def basic_auth_call_next(req):
+        return await basic_auth_middleware.dispatch(req, final_handler)
+
+    with patch('sky.server.auth.loopback.is_loopback_request',
+               return_value=False), \
+         patch('sky.jobs.utils.is_consolidation_mode', return_value=False):
+        response = await prometheus_middleware_user.dispatch(
+            request, basic_auth_call_next)
+
+    assert response.status_code == 401
+    final_handler.assert_not_awaited()
+    assert _get_metric_value(
+        'sky_apiserver_requests_by_user_total', {
+            'user': 'anonymous',
+            'method': 'POST',
+            'status': '4xx'
+        },
+        collectors=[metrics_utils.SKY_APISERVER_REQUESTS_BY_USER_TOTAL]) == 1.0
+    assert _get_metric_value(
+        'sky_apiserver_request_rejections_total', {
+            'reason': middleware_utils.REJECT_REASON_UNAUTHORIZED,
+            'status': '401',
+            'kind': 'http'
+        },
+        collectors=[metrics_utils.SKY_APISERVER_REQUEST_REJECTIONS_TOTAL
+                   ]) == 1.0
+
+
+@pytest.mark.asyncio
 async def test_middleware_records_api_get_duration_by_name(
         prometheus_middleware):
     """/api/get latency is recorded under the request name the handler stamps."""
-    request = MagicMock()
-    request.url.path = '/api/v1/api/get'
-    request.method = 'GET'
-    request.state.auth_user = None
     # The api_get handler stamps request.state.request_name once it knows which
     # request is being fetched.
-    request.state.request_name = 'status'
-
-    response = MagicMock()
-    response.status_code = 200
-
-    call_next = AsyncMock(return_value=response)
+    request = _http_request('/api/v1/api/get',
+                            state={
+                                'auth_user': None,
+                                'request_name': 'status'
+                            })
+    call_next = AsyncMock(return_value=_response(200))
 
     await prometheus_middleware.dispatch(request, call_next)
 
@@ -719,16 +936,8 @@ async def test_middleware_records_api_get_duration_by_name(
 async def test_middleware_no_api_get_duration_without_name(
         prometheus_middleware):
     """No per-name /api/get series is recorded when the name is not stamped."""
-    request = MagicMock(spec=['url', 'method', 'state'])
-    request.url.path = '/api/v1/status'
-    request.method = 'GET'
-    request.state = MagicMock(
-        spec=[])  # No request_name / auth_user attributes.
-
-    response = MagicMock()
-    response.status_code = 200
-
-    call_next = AsyncMock(return_value=response)
+    request = _http_request('/api/v1/status')  # No request_name / auth_user.
+    call_next = AsyncMock(return_value=_response(200))
 
     await prometheus_middleware.dispatch(request, call_next)
 
@@ -750,6 +959,7 @@ def cleanup_metrics():
     metrics_utils.SKY_APISERVER_REQUEST_DURATION_SECONDS.clear()
     metrics_utils.SKY_APISERVER_REQUEST_GET_DURATION_SECONDS.clear()
     metrics_utils.SKY_APISERVER_REQUESTS_BY_USER_TOTAL.clear()
+    metrics_utils.SKY_APISERVER_REQUEST_REJECTIONS_TOTAL.clear()
 
 
 # ─────────────────────────────────────────────────────────────────────────

--- a/tests/unit_tests/test_sky/server/test_middleware_utils.py
+++ b/tests/unit_tests/test_sky/server/test_middleware_utils.py
@@ -404,6 +404,27 @@ def test_record_rejection_is_a_noop_without_a_stamp():
                    kind='http') == 1.0
 
 
+def test_record_rejection_ignores_a_stamp_on_a_success():
+    """A middleware that stamps a reason and then calls `call_next` leaves a
+    stamp on a 2xx/3xx. That is a misuse, not a rejection; the counter must
+    not say `forbidden` about a request that succeeded."""
+    scope = {
+        'state': {
+            'reject_reason': middleware_utils.REJECT_REASON_FORBIDDEN
+        }
+    }
+    for status_code in (200, http.HTTPStatus.CREATED, 307):
+        middleware_utils.record_rejection(scope, status_code,
+                                          middleware_utils.REJECTION_KIND_HTTP)
+    assert _sample(metrics_utils.SKY_APISERVER_REQUEST_REJECTIONS_TOTAL) == 0.0
+    # The same stamp on a refusal is counted.
+    middleware_utils.record_rejection(scope, 403,
+                                      middleware_utils.REJECTION_KIND_HTTP)
+    assert _sample(metrics_utils.SKY_APISERVER_REQUEST_REJECTIONS_TOTAL,
+                   reason='forbidden',
+                   status='403') == 1.0
+
+
 def test_record_rejection_labels_an_http_status_enum_by_number():
     """Responses are often built with `http.HTTPStatus` members; the label
     must be the number, not `HTTPStatus.SERVICE_UNAVAILABLE`."""

--- a/tests/unit_tests/test_sky/server/test_middleware_utils.py
+++ b/tests/unit_tests/test_sky/server/test_middleware_utils.py
@@ -6,6 +6,7 @@ import fastapi
 import pytest
 import starlette.middleware.base
 
+from sky.metrics import utils as metrics_utils
 from sky.server import middleware_utils
 
 
@@ -32,6 +33,15 @@ class RecordingMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
             return fastapi.Response(status_code=http.HTTPStatus.FORBIDDEN)
         if self.behavior == 'error':
             raise RuntimeError('middleware failure')
+        if self.behavior == 'unavailable':
+            # The shape db_lookup's helpers produce: a JSON 503 with a stamped
+            # rejection reason.
+            middleware_utils.mark_rejection(
+                request, middleware_utils.REJECT_REASON_AUTH_DB_TIMEOUT)
+            return fastapi.responses.JSONResponse(
+                status_code=http.HTTPStatus.SERVICE_UNAVAILABLE,
+                headers={'Retry-After': '5'},
+                content={'detail': 'database is slow'})
         return None
 
 
@@ -210,3 +220,201 @@ def test_build_http_scope_converts_scheme():
     assert http_scope['method'] == 'GET'
     assert http_scope['http_version'] == '1.1'
     assert http_scope['state'] is state
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Refused handshakes are counted. What the client receives is unchanged: the
+# close frames asserted above, which ASGI servers render as an empty HTTP 403.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _sample(counter, **labels) -> float:
+    total = 0.0
+    for family in counter.collect():
+        for sample in family.samples:
+            if not sample.name.endswith('_total'):
+                continue
+            if all(sample.labels.get(k) == v for k, v in labels.items()):
+                total += sample.value
+    return total
+
+
+@pytest.fixture(autouse=True)
+def clear_rejection_counters():
+    for counter in (
+            metrics_utils.SKY_APISERVER_WEBSOCKET_HANDSHAKE_REJECTIONS_TOTAL,
+            metrics_utils.SKY_APISERVER_REQUEST_REJECTIONS_TOTAL):
+        counter.clear()
+    yield
+    for counter in (
+            metrics_utils.SKY_APISERVER_WEBSOCKET_HANDSHAKE_REJECTIONS_TOTAL,
+            metrics_utils.SKY_APISERVER_REQUEST_REJECTIONS_TOTAL):
+        counter.clear()
+
+
+async def _run(middleware, scope):
+    sent = []
+
+    async def receive():
+        return {'type': 'websocket.connect'}
+
+    async def send(message):
+        sent.append(message)
+
+    await middleware(scope, receive, send)
+    return sent
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('behavior, outcome, close_frame', [
+    ('unauthorized', 'unauthorized', {
+        'type': 'websocket.close',
+        'code': 4401,
+        'reason': 'Unauthorized',
+    }),
+    ('forbidden', 'forbidden', {
+        'type': 'websocket.close',
+        'code': 4403,
+        'reason': 'Forbidden',
+    }),
+    ('error', 'error', {
+        'type': 'websocket.close',
+        'code': 1011,
+        'reason': 'Internal Server Error',
+    }),
+    ('unavailable', 'error', {
+        'type': 'websocket.close',
+        'code': 1011,
+        'reason': 'Internal Server Error',
+    }),
+])
+async def test_a_refused_handshake_is_counted_and_the_close_frame_is_unchanged(
+        behavior, outcome, close_frame):
+    app_called = False
+
+    async def app(scope, receive, send):
+        del scope, receive, send
+        nonlocal app_called
+        app_called = True
+
+    middleware = _make_middleware(app, behavior=behavior)
+    sent = await _run(middleware,
+                      _make_websocket_scope(path='/kubernetes-pod-ssh-proxy'))
+
+    assert not app_called
+    assert sent == [close_frame]
+    assert _sample(
+        metrics_utils.SKY_APISERVER_WEBSOCKET_HANDSHAKE_REJECTIONS_TOTAL,
+        path='/kubernetes-pod-ssh-proxy',
+        outcome=outcome) == 1.0
+    assert _sample(
+        metrics_utils.SKY_APISERVER_WEBSOCKET_HANDSHAKE_REJECTIONS_TOTAL) == 1.0
+
+
+@pytest.mark.asyncio
+async def test_a_refused_handshake_with_a_stamped_reason_is_attributed():
+    """The auth helpers stamp why they answered 503; the handshake carries
+    it into the rejection counter with the status the middleware produced
+    (the client still sees a 403 close on the wire)."""
+    middleware = _make_middleware(lambda *a: None, behavior='unavailable')
+    await _run(middleware,
+               _make_websocket_scope(path='/kubernetes-pod-ssh-proxy'))
+    assert _sample(metrics_utils.SKY_APISERVER_REQUEST_REJECTIONS_TOTAL,
+                   reason=middleware_utils.REJECT_REASON_AUTH_DB_TIMEOUT,
+                   status='503',
+                   kind='websocket') == 1.0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('behavior', ['unauthorized', 'forbidden', 'error'])
+async def test_a_refused_handshake_without_a_reason_is_not_attributed(behavior):
+    middleware = _make_middleware(lambda *a: None, behavior=behavior)
+    await _run(middleware, _make_websocket_scope())
+    assert _sample(metrics_utils.SKY_APISERVER_REQUEST_REJECTIONS_TOTAL) == 0.0
+
+
+@pytest.mark.asyncio
+async def test_an_accepted_handshake_is_not_counted_as_refused():
+
+    async def app(scope, receive, send):
+        del scope, receive
+        await send({'type': 'websocket.accept'})
+
+    middleware = _make_middleware(app, behavior='accept')
+    sent = await _run(middleware, _make_websocket_scope())
+    assert sent == [{'type': 'websocket.accept'}]
+    assert _sample(
+        metrics_utils.SKY_APISERVER_WEBSOCKET_HANDSHAKE_REJECTIONS_TOTAL) == 0.0
+
+
+@pytest.mark.asyncio
+async def test_handshake_paths_outside_the_websocket_routes_are_bounded():
+    middleware = _make_middleware(lambda *a: None, behavior='forbidden')
+    for i in range(3):
+        await _run(middleware, _make_websocket_scope(path=f'/probe/{i}'))
+    assert _sample(
+        metrics_utils.SKY_APISERVER_WEBSOCKET_HANDSHAKE_REJECTIONS_TOTAL,
+        path=middleware_utils.OTHER_WEBSOCKET_PATH_LABEL,
+        outcome='forbidden') == 3.0
+    assert _sample(
+        metrics_utils.SKY_APISERVER_WEBSOCKET_HANDSHAKE_REJECTIONS_TOTAL,
+        path='/probe/0') == 0.0
+
+
+def test_websocket_path_label():
+    for path in middleware_utils.WEBSOCKET_ROUTE_PATHS:
+        assert middleware_utils.websocket_path_label({'path': path}) == path
+    assert middleware_utils.websocket_path_label({'path': '/x'}) == \
+        middleware_utils.OTHER_WEBSOCKET_PATH_LABEL
+    assert middleware_utils.websocket_path_label({}) == \
+        middleware_utils.OTHER_WEBSOCKET_PATH_LABEL
+
+
+def test_mark_rejection_round_trips_through_the_scope_state():
+    scope = {
+        'type': 'http',
+        'method': 'GET',
+        'path': '/',
+        'headers': [],
+        'state': {}
+    }
+    request = fastapi.Request(scope)
+    assert middleware_utils.get_rejection_reason(scope) is None
+    middleware_utils.mark_rejection(request,
+                                    middleware_utils.REJECT_REASON_FORBIDDEN)
+    assert middleware_utils.get_rejection_reason(scope) == \
+        middleware_utils.REJECT_REASON_FORBIDDEN
+    assert request.state.reject_reason == \
+        middleware_utils.REJECT_REASON_FORBIDDEN
+
+
+def test_record_rejection_is_a_noop_without_a_stamp():
+    middleware_utils.record_rejection({'state': {}}, 503,
+                                      middleware_utils.REJECTION_KIND_HTTP)
+    middleware_utils.record_rejection({}, 503,
+                                      middleware_utils.REJECTION_KIND_HTTP)
+    assert _sample(metrics_utils.SKY_APISERVER_REQUEST_REJECTIONS_TOTAL) == 0.0
+    middleware_utils.record_rejection(
+        {'state': {
+            'reject_reason': middleware_utils.REJECT_REASON_FORBIDDEN
+        }}, 403, middleware_utils.REJECTION_KIND_HTTP)
+    assert _sample(metrics_utils.SKY_APISERVER_REQUEST_REJECTIONS_TOTAL,
+                   reason='forbidden',
+                   status='403',
+                   kind='http') == 1.0
+
+
+def test_record_rejection_labels_an_http_status_enum_by_number():
+    """Responses are often built with `http.HTTPStatus` members; the label
+    must be the number, not `HTTPStatus.SERVICE_UNAVAILABLE`."""
+    middleware_utils.record_rejection(
+        {
+            'state': {
+                'reject_reason': middleware_utils.REJECT_REASON_AUTH_DB_TIMEOUT
+            }
+        }, http.HTTPStatus.SERVICE_UNAVAILABLE,
+        middleware_utils.REJECTION_KIND_WEBSOCKET)
+    assert _sample(metrics_utils.SKY_APISERVER_REQUEST_REJECTIONS_TOTAL,
+                   reason='auth_db_timeout',
+                   status='503',
+                   kind='websocket') == 1.0


### PR DESCRIPTION
## Problem

Responses produced by a middleware were invisible to the request metrics. In a production deployment, an authentication-path failure answered every request with a 503 for about 45 minutes; `sky_apiserver_requests_total` showed only successful requests *dropping*, no 5xx series moved, and no error-ratio alert had a numerator to fire on. Refused WebSocket handshakes (the ssh path) were not counted anywhere.

Cause: `PrometheusMiddleware` was the first middleware added, i.e. the innermost. Every response an outer middleware returns without calling the next layer never reached it: the 503s the authentication middlewares answer when the auth thread executor is saturated or the auth DB deadline elapses, 401s, RBAC 403s, drain 503s, API-version 400s, plugin middlewares. Only failures raised inside a route handler were counted.

This is the small, observational half of the fix. A follow-up PR (stacked on this one) changes the metrics layer itself and what WebSocket clients receive; this PR deliberately does neither.

## Change

**No client-visible change.** Every response body, status code, header and WebSocket close code is exactly what it was. Only what gets counted changes.

1. **The existing `PrometheusMiddleware` is registered last, i.e. outermost**, after the core stack and after plugin loading, still gated by `SKY_API_SERVER_METRICS_ENABLED`. It is the same `BaseHTTPMiddleware` class; it now sees the response the client actually receives, so middleware-emitted 4xx/5xx land in `sky_apiserver_requests_total` / `sky_apiserver_requests_by_user_total` / the duration histogram under the existing metric names and label semantics.
2. **New counter `sky_apiserver_request_rejections_total{reason,status,kind}`** saying *why* a middleware rejected a request. `reason` is a closed set stamped on `request.state` by the code producing the response (`middleware_utils.mark_rejection`): the four `db_lookup` 503 helpers (`auth_worker_exhausted`, `auth_db_timeout`, `role_seed_unavailable`, `jwt_secret_unavailable`), the basic/bearer 401 helpers (`unauthorized`), the RBAC 403 and the dashboard path-traversal 403 (`forbidden`), the drain 503 (`shutting_down`), the version-mismatch 400 (`api_version`), the oauth2-proxy answers, split by cause: could not reach it (`auth_proxy_unavailable`) versus reached it and the answer was unusable -- authenticated with no user info, or a status this server cannot act on (`auth_proxy_bad_response`) and the app-level exhaustion handler's 503 (`request_worker_exhausted`). `status` is the status the middleware answered with; `kind` is `http` or `websocket`. No path label on purpose. A stamp on a response that is not an error (a middleware that marks a reason and then lets the request through) is ignored, so the counter can never disagree with the status the client saw.
3. **New counter `sky_apiserver_websocket_handshake_rejections_total{path,outcome}`**, incremented inside `middleware_utils.websocket_aware` when it refuses a handshake. `outcome` is the existing decision set (`unauthorized` / `forbidden` / `error`, i.e. the 4401 / 4403 / 1011 close codes); `path` is one of the registered WebSocket routes or `other`. Only the outermost refusing middleware runs, so each refused handshake is counted once. If the refusing middleware stamped a reason, the rejection counter also gets `{kind="websocket"}` with the status the middleware produced.
4. The `db_lookup` response helpers take the request as an **optional** argument and stamp the reason only when given, so callers outside this repository that call them with no arguments keep getting the same 503.

### `path` label of `sky_apiserver_requests_total` (please read)

Raw-path semantics are kept: the path is read after the inner layers ran (the scope dict is shared down the stack), so a request that reached the router is recorded under the same path as before, including the internal-dashboard prefix rewrite and 404s. No route templates.

Rejected requests are new to the counter, and their paths are chosen by unauthenticated clients (scanners probe `/wp-admin`, `/.env`, ...), so for a response produced by a middleware (the request never reached the router, detected via Starlette's `scope['router']` stamp) the label is bounded:

- the raw path if it is exactly a parameterless route on the app's own route table (so `/status` or `/api/get` rejections share a series with their successes). `include_router` expands each sub-route onto the table with its prefix applied, so the core and plugin routers' own routes are on it too -- `/jobs/queue` and `/users/update` keep their exact label;
- otherwise one of a fixed set of known prefixes, recorded as `<prefix>*` (`/api/*`, `/dashboard/*`, `/internal/dashboard/*`, `/plugins/*`, `/jobs/*`, `/serve/*`, `/users/*`, `/workspaces/*`, `/volumes/*`, `/ssh_node_pools/*`, `/recipes/*`, `/storage/*`, `/debug/*`; a router's bare root such as `/users` folds into the same bucket) - the `*` form keeps the prefix regexes existing dashboards and rules use (`/api/.*`, `/dashboard/.*`) matching;
- otherwise `other`.

Verified against the real app: 132 routes, of which 126 are parameterless and keep their exact path (121 distinct label values -- some paths appear under two methods); 13 prefix buckets plus `other` cover the rest. `PrometheusMiddleware` is `user_middleware[0]` exactly once.

Smaller semantic consequences of counting at the edge (for 2xx responses produced by a route handler nothing changes: the count is 1:1 with the same `path`, `method` and `user`):

- A request that ends in a `BaseException` rather than a response -- the cancellation a client disconnect produces -- records `status="0xx"`, where it recorded the empty string before. Nothing sets a status on that path; counting it beats dropping a real request, and a test pins the bucket.
- `sky_apiserver_request_duration_seconds` now includes the time the authentication middlewares spend (it is the latency the client observed; P95 panels may shift slightly, and during an auth outage the fast 503s pull the P95 of the affected paths down).
- Rejected requests are recorded with `user="anonymous"`.
- Responses that a middleware serves itself and that never reached the innermost layer before are now counted too, not only failures: CORS preflights (`OPTIONS` answered by `CORSMiddleware`, e.g. `{method="OPTIONS", path="/api/health", status="2xx"}`; browser cross-origin use only) and the sign-in redirects of the OAuth2-proxy middleware (`status="3xx"`). Both appear as new series with `user="anonymous"`; neither was measurable before because it was never counted. Verified on the real app.

### Known gaps and follow-ups

- **Existing alert rules see drain 503s now.** A draining worker answers
  every non-`/api/` request with a 503, which this PR makes visible for the
  first time. `APIServerRequestErrorCatched` (`> 1` over 5m, `for: 1m`)
  would post on every rolling restart, and `APIServerErrorRateHigh` sits on
  its threshold; the `.js` and sandbox/devspaces path exclusions do not
  cover the buckets a middleware-produced response is recorded under.
  Handled in a companion rules change (assemble-org/prototype#2058), which
  gates both rules on `reason="shutting_down"` per pod and is safe to merge
  in either order.
- **`reason` is incomplete on hosted deployments.** The plugin's session and
  RBAC middlewares are what authenticate requests there, and they call the
  `db_lookup` response helpers without a request, so their 503s reach
  `sky_apiserver_requests_total` (the main win) with nothing in
  `sky_apiserver_request_rejections_total`. A plugin change passing the
  request at those call sites follows separately; the request counter is
  unaffected either way.
- `_basic_auth_401_response` / `_bearer_auth_401_response` took a *required*
  request, unlike the deliberately optional `db_lookup` helpers, because
  they are module-private with no callers outside this file. The
  `db_lookup` helpers are called bare from out-of-tree middlewares, where a
  required argument would raise inside a middleware and reach the client as
  a bare 500 on exactly the failure path they exist for.

## Tests

- `tests/unit_tests/test_sky/server/test_edge_error_counting.py` (new): the real `AuthProxyMiddleware`, `InitializeRequestAuthUserMiddleware` and `PrometheusMiddleware` in production order on a FastAPI app, with the auth DB call stubbed to raise `ConcurrentWorkerExhaustedError` / `asyncio.TimeoutError`: the client gets the same 503 (body, `Retry-After`) and it is now counted as a 5xx on `/status` with its reason; the same app with the previous order counts nothing (why the order matters); a refused WebSocket handshake still reaches the client as the 1011 close and is counted; scanner paths fold into `other`, `/api/...` into `/api/*`; a 404 from the router keeps its raw path; a middleware calling the 503 helpers with no arguments still answers 503; the app-level exhaustion handler's 503 is attributed to `request_worker_exhausted`; a subprocess imports the real `sky.server.server.app` with metrics enabled and asserts `PrometheusMiddleware` is outermost and present once.
- `test_metrics.py`: the middleware tests now drive real `fastapi.Request` objects; new cases for the path read after an inner rewrite, the bucketing table, the router-reached detection, and the stamped-rejection counter.
- `test_middleware_utils.py`: each refused handshake decision is counted and its close frame is byte-for-byte unchanged; stamped reasons are attributed with `kind="websocket"`; a stamped reason on a non-error response is not counted; accepted handshakes are not counted; paths outside the WebSocket routes fold into `other`.
- `test_auth_db_deadline.py`: the helpers stamp their reason; the no-argument and original-positional signatures still work.
- The recording path never reaches a client: a fault at each of the four counter call sites leaves the response byte-for-byte identical to a healthy run (status, body, headers) for a 200 and for a middleware 503; a broken path resolver still counts the request, under `other`; an application exception still propagates as a 500 and is counted as one; the failure log is rate-limited (logs once, counts the rest, reports how many it dropped).
- The ordering check: `warn_unless_outermost` on the production order, on an installed-but-displaced layer (inserted the way the plugin API does, bypassing `add_middleware`), and on an app without the layer at all; and `test_the_call_site_is_not_gated_by_an_env_var`, which patches the guard, imports the real server module in a fresh process and asserts one call — this is the test that guards the check, since any gate on the metrics variable is false in a test environment and so fails it.
- `status="0xx"` on a cancellation, pinned rather than left to `_get_status_code_group(0)`; and both oauth2-proxy failure axes assert their distinct reasons through the real middleware.
- `pre-commit run --files <changed files>`: isort, mypy, yapf and pylint clean.
- Mutation-checked, each applied alone: the metrics layer moved back innermost; `record_safely` removed; the path-label fallback removed; the ordering guard forced to pass; the guard's call site gated by either env-var spelling; the rate limiter's suppression disabled; the application exception swallowed; the two oauth2-proxy reasons collapsed; registered routes bucketed. Each breaks at least one test.

## Review status

Reviewed repeatedly, and the head has moved since: the early passes were on
`63ef2d15b`, before the reason set was completed, the route-table claim was
corrected, the recording path was made fail-open and the ordering check was
added. Findings that reached this branch since then, and where they went:

- the drain-503 effect on existing alert rules -> the companion rules change
  above (this one is a real behaviour change for on-call, and worth a look
  from whoever owns those rules);
- the wrong `include_router` claim, which a unit-test case had encoded ->
  fixed here, in the docstrings and the case;
- the ordering check being gated by a predicate the registration does not
  use, and then shipping without a revert-check -> fixed, and the call site
  is now pinned by a test;
- `auth_proxy_unavailable` covering two different failures -> split;
- `reason` being incomplete on hosted deployments -> the plugin change
  above.

What has been verified on a real server: no byte a client receives changes,
over HTTP and WebSocket, with current and older clients. What has not: the
ordering invariant with plugins loaded, and a middleware 503 reaching
`/metrics` on a live server. Both are planned separately; the unit tests
cover the logic, not the deployment.

Related: #10688 (the stacked follow-up), #10681

-Claude

