### PR TITLE
[Jobs] Explain why a managed job has not started, and let a runner say more

### DIFF
--- a/agent/skills/skypilot/SKILL.md
+++ b/agent/skills/skypilot/SKILL.md
@@ -438,11 +438,10 @@ When using SkyPilot programmatically, follow this loop:
 When the user asks "what is my job doing" or "why is it pending/failing", run
 these in order and stop as soon as the question is answered:
 
-1. `sky jobs queue -v -o json` — read `status`, `details`, `failure_reason` (`-v` adds the `details` field)
-2. `sky jobs queue -v -o json` — `details` says why the cluster is still pending (e.g. a Slurm `QOSGrpGRES` or `Dependency` reason, with the partition it is queued in)
-3. `sky jobs logs JOB_ID --tail 100 --no-follow` — recent task output; `--controller` for provisioning/recovery logs
+1. `sky jobs queue -v -o json` — `status`, `details`, `failure_reason` (`-v` is what adds `details`). For a job that has not started, `details` is the answer: it says what the cluster is waiting on, e.g. a Slurm `QOSGrpGRES` or `Dependency` reason with the partition it is queued in
+2. `sky jobs logs JOB_ID --tail 100 --no-follow` — recent task output; `--controller` for provisioning/recovery logs
 
-See [Job Investigation](references/job-investigation.md) for how to read `details`, the event timeline, and Slurm pending reasons.
+See [Job Investigation](references/job-investigation.md) for how to read `details` and the Slurm pending reasons.
 
 ## Common Agent Mistakes
 

--- a/agent/skills/skypilot/SKILL.md
+++ b/agent/skills/skypilot/SKILL.md
@@ -433,6 +433,17 @@ When using SkyPilot programmatically, follow this loop:
 
 > **Never poll with `sleep` + `sky queue`** — use `sky logs CLUSTER JOB_ID` to stream logs and block until done. Use `--status` if you only need the exit code, or `--tail N` to fetch recent output after completion.
 
+## Investigating a Managed Job
+
+When the user asks "what is my job doing" or "why is it pending/failing", run
+these in order and stop as soon as the question is answered:
+
+1. `sky jobs queue -v -o json` — read `status`, `details`, `failure_reason` (`-v` adds the `details` field)
+2. `sky jobs queue -v -o json` — `details` says why the cluster is still pending (e.g. a Slurm `QOSGrpGRES` or `Dependency` reason, with the partition it is queued in)
+3. `sky jobs logs JOB_ID --tail 100 --no-follow` — recent task output; `--controller` for provisioning/recovery logs
+
+See [Job Investigation](references/job-investigation.md) for how to read `details`, the event timeline, and Slurm pending reasons.
+
 ## Common Agent Mistakes
 
 | Mistake | Why it's wrong | Do this instead |
@@ -471,5 +482,6 @@ For detailed reference documentation:
 - [Python SDK](references/python-sdk.md) — Programmatic API and SDK usage
 - [Advanced Patterns](references/advanced-patterns.md) — Multi-cloud, distributed training, production patterns
 - [Migrating from Slurm](references/migrating-from-slurm.md) — Converting `sbatch` scripts to task YAMLs, Slurm command/env-var mapping, Slurm-specific constraints
+- [Job Investigation](references/job-investigation.md) — Which command answers "what is my job doing and why"; reading `details`, events, Slurm pending reasons
 - [Troubleshooting](references/troubleshooting.md) — Error diagnosis and solutions
 - [Examples](references/examples.md) — Copy-paste task YAML examples

--- a/agent/skills/skypilot/evals/evals.json
+++ b/agent/skills/skypilot/evals/evals.json
@@ -1,6 +1,6 @@
 {
   "skill_name": "skypilot",
-  "description": "Evaluates the 'Before You Start (Agent Bootstrap)' and 'Converting a Slurm Workload' section behavior",
+  "description": "Evaluates the 'Before You Start (Agent Bootstrap)', 'Converting a Slurm Workload' and 'Investigating a Managed Job' section behavior",
   "evals": [
     {
       "id": 1,
@@ -127,6 +127,54 @@
         {
           "text": "Agent does NOT propose a shell for-loop as the primary answer",
           "type": "negative"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "name": "why-is-my-managed-job-pending",
+      "prompt": "My managed job 42 has been PENDING for 20 minutes on our Slurm cluster. Why? SkyPilot is already set up.",
+      "expected_output": "Agent reads `details` from `sky jobs queue -v -o json` and finds the Slurm pending reason with its partition (e.g. `Launching (pending: QOSGrpGRES; partition: h200)`), explains that category (quota vs no free capacity vs dependency vs held) and what to do about it. Does not claim the job is stuck in SkyPilot's own queue when the reason is Slurm's.",
+      "assertions": [
+        {
+          "text": "Agent runs `sky jobs queue -v -o json` (`-v` is required for the `details` field) and reads the job's details",
+          "type": "required_action"
+        },
+        {
+          "text": "Agent reads the Slurm pending reason and its partition from `details`",
+          "type": "required_action"
+        },
+        {
+          "text": "Agent explains the pending reason in plain terms (quota, capacity, dependency, or held) with a next step",
+          "type": "required_action"
+        },
+        {
+          "text": "Agent does NOT poll with `sleep` + `sky jobs queue`",
+          "type": "negative"
+        },
+        {
+          "text": "Agent does NOT tear down the jobs controller as a first step",
+          "type": "negative"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "name": "what-happened-to-my-job",
+      "prompt": "Managed job 17 keeps flipping between RUNNING and RECOVERING. Show me what happened.",
+      "expected_output": "Agent reads `sky jobs queue -v -o json` for `details` / `failure_reason` / `recovery_count`, then pulls `sky jobs logs 17 --controller --no-follow` for the recovery history, and points out that a repeated identical reason means a persistent cause the controller cannot fix by retrying.",
+      "assertions": [
+        {
+          "text": "Agent reads `details`, `failure_reason` and `recovery_count` from `sky jobs queue -v -o json`",
+          "type": "required_action"
+        },
+        {
+          "text": "Agent identifies the recurring RECOVERING reason from the events",
+          "type": "required_action"
+        },
+        {
+          "text": "Agent uses `--tail` or `--no-follow` when fetching logs rather than streaming the full log",
+          "type": "required_action"
         }
       ]
     }

--- a/agent/skills/skypilot/references/job-investigation.md
+++ b/agent/skills/skypilot/references/job-investigation.md
@@ -37,7 +37,7 @@ current state. Common shapes:
 | `Failure: <reason>` | Terminal failure | Read the reason; `sky jobs logs N --no-follow` for the task output |
 | `Cancellation requested by ...` | Someone cancelled it | The requester and request ID are in the text |
 | `Launching (pending: <reason>; partition: <p>)` | Job is STARTING and Slurm has not allocated nodes yet | See "Slurm pending reasons" below |
-| `Launching (Slurm job <id> on <cluster>)` | Nodes are allocated; the job is still bootstrapping | Nothing to fix. That id is what `sacct -j <id>` takes if you have login-node access |
+| `Launching (nodes allocated; Slurm job <id> on <cluster>)` | The queue wait is over; the job is still bootstrapping | Nothing to fix. That id is what `sacct -j <id>` takes if you have login-node access |
 
 ## Slurm pending reasons
 

--- a/agent/skills/skypilot/references/job-investigation.md
+++ b/agent/skills/skypilot/references/job-investigation.md
@@ -37,6 +37,7 @@ current state. Common shapes:
 | `Failure: <reason>` | Terminal failure | Read the reason; `sky jobs logs N --no-follow` for the task output |
 | `Cancellation requested by ...` | Someone cancelled it | The requester and request ID are in the text |
 | `Launching (pending: <reason>; partition: <p>)` | Job is STARTING and Slurm has not allocated nodes yet | See "Slurm pending reasons" below |
+| `Launching (Slurm job <id> on <cluster>)` | Nodes are allocated; the job is still bootstrapping | Nothing to fix. That id is what `sacct -j <id>` takes if you have login-node access |
 
 ## Slurm pending reasons
 

--- a/agent/skills/skypilot/references/job-investigation.md
+++ b/agent/skills/skypilot/references/job-investigation.md
@@ -1,0 +1,68 @@
+# Investigating a Managed Job
+
+How to answer "what is my job doing and why" with as few commands as
+possible. Every command here supports `-o json`; prefer it over parsing
+table output.
+
+## Which command answers which question
+
+| Question | Command | Look at |
+|----------|---------|---------|
+| What state is job N in, and why? | `sky jobs queue -v -o json` | `status`, `details`, `failure_reason`, `schedule_state`, `recovery_count` |
+| Why is job N still provisioning / pending on the cluster? | `sky jobs queue -v -o json` | `details`, when it starts with `Launching (` |
+| How long has job N been at this? | `sky jobs queue -v -o json` | `submitted_at`, and the duration columns in the table |
+| What did job N print recently? | `sky jobs logs N --tail 100 --no-follow` | stdout/stderr of the task |
+| What did the controller do (provision, recover, retry)? | `sky jobs logs N --controller --no-follow` | controller log |
+| Wait until job N finishes | `sky jobs logs N` (blocks) | exit when the job ends |
+
+Do not poll with `sleep` + `sky jobs queue`. Stream logs to block, or
+fetch `--tail` once after the fact.
+
+`details` is the current explanation, not a history. For the sequence of
+transitions a job went through — and, on Slurm, how long the allocation
+waited and on what — the timeline lives behind the `jobs.events` API and is
+surfaced by the enterprise client.
+
+## Reading `details`
+
+`details` in `sky jobs queue -v -o json` is the one-line explanation of the
+current state. Common shapes:
+
+| `details` | Meaning | Next step |
+|-----------|---------|-----------|
+| `Waiting for other jobs to launch` | Controller is at its concurrent-launch limit | Nothing to fix; the duration columns say how long it has waited |
+| `Waiting for higher priority jobs to launch` | A higher-priority managed job is ahead | Raise `priority` in the task YAML if this job matters more |
+| `In backoff, waiting for resources` | Provisioning failed and is retrying | `sky jobs logs N --controller --no-follow` shows the last failure |
+| `Recovering: <reason>` | Cluster was lost or the task crashed (e.g. OOMKilled) | Fix the cause; recovery is automatic |
+| `Failure: <reason>` | Terminal failure | Read the reason; `sky jobs logs N --no-follow` for the task output |
+| `Cancellation requested by ...` | Someone cancelled it | The requester and request ID are in the text |
+| `Launching (pending: <reason>; partition: <p>)` | Job is STARTING and Slurm has not allocated nodes yet | See "Slurm pending reasons" below |
+
+## Slurm pending reasons
+
+While a managed job's Slurm allocation is queued, `details` carries the
+`squeue` reason and the partition it is queued in — the partition matters
+because the same reason means different things in different partitions, and
+by the time anyone looks the allocation may be gone. The common codes:
+
+| Reason | Category | What to do |
+|--------|----------|------------|
+| `Resources`, `Priority`, `ReqNodeNotAvail` | No free capacity in the partition | Wait, or resubmit to another partition via `config.slurm` |
+| `QOSGrpGRES`, `QOSMax*`, `AssocGrp*` | A QoS / account quota is full | Wait for the group's jobs to finish, or use a different QoS/partition |
+| `Dependency`, `DependencyNeverSatisfied` | Waiting on another Slurm job; `NeverSatisfied` will pend forever | Check the dependency job; cancel and resubmit if it failed |
+| `JobHeldUser`, `JobHeldAdmin`, `launch failed requeued held` | Job is held | Ask the admin to `scontrol release`, or cancel and relaunch |
+| `BeginTime` | Scheduled start time not reached | Nothing to fix |
+
+The reason is recorded each time it changes, so a job that moved from
+`Resources` to `Priority` and back leaves all three behind it — `details`
+shows only the latest.
+
+## Recognising a stuck job
+
+- Repeated `Recovering: <same reason>` means a persistent problem (bad node,
+  OOM, quota). The controller keeps retrying and will not fix it; read
+  `sky jobs logs N --controller --no-follow`.
+- A long gap between STARTING and RUNNING is provisioning time. On Slurm
+  that is queue time, and `details` says what the queue is waiting on.
+- `failure_reason` distinguishes the user's program failing from an
+  infrastructure failure; do not report the latter as a code bug.

--- a/agent/skills/skypilot/references/troubleshooting.md
+++ b/agent/skills/skypilot/references/troubleshooting.md
@@ -704,22 +704,25 @@ file_mounts:
 
 ### Job stuck in PENDING
 
-**Symptom**: `sky jobs queue` shows a job stuck in PENDING.
+**Symptom**: `sky jobs queue` shows a job stuck in PENDING or STARTING.
 
-**Causes**:
-- The jobs controller is still being provisioned. The first managed job launch creates a controller VM.
-- Insufficient quota for both the controller and the job's requested resources.
+**Diagnose first**: read `details` and `schedule_state` from
+`sky jobs queue -v -o json` (`-v` adds those fields).
 
-**Solutions**:
+| `details` / evidence | Cause | Solution |
+|----------------------|-------|----------|
+| `Waiting for other jobs to launch` | Controller launch-concurrency limit | Nothing to fix; it will start when a slot frees |
+| `Waiting for higher priority jobs to launch` | Higher-priority jobs are ahead | Raise `priority` in the task YAML if needed |
+| `In backoff, waiting for resources` | Provisioning keeps failing | `sky jobs logs <job_id> --controller --no-follow` shows the last error |
+| STARTING with no cluster events, first job ever | Jobs controller itself is being provisioned | Wait; `sky status -o json` shows the controller cluster |
+| `Launching (pending: <reason>; partition: <p>)` in `details` | Slurm has not allocated nodes (quota, capacity, dependency, held) | See [Job Investigation](job-investigation.md#slurm-pending-reasons) |
 
 ```bash
-# Check controller status
-sky status -o json
+sky jobs queue -v -o json
+sky jobs queue -v -o json
+sky jobs logs <job_id> --controller --no-follow
 
-# View controller provisioning logs
-sky jobs logs --controller <job_id>
-
-# If controller is stuck, tear it down and retry
+# Only if the controller itself is wedged (status INIT for a long time):
 sky down sky-jobs-controller-<user_hash> -p -y
 sky jobs launch myjob.yaml
 ```

--- a/sky/dashboard/src/data/connectors/constants.jsx
+++ b/sky/dashboard/src/data/connectors/constants.jsx
@@ -56,7 +56,7 @@ export const WS_API_URL = API_URL.replace(/^http/, 'ws');
 // upgrade then still reports its own build's version, not the new server's, so
 // it can't over-report support for wire formats its code doesn't handle.
 // Enforced by tests/unit_tests/test_api_version_consistency.py.
-export const CLIENT_API_VERSION = '58';
+export const CLIENT_API_VERSION = '59';
 // Header names expected by the server's APIVersionMiddleware. Mirrors
 // sky/server/constants.py:API_VERSION_HEADER / VERSION_HEADER.
 // The middleware (versions._check_version_compatibility) requires BOTH

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -1409,6 +1409,53 @@ def get_cluster_events(
 
 
 @db_retries.retry
+def get_latest_cluster_events(
+    cluster_names: List[str],
+    event_types: List[ClusterEventType],
+) -> Dict[str, Tuple[str, int]]:
+    """{cluster_name: (reason, transitioned_at)} of the newest matching event.
+
+    Looks up by the persisted ``name`` column (like get_cluster_events_by_name)
+    in a single query, so callers can annotate many clusters without a
+    per-cluster round trip. Clusters with no matching event are omitted; the
+    timestamp lets a caller ignore events left by an earlier attempt on a
+    reused cluster name.
+    """
+    if not cluster_names or not event_types:
+        return {}
+    engine = _db_manager.get_engine()
+    type_values = [event_type.value for event_type in event_types]
+    with orm.Session(engine) as session:
+        # Latest transitioned_at per cluster in SQL, so the read does not
+        # grow with a cluster's event history.
+        latest = session.query(
+            cluster_event_table.c.name.label('name'),
+            sqlalchemy.func.max(
+                cluster_event_table.c.transitioned_at).label('latest_at'),
+        ).filter(
+            cluster_event_table.c.name.in_(cluster_names),
+            cluster_event_table.c.type.in_(type_values),
+        ).group_by(cluster_event_table.c.name).subquery()
+        rows = session.query(
+            cluster_event_table.c.name,
+            cluster_event_table.c.reason,
+            cluster_event_table.c.transitioned_at,
+        ).join(
+            latest,
+            sqlalchemy.and_(
+                cluster_event_table.c.name == latest.c.name,
+                cluster_event_table.c.transitioned_at == latest.c.latest_at,
+            ),
+        ).filter(cluster_event_table.c.type.in_(type_values)).all()
+    events: Dict[str, Tuple[str, int]] = {}
+    for name, reason, transitioned_at in rows:
+        # Two events in the same second: keep the first non-empty reason.
+        if name not in events and reason:
+            events[name] = (reason, transitioned_at)
+    return events
+
+
+@db_retries.retry
 def get_cluster_events_by_name(
     cluster_name: str,
     event_types: List[ClusterEventType],

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -289,6 +289,12 @@ cluster_event_table = sqlalchemy.Table(
     sqlalchemy.Column('transitioned_at', sqlalchemy.Integer, primary_key=True),
     sqlalchemy.Column('type', sqlalchemy.Text),
     sqlalchemy.Column('request_id', sqlalchemy.Text, server_default=None),
+    # The primary key is (cluster_hash, reason, transitioned_at), but the two
+    # readers that have to survive a cluster's teardown look events up by
+    # `name` instead -- see get_latest_cluster_events and
+    # get_cluster_events_by_name. Without this they scan the whole table.
+    sqlalchemy.Index('ix_cluster_events_name_type', 'name', 'type',
+                     'transitioned_at'),
 )
 
 ssh_key_table = sqlalchemy.Table(

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -1431,33 +1431,51 @@ def get_latest_cluster_events(
         return {}
     engine = _db_manager.get_engine()
     type_values = [event_type.value for event_type in event_types]
-    with orm.Session(engine) as session:
-        # Latest transitioned_at per cluster in SQL, so the read does not
-        # grow with a cluster's event history.
-        latest = session.query(
-            cluster_event_table.c.name.label('name'),
-            sqlalchemy.func.max(
-                cluster_event_table.c.transitioned_at).label('latest_at'),
-        ).filter(
-            cluster_event_table.c.name.in_(cluster_names),
-            cluster_event_table.c.type.in_(type_values),
-        ).group_by(cluster_event_table.c.name).subquery()
-        rows = session.query(
-            cluster_event_table.c.name,
-            cluster_event_table.c.reason,
-            cluster_event_table.c.transitioned_at,
-        ).join(
-            latest,
-            sqlalchemy.and_(
-                cluster_event_table.c.name == latest.c.name,
-                cluster_event_table.c.transitioned_at == latest.c.latest_at,
-            ),
-        ).filter(cluster_event_table.c.type.in_(type_values)).all()
     events: Dict[str, Tuple[str, int]] = {}
-    for name, reason, transitioned_at in rows:
-        # Two events in the same second: keep the first non-empty reason.
-        if name not in events and reason:
-            events[name] = (reason, transitioned_at)
+    names_list = list(cluster_names)
+    with orm.Session(engine) as session:
+        # Chunked for the same reason as every other name/hash IN query in
+        # this module: SQLite caps a statement at 999 bound parameters, and a
+        # deployment with that many clusters provisioning at once would
+        # otherwise raise -- which the caller swallows, so *every* cluster
+        # would lose its launch reason rather than the excess.
+        for offset in range(0, len(names_list), _CLUSTER_IN_QUERY_CHUNK_SIZE):
+            batch = names_list[offset:offset + _CLUSTER_IN_QUERY_CHUNK_SIZE]
+            # Latest transitioned_at per cluster in SQL, so the read does not
+            # grow with a cluster's event history.
+            latest = session.query(
+                cluster_event_table.c.name.label('name'),
+                sqlalchemy.func.max(
+                    cluster_event_table.c.transitioned_at).label('latest_at'),
+            ).filter(
+                cluster_event_table.c.name.in_(batch),
+                cluster_event_table.c.type.in_(type_values),
+            ).group_by(cluster_event_table.c.name).subquery()
+            rows = session.query(
+                cluster_event_table.c.name,
+                cluster_event_table.c.reason,
+                cluster_event_table.c.transitioned_at,
+            ).join(
+                latest,
+                sqlalchemy.and_(
+                    cluster_event_table.c.name == latest.c.name,
+                    cluster_event_table.c.transitioned_at == latest.c.latest_at,
+                ),
+            ).filter(cluster_event_table.c.type.in_(type_values)).order_by(
+                cluster_event_table.c.transitioned_at.desc(),
+                # transitioned_at is whole seconds, and a provisioner can
+                # write two events inside one -- the Slurm one records the
+                # allocation and then polls for a reason. Without a second
+                # key the winner is whatever the database happened to
+                # return. Descending reason breaks the tie deterministically
+                # and, for those two, prefers `Launching (pending: ...)`
+                # over `Launching (Slurm job ...)`, which is the one a
+                # reader is asking for.
+                cluster_event_table.c.reason.desc(),
+            ).all()
+            for name, reason, transitioned_at in rows:
+                if name not in events and reason:
+                    events[name] = (reason, transitioned_at)
     return events
 
 

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -1463,14 +1463,15 @@ def get_latest_cluster_events(
                 ),
             ).filter(cluster_event_table.c.type.in_(type_values)).order_by(
                 cluster_event_table.c.transitioned_at.desc(),
-                # transitioned_at is whole seconds, and a provisioner can
-                # write two events inside one -- the Slurm one records the
-                # allocation and then polls for a reason. Without a second
-                # key the winner is whatever the database happened to
-                # return. Descending reason breaks the tie deterministically
-                # and, for those two, prefers `Launching (pending: ...)`
-                # over `Launching (Slurm job ...)`, which is the one a
-                # reader is asking for.
+                # transitioned_at is whole seconds and the table has no
+                # insertion order to fall back on, so a second key is what
+                # makes the answer stable instead of whatever the database
+                # happened to return. Which row of a tied pair it prefers is
+                # arbitrary: text ordering is the database's collation, and
+                # the same two rows sort the other way round under a locale
+                # collation than under SQLite's binary one. No caller may
+                # rely on the direction -- writers whose rows must not be
+                # confused for each other must not share a second.
                 cluster_event_table.c.reason.desc(),
             ).all()
             for name, reason, transitioned_at in rows:

--- a/sky/jobs/runner.py
+++ b/sky/jobs/runner.py
@@ -98,7 +98,15 @@ class ManagedJobRunner(Protocol):
 
         ``include_cluster_events`` merges the underlying cluster's
         launch-progress events into the timeline; ``limit`` caps the merged
-        result, with neither source allowed to crowd out the other entirely.
+        result at exactly that many of the most recent rows.
+
+        Reading state directly rather than asking the controller -- which is
+        what ``queue`` does -- is what the ``/jobs/events`` endpoint has
+        always done, and is left unchanged here: it is the API server's own
+        ``spot_jobs`` and ``global_user_state`` that are read, so the answer
+        is complete wherever the controller shares them (consolidation mode,
+        or a shared database). This seam exists to *add* to that answer, not
+        to move where it comes from.
         """
 
     def tail_managed_job_logs(

--- a/sky/jobs/runner.py
+++ b/sky/jobs/runner.py
@@ -75,6 +75,32 @@ class ManagedJobRunner(Protocol):
     ) -> str:
         ...
 
+    def events(
+        self,
+        *,
+        job_id: int,
+        task_id: Optional[int],
+        task: Optional[Union[str, int]],
+        limit: Optional[int],
+        include_cluster_events: bool,
+    ) -> List[Dict[str, Any]]:
+        """The status-transition timeline of a managed job, newest first.
+
+        Rows are dicts with ``spot_job_id``, ``task_id``, ``new_status``,
+        ``code``, ``reason`` and ``timestamp``.
+
+        Unlike the other methods here this one takes no ``handle`` or
+        ``backend``: the answer comes from the jobs database and from the
+        cluster's own events, and nothing is asked of the controller. The
+        extension point exists so a runner can add what the infrastructure
+        knows about the same job -- on Slurm, what the allocation waited on
+        and for how long -- which the default implementation cannot read.
+
+        ``include_cluster_events`` merges the underlying cluster's
+        launch-progress events into the timeline; ``limit`` caps the merged
+        result, with neither source allowed to crowd out the other entirely.
+        """
+
     def tail_managed_job_logs(
         self,
         *,

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -357,6 +357,21 @@ class _DefaultManagedJobRunner:
                 raise RuntimeError(e.error_msg) from e
         return stdout
 
+    def events(
+        self,
+        *,
+        job_id: int,
+        task_id: Optional[int],
+        task: Optional[Union[str, int]],
+        limit: Optional[int],
+        include_cluster_events: bool,
+    ) -> List[Dict[str, Any]]:
+        return _job_events(job_id=job_id,
+                           task_id=task_id,
+                           task=task,
+                           limit=limit,
+                           include_cluster_events=include_cluster_events)
+
     def tail_managed_job_logs(
         self,
         *,
@@ -1997,6 +2012,31 @@ def get_job_events(
     task_id: Optional[int] = None,
     limit: Optional[int] = 10,
     include_cluster_events: bool = False,
+    task: Optional[Union[str, int]] = None,
+) -> List[Dict[str, Any]]:
+    """Get task events for a managed job.
+
+    Routed through the registered ``ManagedJobRunner`` so a runner can add
+    what the infrastructure knows about the same job -- on Slurm, what the
+    allocation waited on and for how long. The default implementation
+    answers from the jobs database and the cluster's own events; see
+    ``_job_events`` for the arguments and the row shape.
+    """
+    return managed_job_runner.current().events(
+        job_id=job_id,
+        task_id=task_id,
+        task=task,
+        limit=limit,
+        include_cluster_events=include_cluster_events)
+
+
+def _job_events(
+    *,
+    job_id: int,
+    task_id: Optional[int],
+    task: Optional[Union[str, int]],
+    limit: Optional[int],
+    include_cluster_events: bool,
 ) -> List[Dict[str, Any]]:
     """Get task events for a managed job.
 
@@ -2012,6 +2052,7 @@ def get_job_events(
     Returns:
         List of task event records, ordered newest first.
     """
+    del task  # Resolved by a later change; the protocol carries it already.
     events = managed_job_state.get_job_events(job_id=job_id,
                                               task_id=task_id,
                                               limit=limit)

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -1971,8 +1971,9 @@ def pool_sync_down_logs(
                                pool=True)
 
 
-def _get_job_cluster_names(job_id: int,
-                           task_id: Optional[int] = None) -> List[str]:
+def _get_job_clusters(
+        job_id: int,
+        task_id: Optional[int] = None) -> List[Tuple[str, Optional[int]]]:
     """Reconstruct the underlying cluster name(s) for a managed job.
 
     Mirrors the derivation used by the controller (see ``jobs/controller.py``):
@@ -1984,10 +1985,11 @@ def _get_job_cluster_names(job_id: int,
     skipped, since their cluster is shared across jobs and its events are not
     attributable to a single job.
 
-    Returns a de-duplicated list of cluster names (a multi-task pipeline uses
-    one cluster per task).
+    Returns de-duplicated ``(cluster_name, task_id)`` pairs (a multi-task
+    pipeline uses one cluster per task), so a caller merging the clusters'
+    events can attribute each one to the task that owns it.
     """
-    cluster_names: List[str] = []
+    clusters: List[Tuple[str, Optional[int]]] = []
     for task in managed_job_state.get_managed_job_tasks(job_id):
         if task_id is not None and task.get('task_id') != task_id:
             continue
@@ -1999,11 +2001,37 @@ def _get_job_cluster_names(job_id: int,
         task_name = task.get('task_name')
         if not task_name:
             continue
-        cluster_names.append(
-            managed_job_utils.generate_managed_job_cluster_name(
-                task_name, job_id))
+        clusters.append((managed_job_utils.generate_managed_job_cluster_name(
+            task_name, job_id), task.get('task_id')))
     # De-duplicate while preserving order.
-    return list(dict.fromkeys(cluster_names))
+    return list(dict.fromkeys(clusters))
+
+
+def _resolve_task_id(job_id: int, task: Union[str, int]) -> int:
+    """Resolve a task name or id to a task id, the way `sky jobs logs` does.
+
+    An int is taken as the id; a numeric string too, matching the CLI's
+    documented behavior. Raises ValueError when nothing matches, so the
+    caller does not silently get the whole job's events instead.
+    """
+    tasks = managed_job_state.get_managed_job_tasks(job_id)
+    if not tasks:
+        raise ValueError(f'Managed job {job_id} not found.')
+    if isinstance(task, str) and task.isdigit():
+        task = int(task)
+    if isinstance(task, int):
+        if any(t.get('task_id') == task for t in tasks):
+            return task
+        raise ValueError(f'Task {task} not found in managed job {job_id}.')
+    for candidate in tasks:
+        if candidate.get('task_name') == task:
+            task_id = candidate.get('task_id')
+            assert task_id is not None, candidate
+            return task_id
+    names = ', '.join(
+        repr(t.get('task_name')) for t in tasks if t.get('task_name'))
+    raise ValueError(f'Task {task!r} not found in managed job {job_id}. '
+                     f'Tasks: {names}.')
 
 
 @usage_lib.entrypoint
@@ -2043,6 +2071,8 @@ def _job_events(
     Args:
         job_id: The job ID to get task events for.
         task_id: Optional task ID to filter by.
+        task: Optional task name or id to filter by, resolved here. Takes
+            precedence over task_id. A name that matches no task raises.
         limit: Optional limit on number of task events to return (default 10).
         include_cluster_events: When True, merge launch-progress events from
             the job's underlying cluster (e.g. image pulling) into the
@@ -2052,7 +2082,8 @@ def _job_events(
     Returns:
         List of task event records, ordered newest first.
     """
-    del task  # Resolved by a later change; the protocol carries it already.
+    if task is not None:
+        task_id = _resolve_task_id(job_id, task)
     events = managed_job_state.get_job_events(job_id=job_id,
                                               task_id=task_id,
                                               limit=limit)
@@ -2060,7 +2091,7 @@ def _job_events(
         return events
 
     try:
-        cluster_names = _get_job_cluster_names(job_id, task_id)
+        clusters = _get_job_clusters(job_id, task_id)
     except Exception as e:  # pylint: disable=broad-except
         # The merge is best-effort: never fail the job-events request because
         # the cluster name(s) could not be reconstructed.
@@ -2074,13 +2105,14 @@ def _job_events(
         global_user_state.ClusterEventType.STATUS_CHANGE,
         global_user_state.ClusterEventType.LAUNCH_PROGRESS,
     ]
-    cluster_events: List[Dict[str, Any]] = []
-    for cluster_name in cluster_names:
+    # (event, task_id) so each merged row keeps the task it belongs to.
+    cluster_events: List[Tuple[Dict[str, Any], Optional[int]]] = []
+    for cluster_name, cluster_task_id in clusters:
         try:
             cluster_events.extend(
-                global_user_state.get_cluster_events_by_name(cluster_name,
-                                                             event_types,
-                                                             limit=limit))
+                (event, cluster_task_id)
+                for event in global_user_state.get_cluster_events_by_name(
+                    cluster_name, event_types, limit=limit))
         except Exception as e:  # pylint: disable=broad-except
             # Best-effort: skip a cluster whose events cannot be read.
             logger.debug(f'Failed to read cluster events for job {job_id} '
@@ -2093,21 +2125,35 @@ def _job_events(
     # transitioned_at is a UTC epoch, so fromtimestamp(tz=...) yields the
     # correct instant in whichever timezone the job events use.
     tz = events[0]['timestamp'].tzinfo if events else None
-    for cluster_event in cluster_events:
-        events.append({
+    converted = [
+        {
             'spot_job_id': job_id,
-            'task_id': None,
+            'task_id': cluster_task_id,
             # These happen while the job is launching its cluster.
             'new_status': managed_job_state.ManagedJobStatus.STARTING,
             'code': None,
             'reason': cluster_event['reason'],
             'timestamp': datetime.datetime.fromtimestamp(
                 cluster_event['transitioned_at'], tz=tz),
-        })
+        } for cluster_event, cluster_task_id in cluster_events
+    ]
 
     # Every event's 'timestamp' is a datetime (job events from the DB, cluster
     # events converted above). datetime.timestamp() gives a comparable epoch.
-    events.sort(key=lambda event: event['timestamp'].timestamp(), reverse=True)
-    if limit is not None:
-        events = events[:limit]
-    return events
+    def _newest_first(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        return sorted(rows,
+                      key=lambda event: event['timestamp'].timestamp(),
+                      reverse=True)
+
+    if limit is None:
+        return _newest_first(events + converted)
+    # Neither source may be starved. One launch can produce more cluster
+    # events than `limit`, and dropping the oldest rows would hide the
+    # PENDING -> STARTING -> RUNNING sequence the timeline is read for; but a
+    # job with many recoveries can fill the budget with its own transitions,
+    # and the launch reason the user is waiting on is usually the newest row
+    # of all. So the cluster side keeps a floor of half the budget (at least
+    # one row), and the trailing cut then trims the oldest job events.
+    cluster_floor = min(max(limit // 2, 1), len(converted))
+    room = max(limit - len(events), cluster_floor)
+    return _newest_first(events + _newest_first(converted)[:room])[:limit]

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -2157,22 +2157,14 @@ def _job_events(
                       key=lambda event: event['timestamp'].timestamp(),
                       reverse=True)
 
-    if limit is None:
-        return _newest_first(events + converted)
-    # Neither source may be starved. One launch can produce more cluster
-    # events than `limit`, and dropping the oldest rows would hide the
-    # PENDING -> STARTING -> RUNNING sequence the timeline is read for; but a
-    # job with many recoveries can fill the budget with its own transitions.
-    # So the job's own events take the budget first, the cluster side is
-    # guaranteed a share of what is left, and recency settles the remainder.
-    floor = min(max(limit // 2, 1), len(converted))
-    room = max(limit - len(events), floor)
-    candidates = _newest_first(converted)[:room]
-    # The share has to be *reserved*, not merely offered as a candidate: the
-    # final cut is by recency, so a job with a full budget of newer
-    # transitions would evict every cluster row that had been admitted.
-    # Capped so the job's own newest row never loses its slot; at limit=1
-    # that leaves the single row to whichever source is newest.
-    reserved = min(floor, len(candidates), limit - (1 if events else 0))
-    rest = _newest_first(events + candidates[reserved:])
-    return _newest_first(candidates[:reserved] + rest[:limit - reserved])
+    # Plain recency: the window is exactly the most recent `limit` rows of
+    # the merged list. Reserving a share for the cluster side was tried and
+    # dropped -- it made the window neither "the most recent N" nor reliably
+    # inclusive (a job with ten recent transitions gave slots away to
+    # provisioning rows from long ago, while a cluster row newer than every
+    # job row could still lose to an older one). "Why has this not started"
+    # is answered by the `details` column instead, which is guaranteed rather
+    # than budget-dependent. `converted` is already bounded per cluster by
+    # the same `limit`, so nothing runs away here.
+    merged = _newest_first(events + converted)
+    return merged if limit is None else merged[:limit]

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -2150,10 +2150,17 @@ def _job_events(
     # Neither source may be starved. One launch can produce more cluster
     # events than `limit`, and dropping the oldest rows would hide the
     # PENDING -> STARTING -> RUNNING sequence the timeline is read for; but a
-    # job with many recoveries can fill the budget with its own transitions,
-    # and the launch reason the user is waiting on is usually the newest row
-    # of all. So the cluster side keeps a floor of half the budget (at least
-    # one row), and the trailing cut then trims the oldest job events.
-    cluster_floor = min(max(limit // 2, 1), len(converted))
-    room = max(limit - len(events), cluster_floor)
-    return _newest_first(events + _newest_first(converted)[:room])[:limit]
+    # job with many recoveries can fill the budget with its own transitions.
+    # So the job's own events take the budget first, the cluster side is
+    # guaranteed a share of what is left, and recency settles the remainder.
+    floor = min(max(limit // 2, 1), len(converted))
+    room = max(limit - len(events), floor)
+    candidates = _newest_first(converted)[:room]
+    # The share has to be *reserved*, not merely offered as a candidate: the
+    # final cut is by recency, so a job with a full budget of newer
+    # transitions would evict every cluster row that had been admitted.
+    # Capped so the job's own newest row never loses its slot; at limit=1
+    # that leaves the single row to whichever source is newest.
+    reserved = min(floor, len(candidates), limit - (1 if events else 0))
+    rest = _newest_first(events + candidates[reserved:])
+    return _newest_first(candidates[:reserved] + rest[:limit - reserved])

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -2050,12 +2050,24 @@ def get_job_events(
     answers from the jobs database and the cluster's own events; see
     ``_job_events`` for the arguments and the row shape.
     """
-    return managed_job_runner.current().events(
-        job_id=job_id,
-        task_id=task_id,
-        task=task,
-        limit=limit,
-        include_cluster_events=include_cluster_events)
+    runner = managed_job_runner.current()
+    # A runner that predates this method: the plugins that register one are
+    # distributed separately from the server, so an older one can be
+    # installed against a newer OSS. Answer from the default rather than
+    # failing the endpoint on an interface it never saw.
+    if not hasattr(runner, 'events'):
+        logger.debug(f'{type(runner).__name__} does not implement events(); '
+                     'using the default')
+        return _job_events(job_id=job_id,
+                           task_id=task_id,
+                           task=task,
+                           limit=limit,
+                           include_cluster_events=include_cluster_events)
+    return runner.events(job_id=job_id,
+                         task_id=task_id,
+                         task=task,
+                         limit=limit,
+                         include_cluster_events=include_cluster_events)
 
 
 def _job_events(

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -3044,7 +3044,8 @@ def _format_job_details(*,
         job['details'] = state_details
     elif job['failure_reason']:
         job['details'] = f'Failure: {job["failure_reason"]}'
-    elif recovery_reason:
+    elif recovery_reason and job['status'] == (
+            managed_job_state.ManagedJobStatus.RECOVERING.value):
         # Surface why a job is recovering (e.g. an OOMKilled pod) so the
         # transient recovery cause is visible in the CLI and dashboard, not
         # just the controller logs. The reason (e.g. from
@@ -3063,7 +3064,8 @@ def _format_job_details(*,
             if hint is not None:
                 detail += f' ({hint})'
         job['details'] = detail
-    elif pending_reason:
+    elif pending_reason and job['status'] == (
+            managed_job_state.ManagedJobStatus.PENDING.value):
         # Surface why a job is still PENDING (e.g. it was submitted to the
         # controller queue or is in launch backoff) so the reason is visible
         # in the job details view, not just the event table. Collapse
@@ -3339,6 +3341,11 @@ def get_managed_job_queue(
             for job in jobs
             if job['status'] == managed_job_state.ManagedJobStatus.PENDING.value
         ]
+        # Keyed by job id, not by task: in a job group every task shares the
+        # id, so a RECOVERING task's reason reaches its STARTING sibling's row
+        # too. `_format_job_details` therefore only applies each of these to a
+        # row that is itself in that status -- the maps are built from rows in
+        # that status, so nothing else could have been meant by them.
         recovery_reasons, pending_reasons = (
             managed_job_state.get_latest_recovery_and_pending_reasons(
                 recovering_job_ids, pending_job_ids))

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -2892,6 +2892,20 @@ def _update_fields(fields: List[str],) -> Tuple[List[str], bool]:
             new_fields.append('priority')
         if 'failure_reason' not in new_fields:
             new_fields.append('failure_reason')
+        # Needed to derive the cluster name of STARTING jobs for the
+        # launch-progress reason lookup, key it per task, and ignore events
+        # left by an earlier attempt. Selected even when the caller (e.g. the
+        # dashboard) did not ask for them.
+        if 'task_name' not in new_fields:
+            new_fields.append('task_name')
+        if 'pool' not in new_fields:
+            new_fields.append('pool')
+        if 'task_id' not in new_fields:
+            new_fields.append('task_id')
+        if 'last_recovered_at' not in new_fields:
+            new_fields.append('last_recovered_at')
+        if 'submitted_at' not in new_fields:
+            new_fields.append('submitted_at')
     if 'user_yaml' in new_fields:
         if 'original_user_yaml_path' not in new_fields:
             new_fields.append('original_user_yaml_path')
@@ -2940,14 +2954,66 @@ def _cluster_handle_not_required(fields: List[str]) -> bool:
     return not any(field in fields for field in _CLUSTER_HANDLE_FIELDS)
 
 
+def _get_launch_reasons_by_task(
+        jobs: List[Dict[str, Any]]) -> Dict[Tuple[int, Optional[int]], str]:
+    """{(job_id, task_id): latest LAUNCH_PROGRESS reason} for STARTING tasks.
+
+    Keyed per task: in a job group each task launches its own cluster, and a
+    RUNNING sibling must not inherit a STARTING task's reason. The cluster
+    name is derived from the task name and job id the way the controller
+    names it; pool tasks share a cluster and are skipped, as in the
+    job-events merge.
+
+    A managed job's cluster name is reused across recovery attempts, and
+    launch-progress events are retained for days, so an event older than the
+    current attempt is dropped rather than shown as the current reason (e.g.
+    a stale image-pull reason after failover to a cloud that records no
+    launch progress). Best-effort: never raises.
+    """
+    cluster_name_by_task: Dict[Tuple[int, Optional[int]], str] = {}
+    attempt_start_by_task: Dict[Tuple[int, Optional[int]], float] = {}
+    for job in jobs:
+        if (job.get('status') !=
+                managed_job_state.ManagedJobStatus.STARTING.value or
+                job.get('pool') is not None or not job.get('task_name')):
+            continue
+        key = (job['job_id'], job.get('task_id'))
+        cluster_name_by_task[key] = generate_managed_job_cluster_name(
+            job['task_name'], job['job_id'])
+        # last_recovered_at is 0/None before the first recovery; fall back to
+        # submission time, and to 0 (no filtering) when neither is known.
+        attempt_start = job.get('last_recovered_at') or job.get('submitted_at')
+        attempt_start_by_task[key] = attempt_start or 0
+    if not cluster_name_by_task:
+        return {}
+    try:
+        events = global_user_state.get_latest_cluster_events(
+            list(dict.fromkeys(cluster_name_by_task.values())),
+            [global_user_state.ClusterEventType.LAUNCH_PROGRESS])
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f'Failed to read launch-progress reasons: {e}')
+        return {}
+    reasons: Dict[Tuple[int, Optional[int]], str] = {}
+    for key, name in cluster_name_by_task.items():
+        event = events.get(name)
+        if event is None:
+            continue
+        reason, transitioned_at = event
+        if transitioned_at < attempt_start_by_task[key]:
+            continue
+        reasons[key] = reason
+    return reasons
+
+
 def _format_job_details(*,
                         job: Dict[str, Any],
                         highest_blocking_priority: int,
                         recovery_reason: Optional[str] = None,
                         pending_reason: Optional[str] = None,
-                        cancel_reason: Optional[str] = None) -> None:
+                        cancel_reason: Optional[str] = None,
+                        launch_reason: Optional[str] = None) -> None:
     """Add details about schedule state / backoff / recovery / pending /
-    who requested a cancellation."""
+    who requested a cancellation / what a launch is waiting on."""
     if cancel_reason:
         # Surface who asked for the cancellation, and under which API
         # request, e.g. 'Cancellation requested by user alice (request ID:
@@ -3004,6 +3070,11 @@ def _format_job_details(*,
         # whitespace so a multi-line reason renders on a single line in the
         # details column.
         job['details'] = ' '.join(pending_reason.split())
+    elif launch_reason:
+        # Surface what the job's cluster is waiting on while STARTING (e.g. a
+        # Slurm squeue pending reason or a Kubernetes image pull), taken from
+        # the cluster's latest LAUNCH_PROGRESS event.
+        job['details'] = ' '.join(launch_reason.split())
     else:
         job['details'] = None
 
@@ -3257,6 +3328,7 @@ def get_managed_job_queue(
     recovery_reasons: Dict[int, str] = {}
     pending_reasons: Dict[int, str] = {}
     cancel_reasons: Dict[int, str] = {}
+    launch_reasons: Dict[Tuple[int, Optional[int]], str] = {}
     if not fields or 'details' in fields:
         recovering_job_ids = [
             job['job_id'] for job in jobs if job['status'] ==
@@ -3281,6 +3353,10 @@ def get_managed_job_queue(
         })
         cancel_reasons = managed_job_state.get_cancel_request_reasons(
             cancelled_job_ids)
+        # STARTING jobs: the latest launch-progress event of the cluster being
+        # provisioned (e.g. 'Launching (pending: QOSGrpGRES)' on Slurm), so
+        # `details` answers why the job has not started yet.
+        launch_reasons = _get_launch_reasons_by_task(jobs)
 
     for job in jobs:
         if not fields or 'details' in fields:
@@ -3289,7 +3365,9 @@ def get_managed_job_queue(
                 highest_blocking_priority=highest_blocking_priority,
                 recovery_reason=recovery_reasons.get(job['job_id']),
                 pending_reason=pending_reasons.get(job['job_id']),
-                cancel_reason=cancel_reasons.get(job['job_id']))
+                cancel_reason=cancel_reasons.get(job['job_id']),
+                launch_reason=launch_reasons.get(
+                    (job['job_id'], job.get('task_id'))))
 
         # Derive is_job_group from execution column
         job['is_job_group'] = (

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -3343,9 +3343,12 @@ def get_managed_job_queue(
         ]
         # Keyed by job id, not by task: in a job group every task shares the
         # id, so a RECOVERING task's reason reaches its STARTING sibling's row
-        # too. `_format_job_details` therefore only applies each of these to a
-        # row that is itself in that status -- the maps are built from rows in
-        # that status, so nothing else could have been meant by them.
+        # too. `_format_job_details` therefore applies these two only to a row
+        # that is itself in that status -- the maps are built from rows in that
+        # status, so nothing else could have been meant by them. The
+        # cancellation below is deliberately not guarded that way: cancelling
+        # a job cancels every task in it, so it is the right answer on a
+        # sibling's row as well, and it is checked first for that reason.
         recovery_reasons, pending_reasons = (
             managed_job_state.get_latest_recovery_and_pending_reasons(
                 recovering_job_ids, pending_job_ids))

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -378,13 +378,17 @@ def _record_nodes_allocated(cluster_name: str, slurm_cluster: str,
     """Record that the allocation has its nodes, as launch progress.
 
     Written once the wait returns, so `details` moves from why the queue was
-    waiting to which allocation is now bootstrapping the runtime.
+    waiting to which allocation is now bootstrapping the runtime. The text
+    leads with the transition rather than the id, because marking the end of
+    the queue wait is what a reader watching that column is waiting for.
     """
+    reason = (f'Launching (nodes allocated; Slurm job {job_id} '
+              f'on {slurm_cluster})')
     try:
         global_user_state.add_cluster_event(
             cluster_name,
             new_status=None,
-            reason=f'Launching (Slurm job {job_id} on {slurm_cluster})',
+            reason=reason,
             event_type=global_user_state.ClusterEventType.LAUNCH_PROGRESS,
             nop_if_duplicate=True,
         )

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -271,6 +271,17 @@ def _wait_for_job_nodes(
             raise RuntimeError(f'Job {job_id} terminated with state {state} '
                                'before nodes were allocated.')
 
+        # Checked before the pending branch, not after: the state read above
+        # can say CONFIGURING (or PENDING) while the nodes are granted moments
+        # later in this same iteration, and recording a pending reason then
+        # would write it in the same second as the caller's node-allocated
+        # event. transitioned_at is whole seconds, so those two rows would tie
+        # with nothing but the database's collation to separate them -- the
+        # thing the two event types exist to avoid.
+        if client.check_job_has_nodes(job_id):
+            logger.debug(f'Job {job_id} has nodes allocated')
+            return
+
         if state in ('PENDING', 'CONFIGURING') and on_pending is not None:
             try:
                 reason = client.get_job_reason(job_id)
@@ -284,10 +295,6 @@ def _wait_for_job_nodes(
             except Exception as e:  # pylint: disable=broad-except
                 logger.debug(f'Failed to get pending status for job '
                              f'{job_id}: {e}')
-
-        if client.check_job_has_nodes(job_id):
-            logger.debug(f'Job {job_id} has nodes allocated')
-            return
 
         time.sleep(2)
 
@@ -339,12 +346,39 @@ def _record_allocation(cluster_name: str, slurm_cluster: str,
     still be asked what its allocation did, which is the whole reason to read
     sacct: it is the only source for a job squeue has already forgotten.
 
+    Written at submission, so it survives a job cancelled while it was still
+    queued -- the case most worth asking about afterwards.
+
     One event per allocation, by id: a recovery submits a new one and adds a
     row rather than replacing this one, so every attempt stays addressable.
-    The wording follows the launch-progress convention of this module so the
-    row reads sensibly wherever launch progress is shown, and it is
-    deliberately distinct from the sentences a reader of the timeline
-    composes from it.
+
+    A DEBUG event rather than launch progress: which allocation backs a
+    cluster is metadata. It never changes and the launch is not waiting on it,
+    so it does not belong in the column that says what the launch *is* waiting
+    on -- where it also landed in the same second as the first pending reason,
+    leaving the database's collation to decide which of the two a reader saw.
+    The launch-progress half is recorded once the nodes are granted, by which
+    time it is strictly later than any pending reason.
+    """
+    try:
+        global_user_state.add_cluster_event(
+            cluster_name,
+            new_status=None,
+            reason=f'Slurm allocation {job_id} on {slurm_cluster}',
+            event_type=global_user_state.ClusterEventType.DEBUG,
+            nop_if_duplicate=True,
+        )
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f'Failed to record the Slurm allocation of '
+                     f'{cluster_name}: {e}')
+
+
+def _record_nodes_allocated(cluster_name: str, slurm_cluster: str,
+                            job_id: str) -> None:
+    """Record that the allocation has its nodes, as launch progress.
+
+    Written once the wait returns, so `details` moves from why the queue was
+    waiting to which allocation is now bootstrapping the runtime.
     """
     try:
         global_user_state.add_cluster_event(
@@ -355,7 +389,7 @@ def _record_allocation(cluster_name: str, slurm_cluster: str,
             nop_if_duplicate=True,
         )
     except Exception as e:  # pylint: disable=broad-except
-        logger.debug(f'Failed to record the Slurm allocation of '
+        logger.debug(f'Failed to record the node allocation of '
                      f'{cluster_name}: {e}')
 
 
@@ -863,6 +897,7 @@ def _create_virtual_instance(
         # Wait for nodes to be allocated (job might be in PENDING state)
         _wait_for_job_nodes(client, job_id, provision_timeout, partition,
                             on_pending)
+        _record_nodes_allocated(cluster_name, slurm_cluster, job_id)
         nodes, _ = client.get_job_nodes(job_id)
         # Reset spinner since nodes are now allocated
         rich_utils.force_update_status(
@@ -1310,6 +1345,7 @@ touch {sky_cluster_home_dir}/.hushlogin
 
     _wait_for_job_nodes(client, job_id, provision_timeout, partition,
                         on_pending)
+    _record_nodes_allocated(cluster_name, slurm_cluster, job_id)
     nodes, _ = client.get_job_nodes(job_id)
     # Reset spinner since nodes are now allocated
     rich_utils.force_update_status(

--- a/sky/provision/slurm/instance.py
+++ b/sky/provision/slurm/instance.py
@@ -15,6 +15,7 @@ import uuid
 import colorama
 
 from sky import exceptions
+from sky import global_user_state
 from sky import sky_logging
 from sky import skypilot_config
 from sky.adaptors import slurm
@@ -292,6 +293,106 @@ def _wait_for_job_nodes(
 
     raise TimeoutError(f'Job {job_id} did not get nodes allocated within '
                        f'{timeout} seconds. Last state: {last_state}')
+
+
+def _record_pending_reason(cluster_name: str, reason: Optional[str],
+                           partition: Optional[str]) -> None:
+    """Persist the squeue pending reason as a cluster launch-progress event.
+
+    The spinner is transient; this makes the reason visible in `sky jobs queue
+    -v` details and in the job's event timeline. Only the reason is
+    recorded (not the pending count) so nop_if_duplicate collapses repeated
+    polls into one event.
+
+    The partition rides along because a reader has no other way to get it: by
+    the time anyone looks at the event the allocation may be gone, and Slurm's
+    reason code alone ('Resources') cannot say *where* the job was waiting.
+    Deliberately not recorded: node counts. They are a snapshot, and a
+    "3 idle nodes" claim still sitting in the event log an hour later is worse
+    than no claim -- a reader that wants counts should ask for them now.
+    """
+    if not reason:
+        return
+    detail = f'pending: {reason}'
+    if partition:
+        detail += f'; partition: {partition}'
+    try:
+        global_user_state.add_cluster_event(
+            cluster_name,
+            new_status=None,
+            reason=f'Launching ({detail})',
+            event_type=global_user_state.ClusterEventType.LAUNCH_PROGRESS,
+            nop_if_duplicate=True,
+        )
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f'Failed to record pending reason for {cluster_name}: '
+                     f'{e}')
+
+
+def _record_allocation(cluster_name: str, slurm_cluster: str,
+                       job_id: str) -> None:
+    """Persist which Slurm allocation backs this cluster.
+
+    The cluster row carries the same two facts -- its resources' region, and
+    cluster_name_on_cloud on the handle -- but teardown removes it, while
+    cluster events outlive it. Recording them is what lets a finished job
+    still be asked what its allocation did, which is the whole reason to read
+    sacct: it is the only source for a job squeue has already forgotten.
+
+    One event per allocation, by id: a recovery submits a new one and adds a
+    row rather than replacing this one, so every attempt stays addressable.
+    The wording follows the launch-progress convention of this module so the
+    row reads sensibly wherever launch progress is shown, and it is
+    deliberately distinct from the sentences a reader of the timeline
+    composes from it.
+    """
+    try:
+        global_user_state.add_cluster_event(
+            cluster_name,
+            new_status=None,
+            reason=f'Launching (Slurm job {job_id} on {slurm_cluster})',
+            event_type=global_user_state.ClusterEventType.LAUNCH_PROGRESS,
+            nop_if_duplicate=True,
+        )
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f'Failed to record the Slurm allocation of '
+                     f'{cluster_name}: {e}')
+
+
+def _make_pending_callback(
+    cluster_name: str,
+    partition: Optional[str] = None,
+) -> Callable[[str, Optional[str], Optional[int]], None]:
+    """Callback for the pending phase of a Slurm allocation.
+
+    Refreshes the launch spinner and records the squeue reason as a cluster
+    event. Both are change-gated: the wait loop polls every few seconds, and
+    the spinner message embeds the pending count (which moves far more often
+    than the reason), so the two need separate memories.
+    """
+    last_status_msg: Optional[str] = None
+    last_recorded_reason: Optional[str] = None
+
+    def _on_pending(state: str, reason: Optional[str],
+                    pending_count: Optional[int]) -> None:
+        nonlocal last_status_msg, last_recorded_reason
+        del state  # unused
+        parts = []
+        if reason:
+            parts.append(f'pending: {reason}')
+        if pending_count is not None and pending_count > 0:
+            word = 'other' if pending_count == 1 else 'others'
+            parts.append(f'{pending_count} {word} pending')
+        msg = f'Launching ({", ".join(parts)})' if parts else 'Launching'
+        status_msg = ux_utils.spinner_message(msg, cluster_name=cluster_name)
+        if status_msg != last_status_msg:
+            rich_utils.force_update_status(status_msg)
+            last_status_msg = status_msg
+        if reason != last_recorded_reason:
+            _record_pending_reason(cluster_name, reason, partition)
+            last_recorded_reason = reason
+
+    return _on_pending
 
 
 def _sky_cluster_home_dir(base_dir: str, cluster_name_on_cloud: str) -> str:
@@ -747,26 +848,7 @@ def _create_virtual_instance(
                  f'job to be allocated on partition {partition}')
 
     num_nodes = config.count
-    last_status_msg = None
-
-    def _on_pending(state: str, reason: Optional[str],
-                    pending_count: Optional[int]) -> None:
-        nonlocal last_status_msg
-        del state  # unused
-        parts = []
-        if reason:
-            parts.append(f'pending: {reason}')
-        if pending_count is not None and pending_count > 0:
-            word = 'other' if pending_count == 1 else 'others'
-            parts.append(f'{pending_count} {word} pending')
-        if parts:
-            msg = f'Launching ({", ".join(parts)})'
-        else:
-            msg = 'Launching'
-        status_msg = ux_utils.spinner_message(msg, cluster_name=cluster_name)
-        if status_msg != last_status_msg:
-            rich_utils.force_update_status(status_msg)
-            last_status_msg = status_msg
+    on_pending = _make_pending_callback(cluster_name, partition)
 
     if existing_jobs:
         assert len(existing_jobs) == 1, (
@@ -776,10 +858,11 @@ def _create_virtual_instance(
         job_id = existing_jobs[0]
         logger.debug(f'Job with name {cluster_name_on_cloud} already exists '
                      f'(JOBID: {job_id})')
+        _record_allocation(cluster_name, slurm_cluster, job_id)
 
         # Wait for nodes to be allocated (job might be in PENDING state)
         _wait_for_job_nodes(client, job_id, provision_timeout, partition,
-                            _on_pending)
+                            on_pending)
         nodes, _ = client.get_job_nodes(job_id)
         # Reset spinner since nodes are now allocated
         rich_utils.force_update_status(
@@ -1223,9 +1306,10 @@ touch {sky_cluster_home_dir}/.hushlogin
     logger.debug(f'Successfully submitted Slurm job {job_id} to partition '
                  f'{partition} for cluster {cluster_name_on_cloud} '
                  f'with {num_nodes} nodes')
+    _record_allocation(cluster_name, slurm_cluster, job_id)
 
     _wait_for_job_nodes(client, job_id, provision_timeout, partition,
-                        _on_pending)
+                        on_pending)
     nodes, _ = client.get_job_nodes(job_id)
     # Reset spinner since nodes are now allocated
     rich_utils.force_update_status(

--- a/sky/schemas/db/global_user_state/023_add_cluster_events_name_index.py
+++ b/sky/schemas/db/global_user_state/023_add_cluster_events_name_index.py
@@ -1,0 +1,55 @@
+"""Add an index for the cluster_events lookups keyed on the name column.
+
+cluster_events is keyed (cluster_hash, reason, transitioned_at), but two
+readers filter on the ``name`` column instead, because it is the only one
+that survives a cluster's teardown:
+get_latest_cluster_events (the details column of every `sky jobs queue -v`)
+and get_cluster_events_by_name (the job-events timeline). Neither name nor
+type is indexed, so both were full-table scans over every cluster's whole
+history.
+
+Revision ID: 023
+Revises: 022
+Create Date: 2026-09-09
+
+"""
+# pylint: disable=invalid-name
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '023'
+down_revision: Union[str, Sequence[str], None] = '022'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_INDEX_NAME = 'ix_cluster_events_name_type'
+
+
+def _existing_indexes(table_name: str) -> set:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return {ix['name'] for ix in inspector.get_indexes(table_name)}
+
+
+def upgrade():
+    """Create the index if it doesn't already exist.
+
+    Idempotent, and inside an autocommit block so PostgreSQL accepts the
+    implicit transactional DDL and SQLite runs the statement directly --
+    the same pattern as the spot_jobs index migrations.
+    """
+    if _INDEX_NAME in _existing_indexes('cluster_events'):
+        return
+    with op.get_context().autocommit_block():
+        # transitioned_at trails the equality columns so the ORDER BY of
+        # both readers is served by the index rather than by a sort.
+        op.create_index(_INDEX_NAME, 'cluster_events',
+                        ['name', 'type', 'transitioned_at'])
+
+
+def downgrade():
+    """No-op for backward compatibility."""
+    pass

--- a/sky/server/constants.py
+++ b/sky/server/constants.py
@@ -11,7 +11,7 @@ from sky.skylet import runtime_utils
 # based on version info is needed.
 # For more details and code guidelines, refer to:
 # https://docs.skypilot.co/en/latest/developers/CONTRIBUTING.html#backward-compatibility-guidelines
-API_VERSION = 58  # managed jobs queue infra filter (--infra)
+API_VERSION = 59  # task name/id filter for /jobs/events
 
 # The minimum peer API version that the code should still work with.
 # Notes (dev):

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -1081,6 +1081,9 @@ class GetJobEventsBody(RequestBody):
     """The request body for the get job task events endpoint."""
     job_id: int
     task_id: Optional[int] = None
+    # Task name or id, resolved server-side. Mirrors the `task` argument of
+    # `sky jobs logs`; `task_id` stays for callers that already have the id.
+    task: Optional[Union[str, int]] = None
     limit: Optional[int] = 10  # Default to 10 most recent task events
     # When True, merge in launch-progress events from the job's underlying
     # cluster (e.g. image pulling) so the timeline shows provisioning

--- a/sky/utils/db/migration_utils.py
+++ b/sky/utils/db/migration_utils.py
@@ -30,7 +30,7 @@ DB_INIT_LOCK_TIMEOUT_SECONDS = 10
 _alembic_thread_lock = threading.Lock()
 
 GLOBAL_USER_STATE_DB_NAME = 'state_db'
-GLOBAL_USER_STATE_VERSION = '022'  # add volume resize fields
+GLOBAL_USER_STATE_VERSION = '023'  # index cluster_events by name
 GLOBAL_USER_STATE_LOCK_PATH = f'~/.sky/locks/.{GLOBAL_USER_STATE_DB_NAME}.lock'
 
 SPOT_JOBS_DB_NAME = 'spot_jobs_db'

--- a/sky/utils/debug_utils.py
+++ b/sky/utils/debug_utils.py
@@ -611,7 +611,7 @@ def _managed_job_cluster_names_from_records(
     current_cluster_name. Non-pool jobs use a deterministic per-task
     cluster name (a multi-task pipeline launches one cluster per task,
     so a job can have several). Mirrors the resolution in
-    jobs.utils.queue_v2 and jobs.server.core._get_job_cluster_names.
+    jobs.utils.queue_v2 and jobs.server.core._get_job_clusters.
 
     job_records are queue_v2 records: one record per task, so a
     multi-task job contributes one name per task.

--- a/tests/unit_tests/test_jobs_events_merge.py
+++ b/tests/unit_tests/test_jobs_events_merge.py
@@ -105,16 +105,13 @@ def test_merge_orders_newest_first_and_truncates(monkeypatch):
         global_user_state.ClusterEventType.STATUS_CHANGE,
         global_user_state.ClusterEventType.LAUNCH_PROGRESS,
     })
-    # Newest first, capped at limit=3. The job's own two transitions keep
-    # their place and the remaining slot goes to the newest cluster event:
-    # a launch can emit more cluster events than the limit, and losing the
-    # job's status sequence to them is the worse failure (see
-    # test_limit_never_starves_the_job_own_timeline).
+    # Newest first, and the window is exactly the most recent three rows of
+    # the merged list -- so the older 'Job is starting' drops out.
     reasons = [e['reason'] for e in result]
     assert reasons == [
         'Job has started',
         'Launching (1 pod(s) pending due to Pulling)',
-        'Job is starting',
+        'Launching (Kubernetes cluster is autoscaling)',
     ]
     # Merged cluster events are tagged as STARTING-phase events, and carry
     # the task whose cluster produced them (this used to be hard-coded None,
@@ -331,51 +328,10 @@ class TestResolveTaskId:
             core._resolve_task_id(7, 'train')
 
 
-def test_limit_never_starves_the_job_own_timeline(monkeypatch):
-    """A chatty launch must not push PENDING/STARTING out of the window.
-
-    The merged list is capped at `limit`, and the cluster side can produce
-    more events than that on its own; the job's transitions are the sequence
-    the timeline is read for, so they keep their place.
-    """
-    job_events = [
-        _job_event('Job submitted to queue',
-                   managed_job_state.ManagedJobStatus.PENDING, 100),
-        _job_event('Job is starting',
-                   managed_job_state.ManagedJobStatus.STARTING, 110),
-    ]
-    monkeypatch.setattr(managed_job_state, 'get_job_events',
-                        lambda **kwargs: list(job_events))
-    monkeypatch.setattr(managed_job_state, 'get_managed_job_tasks',
-                        lambda job_id: [_task()])
-    # 20 cluster events, all newer than the job's own two.
-    monkeypatch.setattr(global_user_state,
-                        'get_cluster_events_by_name',
-                        lambda name, event_types, limit=None: [{
-                            'reason': f'Launching (step {i})',
-                            'transitioned_at': 200 + i
-                        } for i in range(20)][:limit or 20])
-
-    result = core.get_job_events(job_id=1, limit=5, include_cluster_events=True)
-    assert len(result) == 5
-    reasons = [event['reason'] for event in result]
-    # Both job events survive; the rest of the budget goes to the newest
-    # cluster events.
-    assert 'Job submitted to queue' in reasons
-    assert 'Job is starting' in reasons
-    assert sum(1 for r in reasons if r.startswith('Launching')) == 3
-    # Still newest-first overall.
-    stamps = [event['timestamp'].timestamp() for event in result]
-    assert stamps == sorted(stamps, reverse=True)
-
-
-def test_limit_never_starves_the_cluster_events(monkeypatch):
-    """A job with many recoveries must not hide the current launch reason.
-
-    The mirror of test_limit_never_starves_the_job_own_timeline: when the
-    job's own transitions can fill the whole budget, the newest row of all
-    is usually the launch reason the user is waiting on, so the cluster side
-    keeps a floor.
+def test_the_newest_row_wins_when_the_job_is_chatty(monkeypatch):
+    """A job with enough transitions to fill the budget on its own still
+    reports the launch reason when that is the newest row of all: the cut is
+    by recency across both sources, not per source.
     """
     job_events = [
         _job_event(f'transition {i}',
@@ -403,6 +359,36 @@ def test_limit_never_starves_the_cluster_events(monkeypatch):
     # The oldest job transition is what gives up its slot.
     assert 'transition 0' not in reasons
     assert 'transition 4' in reasons
+
+
+def test_the_window_is_exactly_the_most_recent_rows(monkeypatch):
+    """Reserving a share for the cluster side was tried and dropped: it gave
+    slots to provisioning rows from long ago, so a caller that asked for the
+    ten most recent events got six of them. `details` carries the
+    "why has this not started" guarantee instead.
+    """
+    job_events = [
+        _job_event(f'transition {i}',
+                   managed_job_state.ManagedJobStatus.RECOVERING, 1000 + i)
+        for i in range(10)
+    ]
+    monkeypatch.setattr(managed_job_state, 'get_job_events',
+                        lambda **kwargs: list(reversed(job_events)))
+    monkeypatch.setattr(managed_job_state, 'get_managed_job_tasks',
+                        lambda job_id: [_task()])
+    monkeypatch.setattr(global_user_state,
+                        'get_cluster_events_by_name',
+                        lambda name, event_types, limit=None: [{
+                            'reason': f'Launching (step {i})',
+                            'transitioned_at': 100 + i
+                        } for i in range(4)])
+
+    result = core.get_job_events(job_id=1,
+                                 limit=10,
+                                 include_cluster_events=True)
+    reasons = [event['reason'] for event in result]
+    assert len(reasons) == 10
+    assert not any(r.startswith('Launching') for r in reasons)
 
 
 def test_limit_one_returns_the_newest_event_of_either_source(monkeypatch):
@@ -469,41 +455,11 @@ def test_the_default_runner_still_reads_the_database(monkeypatch):
                                include_cluster_events=False) == job_events
 
 
-def test_the_floor_holds_when_the_job_events_are_all_newer(monkeypatch):
-    """The floor has to *reserve* a slot, not just widen the candidate pool.
-    The final cut is by recency, so a job with a full budget of newer
-    transitions used to evict every cluster row that had been admitted --
-    hiding exactly the provisioning history the merge is read for.
-    """
-    job_events = [
-        _job_event('Job is restarting',
-                   managed_job_state.ManagedJobStatus.STARTING, 600 + i)
-        for i in range(3)
-    ]
-    monkeypatch.setattr(managed_job_state, 'get_job_events',
-                        lambda **kwargs: list(job_events))
-    monkeypatch.setattr(managed_job_state, 'get_managed_job_tasks',
-                        lambda job_id: [_task()])
-    monkeypatch.setattr(
-        global_user_state,
-        'get_cluster_events_by_name',
-        lambda name, event_types, limit=None: [{
-            'reason': 'Launching (pending: Resources; partition: dev)',
-            'transitioned_at': 100,
-        }])
-
-    result = core.get_job_events(job_id=1, limit=3, include_cluster_events=True)
-    assert len(result) == 3
-    assert result[-1]['reason'] == (
-        'Launching (pending: Resources; partition: dev)')
-
-
 def test_limit_one_prefers_the_newest_even_when_it_is_the_job_s_own(
         monkeypatch):
     """The mirror of test_limit_one_returns_the_newest_event_of_either_source:
-    the reserved infra share must never cost the job's own newest row, or a
-    single-row view would show an old launch line instead of the transition
-    that just happened."""
+    a single-row view shows the transition that just happened, not an older
+    launch line."""
     job_events = [
         _job_event('Job has started',
                    managed_job_state.ManagedJobStatus.RUNNING, 500)

--- a/tests/unit_tests/test_jobs_events_merge.py
+++ b/tests/unit_tests/test_jobs_events_merge.py
@@ -6,6 +6,8 @@ underlying cluster in the managed-job timeline.
 """
 import datetime
 
+import pytest
+
 from sky import global_user_state
 from sky.jobs import runner as managed_job_runner
 from sky.jobs import state as managed_job_state
@@ -103,18 +105,24 @@ def test_merge_orders_newest_first_and_truncates(monkeypatch):
         global_user_state.ClusterEventType.STATUS_CHANGE,
         global_user_state.ClusterEventType.LAUNCH_PROGRESS,
     })
-    # Newest first, truncated to limit=3 (drops the oldest 'Job is starting').
+    # Newest first, capped at limit=3. The job's own two transitions keep
+    # their place and the remaining slot goes to the newest cluster event:
+    # a launch can emit more cluster events than the limit, and losing the
+    # job's status sequence to them is the worse failure (see
+    # test_limit_never_starves_the_job_own_timeline).
     reasons = [e['reason'] for e in result]
     assert reasons == [
         'Job has started',
         'Launching (1 pod(s) pending due to Pulling)',
-        'Launching (Kubernetes cluster is autoscaling)',
+        'Job is starting',
     ]
-    # Merged cluster events are tagged as STARTING-phase events.
+    # Merged cluster events are tagged as STARTING-phase events, and carry
+    # the task whose cluster produced them (this used to be hard-coded None,
+    # which made a job group's tasks indistinguishable in the timeline).
     pulling = next(e for e in result if 'Pulling' in e['reason'])
     assert pulling['new_status'] == managed_job_state.ManagedJobStatus.STARTING
     assert pulling['spot_job_id'] == 1
-    assert pulling['task_id'] is None
+    assert pulling['task_id'] == 0
 
 
 def test_pool_jobs_skip_merge(monkeypatch):
@@ -241,6 +249,182 @@ def test_pipeline_uses_per_task_cluster_name(monkeypatch):
 
     # Per-task cluster names, not the shared DAG name 'pipe-1'.
     assert queried_names == ['pipe-0-1', 'pipe-1-1']
+
+
+def test_merged_cluster_events_carry_their_task_id(monkeypatch):
+    """A job group's cluster events must not all report task_id None.
+
+    Otherwise the CLI's TASK column is wrong for every merged row and the
+    events of two tasks are indistinguishable.
+    """
+    job_events = [
+        _job_event('Job is starting',
+                   managed_job_state.ManagedJobStatus.STARTING, 100)
+    ]
+    monkeypatch.setattr(managed_job_state, 'get_job_events',
+                        lambda **kwargs: list(job_events))
+    monkeypatch.setattr(
+        managed_job_state, 'get_managed_job_tasks', lambda job_id: [
+            _task(task_name='grp-0', task_id=0),
+            _task(task_name='grp-1', task_id=1),
+        ])
+    c0 = managed_job_utils.generate_managed_job_cluster_name('grp-0', 1)
+    c1 = managed_job_utils.generate_managed_job_cluster_name('grp-1', 1)
+    by_cluster = {
+        c0: [{
+            'reason': 'Launching (pending: Resources)',
+            'transitioned_at': 110
+        }],
+        c1: [{
+            'reason': 'Launching (pending: Priority)',
+            'transitioned_at': 120
+        }],
+    }
+    monkeypatch.setattr(
+        global_user_state,
+        'get_cluster_events_by_name',
+        lambda name, event_types, limit=None: by_cluster.get(name, []))
+
+    events = core.get_job_events(job_id=1,
+                                 limit=None,
+                                 include_cluster_events=True)
+    merged = {
+        event['reason']: event['task_id']
+        for event in events
+        if 'pending:' in event['reason']
+    }
+    assert merged == {
+        'Launching (pending: Resources)': 0,
+        'Launching (pending: Priority)': 1,
+    }
+
+
+class TestResolveTaskId:
+    """A task name or id is resolved the way `sky jobs logs` accepts it."""
+
+    @staticmethod
+    def _tasks(monkeypatch):
+        monkeypatch.setattr(
+            managed_job_state, 'get_managed_job_tasks', lambda job_id: [
+                _task(task_name='train', task_id=0),
+                _task(task_name='eval', task_id=1),
+            ])
+
+    def test_name_and_id(self, monkeypatch):
+        self._tasks(monkeypatch)
+        assert core._resolve_task_id(1, 'eval') == 1
+        assert core._resolve_task_id(1, 0) == 0
+        # A numeric string is an id, matching the CLI's documented behavior.
+        assert core._resolve_task_id(1, '1') == 1
+
+    def test_unknown_name_or_id_raises(self, monkeypatch):
+        self._tasks(monkeypatch)
+        with pytest.raises(ValueError, match="'nope' not found"):
+            core._resolve_task_id(1, 'nope')
+        with pytest.raises(ValueError, match='Task 9 not found'):
+            core._resolve_task_id(1, 9)
+
+    def test_missing_job_raises(self, monkeypatch):
+        monkeypatch.setattr(managed_job_state, 'get_managed_job_tasks',
+                            lambda job_id: [])
+        with pytest.raises(ValueError, match='Managed job 7 not found'):
+            core._resolve_task_id(7, 'train')
+
+
+def test_limit_never_starves_the_job_own_timeline(monkeypatch):
+    """A chatty launch must not push PENDING/STARTING out of the window.
+
+    The merged list is capped at `limit`, and the cluster side can produce
+    more events than that on its own; the job's transitions are the sequence
+    the timeline is read for, so they keep their place.
+    """
+    job_events = [
+        _job_event('Job submitted to queue',
+                   managed_job_state.ManagedJobStatus.PENDING, 100),
+        _job_event('Job is starting',
+                   managed_job_state.ManagedJobStatus.STARTING, 110),
+    ]
+    monkeypatch.setattr(managed_job_state, 'get_job_events',
+                        lambda **kwargs: list(job_events))
+    monkeypatch.setattr(managed_job_state, 'get_managed_job_tasks',
+                        lambda job_id: [_task()])
+    # 20 cluster events, all newer than the job's own two.
+    monkeypatch.setattr(global_user_state,
+                        'get_cluster_events_by_name',
+                        lambda name, event_types, limit=None: [{
+                            'reason': f'Launching (step {i})',
+                            'transitioned_at': 200 + i
+                        } for i in range(20)][:limit or 20])
+
+    result = core.get_job_events(job_id=1, limit=5, include_cluster_events=True)
+    assert len(result) == 5
+    reasons = [event['reason'] for event in result]
+    # Both job events survive; the rest of the budget goes to the newest
+    # cluster events.
+    assert 'Job submitted to queue' in reasons
+    assert 'Job is starting' in reasons
+    assert sum(1 for r in reasons if r.startswith('Launching')) == 3
+    # Still newest-first overall.
+    stamps = [event['timestamp'].timestamp() for event in result]
+    assert stamps == sorted(stamps, reverse=True)
+
+
+def test_limit_never_starves_the_cluster_events(monkeypatch):
+    """A job with many recoveries must not hide the current launch reason.
+
+    The mirror of test_limit_never_starves_the_job_own_timeline: when the
+    job's own transitions can fill the whole budget, the newest row of all
+    is usually the launch reason the user is waiting on, so the cluster side
+    keeps a floor.
+    """
+    job_events = [
+        _job_event(f'transition {i}',
+                   managed_job_state.ManagedJobStatus.RECOVERING, 100 + i)
+        for i in range(5)
+    ]
+    monkeypatch.setattr(managed_job_state, 'get_job_events',
+                        lambda **kwargs: list(reversed(job_events)))
+    monkeypatch.setattr(managed_job_state, 'get_managed_job_tasks',
+                        lambda job_id: [_task()])
+    monkeypatch.setattr(managed_job_utils, 'generate_managed_job_cluster_name',
+                        lambda name, job_id: f'{name}-{job_id}')
+    monkeypatch.setattr(global_user_state,
+                        'get_cluster_events_by_name',
+                        lambda name, event_types, limit=None: [{
+                            'reason': 'Launching (pending: Resources)',
+                            'transitioned_at': 500
+                        }])
+
+    result = core.get_job_events(job_id=1, limit=5, include_cluster_events=True)
+    reasons = [event['reason'] for event in result]
+    assert len(result) == 5
+    # The newest event of all survives, and it is reported first.
+    assert reasons[0] == 'Launching (pending: Resources)'
+    # The oldest job transition is what gives up its slot.
+    assert 'transition 0' not in reasons
+    assert 'transition 4' in reasons
+
+
+def test_limit_one_returns_the_newest_event_of_either_source(monkeypatch):
+    job_events = [
+        _job_event('Job is starting',
+                   managed_job_state.ManagedJobStatus.STARTING, 100)
+    ]
+    monkeypatch.setattr(managed_job_state, 'get_job_events',
+                        lambda **kwargs: list(job_events))
+    monkeypatch.setattr(managed_job_state, 'get_managed_job_tasks',
+                        lambda job_id: [_task()])
+    monkeypatch.setattr(managed_job_utils, 'generate_managed_job_cluster_name',
+                        lambda name, job_id: f'{name}-{job_id}')
+    monkeypatch.setattr(global_user_state,
+                        'get_cluster_events_by_name',
+                        lambda name, event_types, limit=None: [{
+                            'reason': 'Launching (pending: Resources)',
+                            'transitioned_at': 500
+                        }])
+
+    result = core.get_job_events(job_id=1, limit=1, include_cluster_events=True)
+    assert [e['reason'] for e in result] == ['Launching (pending: Resources)']
 
 
 def test_events_go_through_the_registered_runner(monkeypatch):

--- a/tests/unit_tests/test_jobs_events_merge.py
+++ b/tests/unit_tests/test_jobs_events_merge.py
@@ -7,6 +7,7 @@ underlying cluster in the managed-job timeline.
 import datetime
 
 from sky import global_user_state
+from sky.jobs import runner as managed_job_runner
 from sky.jobs import state as managed_job_state
 from sky.jobs import utils as managed_job_utils
 from sky.jobs.server import core
@@ -240,3 +241,45 @@ def test_pipeline_uses_per_task_cluster_name(monkeypatch):
 
     # Per-task cluster names, not the shared DAG name 'pipe-1'.
     assert queried_names == ['pipe-0-1', 'pipe-1-1']
+
+
+def test_events_go_through_the_registered_runner(monkeypatch):
+    """The whole point of the indirection: a runner can answer with what the
+    infrastructure knows about the job, which the default cannot read."""
+    calls = []
+
+    class _Runner:
+
+        def events(self, **kwargs):
+            calls.append(kwargs)
+            return [_job_event('from the runner', None, 1)]
+
+    monkeypatch.setattr(managed_job_runner, '_current', _Runner())
+    result = core.get_job_events(job_id=7,
+                                 task_id=1,
+                                 limit=5,
+                                 include_cluster_events=True,
+                                 task='train')
+    assert [event['reason'] for event in result] == ['from the runner']
+    # Every argument is passed through; nothing is interpreted on the way.
+    assert calls == [{
+        'job_id': 7,
+        'task_id': 1,
+        'task': 'train',
+        'limit': 5,
+        'include_cluster_events': True,
+    }]
+
+
+def test_the_default_runner_still_reads_the_database(monkeypatch):
+    """Overriding must be a choice, not the only path: with nothing
+    registered the answer is the same as before the indirection existed."""
+    job_events = [
+        _job_event('Job has started',
+                   managed_job_state.ManagedJobStatus.RUNNING, 300)
+    ]
+    monkeypatch.setattr(managed_job_state, 'get_job_events',
+                        lambda **kwargs: list(job_events))
+    monkeypatch.setattr(managed_job_runner, '_current', None)
+    assert core.get_job_events(job_id=1,
+                               include_cluster_events=False) == job_events

--- a/tests/unit_tests/test_jobs_events_merge.py
+++ b/tests/unit_tests/test_jobs_events_merge.py
@@ -467,3 +467,57 @@ def test_the_default_runner_still_reads_the_database(monkeypatch):
     monkeypatch.setattr(managed_job_runner, '_current', None)
     assert core.get_job_events(job_id=1,
                                include_cluster_events=False) == job_events
+
+
+def test_the_floor_holds_when_the_job_events_are_all_newer(monkeypatch):
+    """The floor has to *reserve* a slot, not just widen the candidate pool.
+    The final cut is by recency, so a job with a full budget of newer
+    transitions used to evict every cluster row that had been admitted --
+    hiding exactly the provisioning history the merge is read for.
+    """
+    job_events = [
+        _job_event('Job is restarting',
+                   managed_job_state.ManagedJobStatus.STARTING, 600 + i)
+        for i in range(3)
+    ]
+    monkeypatch.setattr(managed_job_state, 'get_job_events',
+                        lambda **kwargs: list(job_events))
+    monkeypatch.setattr(managed_job_state, 'get_managed_job_tasks',
+                        lambda job_id: [_task()])
+    monkeypatch.setattr(
+        global_user_state,
+        'get_cluster_events_by_name',
+        lambda name, event_types, limit=None: [{
+            'reason': 'Launching (pending: Resources; partition: dev)',
+            'transitioned_at': 100,
+        }])
+
+    result = core.get_job_events(job_id=1, limit=3, include_cluster_events=True)
+    assert len(result) == 3
+    assert result[-1]['reason'] == (
+        'Launching (pending: Resources; partition: dev)')
+
+
+def test_limit_one_prefers_the_newest_even_when_it_is_the_job_s_own(
+        monkeypatch):
+    """The mirror of test_limit_one_returns_the_newest_event_of_either_source:
+    the reserved infra share must never cost the job's own newest row, or a
+    single-row view would show an old launch line instead of the transition
+    that just happened."""
+    job_events = [
+        _job_event('Job has started',
+                   managed_job_state.ManagedJobStatus.RUNNING, 500)
+    ]
+    monkeypatch.setattr(managed_job_state, 'get_job_events',
+                        lambda **kwargs: list(job_events))
+    monkeypatch.setattr(managed_job_state, 'get_managed_job_tasks',
+                        lambda job_id: [_task()])
+    monkeypatch.setattr(global_user_state,
+                        'get_cluster_events_by_name',
+                        lambda name, event_types, limit=None: [{
+                            'reason': 'Launching (pending: Resources)',
+                            'transitioned_at': 100
+                        }])
+
+    result = core.get_job_events(job_id=1, limit=1, include_cluster_events=True)
+    assert [event['reason'] for event in result] == ['Job has started']

--- a/tests/unit_tests/test_jobs_events_merge.py
+++ b/tests/unit_tests/test_jobs_events_merge.py
@@ -521,3 +521,32 @@ def test_limit_one_prefers_the_newest_even_when_it_is_the_job_s_own(
 
     result = core.get_job_events(job_id=1, limit=1, include_cluster_events=True)
     assert [event['reason'] for event in result] == ['Job has started']
+
+
+def test_a_runner_without_events_falls_back_to_the_default(monkeypatch):
+    """The plugins that register a runner ship separately from the server, so
+    one predating this method can be installed against a newer OSS. Calling
+    it unconditionally would fail the endpoint on an interface it never saw.
+    """
+    job_events = [
+        _job_event('Job has started',
+                   managed_job_state.ManagedJobStatus.RUNNING, 300)
+    ]
+    monkeypatch.setattr(managed_job_state, 'get_job_events',
+                        lambda **kwargs: list(job_events))
+
+    class _OldRunner:
+        """Implements the three methods that existed before `events`."""
+
+        def fetch_managed_job_table(self, **kwargs):
+            raise AssertionError('not reached')
+
+        def cancel_managed_jobs(self, **kwargs):
+            raise AssertionError('not reached')
+
+        def tail_managed_job_logs(self, **kwargs):
+            raise AssertionError('not reached')
+
+    monkeypatch.setattr(managed_job_runner, '_current', _OldRunner())
+    assert core.get_job_events(job_id=1,
+                               include_cluster_events=False) == job_events

--- a/tests/unit_tests/test_sky/jobs/test_details_launch_reason.py
+++ b/tests/unit_tests/test_sky/jobs/test_details_launch_reason.py
@@ -1,0 +1,146 @@
+"""Tests for surfacing the cluster launch-progress reason in job details."""
+from unittest import mock
+
+from sky.jobs import utils as managed_job_utils
+
+
+def _job(status='STARTING', **kwargs):
+    job = {
+        'job_id': 1,
+        'task_id': 0,
+        'last_recovered_at': 0,
+        'submitted_at': 0,
+        'status': status,
+        'schedule_state': 'ALIVE',
+        'failure_reason': None,
+        'priority': 500,
+        'task_name': 'train',
+        'pool': None,
+    }
+    job.update(kwargs)
+    return job
+
+
+def test_launch_reason_fills_details_when_nothing_else_applies():
+    job = _job()
+    managed_job_utils._format_job_details(
+        job=job,
+        highest_blocking_priority=0,
+        launch_reason='Launching  (pending:\n QOSGrpGRES)')
+    assert job['details'] == 'Launching (pending: QOSGrpGRES)'
+
+
+def test_failure_reason_wins_over_launch_reason():
+    job = _job(failure_reason='boom')
+    managed_job_utils._format_job_details(job=job,
+                                          highest_blocking_priority=0,
+                                          launch_reason='Launching (x)')
+    assert job['details'] == 'Failure: boom'
+
+
+def test_no_launch_reason_leaves_details_empty():
+    job = _job()
+    managed_job_utils._format_job_details(job=job, highest_blocking_priority=0)
+    assert job['details'] is None
+
+
+def _jobs():
+    return [
+        _job(job_id=1, task_id=0, status='STARTING', task_name='train'),
+        _job(job_id=2,
+             task_id=0,
+             status='STARTING',
+             task_name='train',
+             pool='p'),
+        _job(job_id=3, task_id=0, status='RUNNING', task_name='train'),
+        _job(job_id=4, task_id=0, status='STARTING', task_name=None),
+    ]
+
+
+def test_launch_reasons_derive_cluster_name_for_starting_non_pool_jobs():
+    expected = managed_job_utils.generate_managed_job_cluster_name('train', 1)
+    with mock.patch.object(managed_job_utils.global_user_state,
+                           'get_latest_cluster_events',
+                           return_value={
+                               expected: ('Launching (pending: x)', 100)
+                           }) as get_reasons:
+        reasons = managed_job_utils._get_launch_reasons_by_task(_jobs())
+    # Only job 1 qualifies: 2 is a pool job, 3 is not STARTING, 4 has no
+    # task name.
+    names, _ = get_reasons.call_args.args
+    assert names == [expected]
+    assert reasons == {(1, 0): 'Launching (pending: x)'}
+
+
+def test_launch_reasons_are_per_task_in_a_job_group():
+    # One job group: task 0 STARTING, task 1 RUNNING, task 2 STARTING. Only the
+    # STARTING tasks get a reason, each from its own cluster.
+    jobs = [
+        _job(job_id=7, task_id=0, status='STARTING', task_name='grp-0'),
+        _job(job_id=7, task_id=1, status='RUNNING', task_name='grp-1'),
+        _job(job_id=7, task_id=2, status='STARTING', task_name='grp-2'),
+    ]
+    c0 = managed_job_utils.generate_managed_job_cluster_name('grp-0', 7)
+    c2 = managed_job_utils.generate_managed_job_cluster_name('grp-2', 7)
+    with mock.patch.object(managed_job_utils.global_user_state,
+                           'get_latest_cluster_events',
+                           return_value={
+                               c0: ('Launching (pending: Resources)', 100),
+                               c2: ('Launching (pending: Priority)', 100),
+                           }) as get_reasons:
+        reasons = managed_job_utils._get_launch_reasons_by_task(jobs)
+    names, _ = get_reasons.call_args.args
+    assert names == [c0, c2]
+    assert reasons == {
+        (7, 0): 'Launching (pending: Resources)',
+        (7, 2): 'Launching (pending: Priority)',
+    }
+    assert (7, 1) not in reasons
+
+
+def test_launch_reasons_skip_lookup_when_no_starting_jobs():
+    with mock.patch.object(managed_job_utils.global_user_state,
+                           'get_latest_cluster_events') as get_reasons:
+        assert not managed_job_utils._get_launch_reasons_by_task(
+            [_job(status='RUNNING')])
+    get_reasons.assert_not_called()
+
+
+def test_launch_reasons_ignore_events_from_an_earlier_attempt():
+    # The cluster name is reused across recovery attempts: an event older
+    # than the current attempt's start must not be shown as its reason.
+    cluster = managed_job_utils.generate_managed_job_cluster_name('train', 1)
+    fresh = _job(job_id=1,
+                 task_id=0,
+                 status='STARTING',
+                 task_name='train',
+                 last_recovered_at=500,
+                 submitted_at=100)
+    with mock.patch.object(managed_job_utils.global_user_state,
+                           'get_latest_cluster_events',
+                           return_value={cluster: ('stale reason', 499)}):
+        assert not managed_job_utils._get_launch_reasons_by_task([fresh])
+    with mock.patch.object(managed_job_utils.global_user_state,
+                           'get_latest_cluster_events',
+                           return_value={cluster: ('current reason', 501)}):
+        assert managed_job_utils._get_launch_reasons_by_task([fresh]) == {
+            (1, 0): 'current reason'
+        }
+    # No recovery yet: submission time is the attempt start.
+    first = _job(job_id=1,
+                 task_id=0,
+                 status='STARTING',
+                 task_name='train',
+                 last_recovered_at=None,
+                 submitted_at=300)
+    with mock.patch.object(managed_job_utils.global_user_state,
+                           'get_latest_cluster_events',
+                           return_value={cluster: ('before submit', 299)}):
+        assert not managed_job_utils._get_launch_reasons_by_task([first])
+
+
+def test_launch_reasons_swallow_db_errors():
+    with mock.patch.object(managed_job_utils.global_user_state,
+                           'get_latest_cluster_events',
+                           side_effect=RuntimeError('db')):
+        assert not managed_job_utils._get_launch_reasons_by_task(_jobs())

--- a/tests/unit_tests/test_sky/jobs/test_details_launch_reason.py
+++ b/tests/unit_tests/test_sky/jobs/test_details_launch_reason.py
@@ -144,3 +144,39 @@ def test_launch_reasons_swallow_db_errors():
                            'get_latest_cluster_events',
                            side_effect=RuntimeError('db')):
         assert not managed_job_utils._get_launch_reasons_by_task(_jobs())
+
+
+def test_a_sibling_task_recovery_reason_does_not_shadow_a_launch_reason():
+    """In a job group each task has its own row, but recovery and pending
+    reasons are looked up by job id alone -- so a STARTING task used to
+    inherit a RECOVERING sibling's reason, and since that branch is checked
+    first, its own launch reason was hidden. The reason belongs to the task
+    that is in that status.
+    """
+    starting = _job(job_id=7, task_id=1, status='STARTING')
+    managed_job_utils._format_job_details(
+        job=starting,
+        highest_blocking_priority=0,
+        recovery_reason='OOMKilled',
+        launch_reason='Launching (pending: Resources; partition: dev)')
+    assert starting['details'] == (
+        'Launching (pending: Resources; partition: dev)')
+
+
+def test_a_recovering_task_still_reports_its_recovery_reason():
+    """The mirror: the guard must not silence the row the reason is about."""
+    recovering = _job(job_id=7, task_id=0, status='RECOVERING')
+    managed_job_utils._format_job_details(job=recovering,
+                                          highest_blocking_priority=0,
+                                          recovery_reason='OOMKilled')
+    assert recovering['details'] == 'Recovering: OOMKilled'
+
+
+def test_a_sibling_pending_reason_does_not_shadow_a_launch_reason():
+    starting = _job(job_id=7, task_id=1, status='STARTING')
+    managed_job_utils._format_job_details(
+        job=starting,
+        highest_blocking_priority=0,
+        pending_reason='Waiting for a launch slot',
+        launch_reason='Launching (pending: Priority)')
+    assert starting['details'] == 'Launching (pending: Priority)'

--- a/tests/unit_tests/test_sky/jobs/test_details_launch_reason.py
+++ b/tests/unit_tests/test_sky/jobs/test_details_launch_reason.py
@@ -180,3 +180,17 @@ def test_a_sibling_pending_reason_does_not_shadow_a_launch_reason():
         pending_reason='Waiting for a launch slot',
         launch_reason='Launching (pending: Priority)')
     assert starting['details'] == 'Launching (pending: Priority)'
+
+
+def test_a_cancellation_wins_over_a_launch_reason():
+    """Cancelling a job cancels every task in it, so unlike the recovery and
+    pending reasons this one is right on a sibling's row too -- it is checked
+    first and deliberately not gated on the row's own status.
+    """
+    starting = _job(job_id=7, task_id=1, status='STARTING')
+    managed_job_utils._format_job_details(
+        job=starting,
+        highest_blocking_priority=0,
+        cancel_reason='Cancellation requested by alice',
+        launch_reason='Launching (pending: Resources)')
+    assert starting['details'] == 'Cancellation requested by alice'

--- a/tests/unit_tests/test_sky/jobs/test_utils.py
+++ b/tests/unit_tests/test_sky/jobs/test_utils.py
@@ -86,12 +86,18 @@ class TestUpdateFields:
         assert 'task_name' in updated_fields
 
     def test_adds_dependencies_for_details(self):
-        """Test that schedule_state, priority, and failure_reason are added when details is present."""
+        """Test the columns `details` is assembled from are selected.
+
+        task_name/task_id/pool and the attempt-start columns are what the
+        launch-progress lookup keys on, so a caller that asks only for
+        `details` (e.g. the dashboard) must still get them.
+        """
         fields = ['details']
         updated_fields, _ = jobs_utils._update_fields(fields)
-        assert 'schedule_state' in updated_fields
-        assert 'priority' in updated_fields
-        assert 'failure_reason' in updated_fields
+        for field in ('schedule_state', 'priority', 'failure_reason',
+                      'task_name', 'task_id', 'pool', 'last_recovered_at',
+                      'submitted_at'):
+            assert field in updated_fields, field
 
     def test_adds_original_user_yaml_path_for_user_yaml(self):
         """Test that original_user_yaml_path is added when user_yaml is present."""

--- a/tests/unit_tests/test_sky/provision/slurm/test_instance.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_instance.py
@@ -1536,7 +1536,8 @@ class TestRecordAllocation:
         add_event.assert_called_once_with(
             _CLUSTER,
             new_status=None,
-            reason='Launching (Slurm job 17269 on hyperpod-slurm)',
+            reason=('Launching (nodes allocated; Slurm job 17269 '
+                    'on hyperpod-slurm)'),
             event_type=instance.global_user_state.ClusterEventType.
             LAUNCH_PROGRESS,
             nop_if_duplicate=True,

--- a/tests/unit_tests/test_sky/provision/slurm/test_instance.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_instance.py
@@ -1504,6 +1504,38 @@ class TestRecordAllocation:
         add_event.assert_called_once_with(
             _CLUSTER,
             new_status=None,
+            reason='Slurm allocation 17269 on hyperpod-slurm',
+            event_type=instance.global_user_state.ClusterEventType.DEBUG,
+            nop_if_duplicate=True,
+        )
+
+    def test_the_identity_is_not_a_launch_progress_event(self):
+        """It used to be, and it was written in the same second as the first
+        pending reason -- so which of the two `details` showed came down to
+        the database's text collation, which orders them the other way round
+        under a locale collation than under SQLite's binary one.
+        """
+        with mock.patch.object(instance.global_user_state,
+                               'add_cluster_event') as add_event:
+            instance._record_allocation(_CLUSTER, 'hyperpod-slurm', '17269')
+            instance._record_pending_reason(_CLUSTER, 'Resources', 'dev')
+        types = [c.kwargs['event_type'] for c in add_event.call_args_list]
+        progress = instance.global_user_state.ClusterEventType.LAUNCH_PROGRESS
+        assert types == [
+            instance.global_user_state.ClusterEventType.DEBUG, progress
+        ]
+
+    def test_the_nodes_are_granted_as_launch_progress(self):
+        """The progress half, written once the wait returns: later than any
+        pending reason, so recency alone settles which one a reader sees.
+        """
+        with mock.patch.object(instance.global_user_state,
+                               'add_cluster_event') as add_event:
+            instance._record_nodes_allocated(_CLUSTER, 'hyperpod-slurm',
+                                             '17269')
+        add_event.assert_called_once_with(
+            _CLUSTER,
+            new_status=None,
             reason='Launching (Slurm job 17269 on hyperpod-slurm)',
             event_type=instance.global_user_state.ClusterEventType.
             LAUNCH_PROGRESS,
@@ -1511,16 +1543,18 @@ class TestRecordAllocation:
         )
 
     def test_the_text_does_not_collide_with_a_pending_reason(self):
-        """Both are launch-progress events on the same cluster, and a reader
-        tells them apart by their text alone."""
+        """A reader of the timeline tells the rows apart by their text."""
         with mock.patch.object(instance.global_user_state,
                                'add_cluster_event') as add_event:
             instance._record_allocation(_CLUSTER, 'hyperpod-slurm', '17269')
             allocation = add_event.call_args.kwargs['reason']
+            instance._record_nodes_allocated(_CLUSTER, 'hyperpod-slurm',
+                                             '17269')
+            granted = add_event.call_args.kwargs['reason']
             instance._record_pending_reason(_CLUSTER, 'Resources', 'dev')
             pending = add_event.call_args.kwargs['reason']
-        assert allocation != pending
-        assert 'pending:' not in allocation
+        assert len({allocation, granted, pending}) == 3
+        assert 'pending:' not in allocation and 'pending:' not in granted
         assert 'Slurm job' not in pending
 
     def test_swallows_db_errors(self):
@@ -1529,3 +1563,35 @@ class TestRecordAllocation:
                                'add_cluster_event',
                                side_effect=RuntimeError('db is down')):
             instance._record_allocation(_CLUSTER, 'hyperpod-slurm', '17269')
+            instance._record_nodes_allocated(_CLUSTER, 'hyperpod-slurm',
+                                             '17269')
+
+
+class TestWaitForJobNodes:
+    """The wait loop's ordering, which decides what shares a second."""
+
+    def test_no_pending_reason_is_recorded_once_the_nodes_are_granted(self):
+        """The state read can say CONFIGURING while the nodes land in the same
+        iteration. Recording a reason then would put it in the same whole
+        second as the caller's node-allocated event, leaving the two to be
+        separated by the database's collation alone.
+        """
+        client = mock.MagicMock()
+        client.get_job_state.return_value = 'CONFIGURING'
+        client.check_job_has_nodes.return_value = True
+        on_pending = mock.MagicMock()
+        instance._wait_for_job_nodes(client, '17269', 60, 'dev', on_pending)
+        on_pending.assert_not_called()
+        client.get_job_reason.assert_not_called()
+
+    def test_a_pending_job_still_reports_its_reason(self):
+        """The mirror: the reorder must not silence the wait it is about."""
+        client = mock.MagicMock()
+        client.get_job_state.return_value = 'PENDING'
+        client.check_job_has_nodes.side_effect = [False, True]
+        client.get_job_reason.return_value = 'Resources'
+        client.get_pending_job_count.return_value = 2
+        on_pending = mock.MagicMock()
+        with mock.patch.object(instance.time, 'sleep'):
+            instance._wait_for_job_nodes(client, '17269', 60, 'dev', on_pending)
+        on_pending.assert_called_once_with('PENDING', 'Resources', 2)

--- a/tests/unit_tests/test_sky/provision/slurm/test_instance.py
+++ b/tests/unit_tests/test_sky/provision/slurm/test_instance.py
@@ -1396,3 +1396,136 @@ class TestQueryInstances:
         expected_rounds = 1 + instance._MAX_QUERY_INSTANCES_RETRIES
         assert mock_client.query_jobs.call_count == 7 * expected_rounds
         read_manifest.assert_called_once()
+
+
+class TestRecordPendingReason:
+    """The squeue pending reason is persisted as a launch-progress event."""
+
+    def test_records_reason_with_dedup(self):
+        with mock.patch.object(instance.global_user_state,
+                               'add_cluster_event') as add_event:
+            instance._record_pending_reason(_CLUSTER, 'QOSGrpGRES', 'h200')
+        add_event.assert_called_once_with(
+            _CLUSTER,
+            new_status=None,
+            reason='Launching (pending: QOSGrpGRES; partition: h200)',
+            event_type=instance.global_user_state.ClusterEventType.
+            LAUNCH_PROGRESS,
+            nop_if_duplicate=True,
+        )
+
+    def test_records_without_a_partition(self):
+        """The partition is optional: a reader has to cope with the shape that
+        carries no partition, since events written before this existed do
+        not."""
+        with mock.patch.object(instance.global_user_state,
+                               'add_cluster_event') as add_event:
+            instance._record_pending_reason(_CLUSTER, 'Resources', None)
+        assert (add_event.call_args.kwargs['reason'] ==
+                'Launching (pending: Resources)')
+
+    @pytest.mark.parametrize('reason', [None, ''])
+    def test_skips_empty_reason(self, reason):
+        with mock.patch.object(instance.global_user_state,
+                               'add_cluster_event') as add_event:
+            instance._record_pending_reason(_CLUSTER, reason, 'h200')
+        add_event.assert_not_called()
+
+    def test_swallows_db_errors(self):
+        with mock.patch.object(instance.global_user_state,
+                               'add_cluster_event',
+                               side_effect=RuntimeError('db down')):
+            instance._record_pending_reason(_CLUSTER, 'Resources', 'h200')
+
+
+class TestPendingCallback:
+    """The pending callback records the reason and gates repeated polls."""
+
+    def test_records_once_per_distinct_reason(self):
+        on_pending = instance._make_pending_callback(_CLUSTER)
+        with mock.patch.object(instance, '_record_pending_reason') as record, \
+             mock.patch.object(instance.rich_utils, 'force_update_status'):
+            # Same reason, moving pending count: one record, several spinner
+            # updates.
+            on_pending('PENDING', 'Resources', 3)
+            on_pending('PENDING', 'Resources', 2)
+            on_pending('PENDING', 'Resources', None)
+            assert record.call_args_list == [
+                mock.call(_CLUSTER, 'Resources', None)
+            ]
+            # A new reason records again.
+            on_pending('PENDING', 'Priority', None)
+            assert record.call_args_list[-1] == mock.call(
+                _CLUSTER, 'Priority', None)
+            assert record.call_count == 2
+
+    def test_spinner_reflects_reason_and_count(self):
+        on_pending = instance._make_pending_callback(_CLUSTER)
+        with mock.patch.object(instance, '_record_pending_reason'), \
+             mock.patch.object(instance.rich_utils,
+                               'force_update_status') as spinner:
+            on_pending('PENDING', 'Resources', 2)
+            on_pending('CONFIGURING', None, None)
+        msgs = [call.args[0] for call in spinner.call_args_list]
+        assert 'pending: Resources' in msgs[0] and '2 others pending' in msgs[0]
+        assert 'Launching' in msgs[1] and 'pending:' not in msgs[1]
+
+    def test_reasonless_polls_never_touch_the_db(self):
+        # squeue reports no reason yet: the callback starts out remembering
+        # None, so nothing is recorded at all.
+        on_pending = instance._make_pending_callback(_CLUSTER)
+        with mock.patch.object(instance, '_record_pending_reason') as record, \
+             mock.patch.object(instance.rich_utils, 'force_update_status'):
+            on_pending('PENDING', None, 0)
+            on_pending('CONFIGURING', None, None)
+            record.assert_not_called()
+            # A reason appearing later is recorded, and going back to no
+            # reason records that transition once.
+            on_pending('PENDING', 'Resources', None)
+            on_pending('PENDING', None, None)
+        assert record.call_args_list == [
+            mock.call(_CLUSTER, 'Resources', None),
+            mock.call(_CLUSTER, None, None),
+        ]
+
+
+class TestRecordAllocation:
+    """Which Slurm allocation backs a cluster, persisted as an event.
+
+    The cluster row carries the same facts, but teardown removes it while
+    cluster events outlive it -- and reading a job's accounting history is
+    exactly what you want *after* the job is over.
+    """
+
+    def test_records_the_id_and_the_cluster(self):
+        with mock.patch.object(instance.global_user_state,
+                               'add_cluster_event') as add_event:
+            instance._record_allocation(_CLUSTER, 'hyperpod-slurm', '17269')
+        add_event.assert_called_once_with(
+            _CLUSTER,
+            new_status=None,
+            reason='Launching (Slurm job 17269 on hyperpod-slurm)',
+            event_type=instance.global_user_state.ClusterEventType.
+            LAUNCH_PROGRESS,
+            nop_if_duplicate=True,
+        )
+
+    def test_the_text_does_not_collide_with_a_pending_reason(self):
+        """Both are launch-progress events on the same cluster, and a reader
+        tells them apart by their text alone."""
+        with mock.patch.object(instance.global_user_state,
+                               'add_cluster_event') as add_event:
+            instance._record_allocation(_CLUSTER, 'hyperpod-slurm', '17269')
+            allocation = add_event.call_args.kwargs['reason']
+            instance._record_pending_reason(_CLUSTER, 'Resources', 'dev')
+            pending = add_event.call_args.kwargs['reason']
+        assert allocation != pending
+        assert 'pending:' not in allocation
+        assert 'Slurm job' not in pending
+
+    def test_swallows_db_errors(self):
+        """Provisioning must not fail because an event could not be written."""
+        with mock.patch.object(instance.global_user_state,
+                               'add_cluster_event',
+                               side_effect=RuntimeError('db is down')):
+            instance._record_allocation(_CLUSTER, 'hyperpod-slurm', '17269')

--- a/tests/unit_tests/test_sky/test_global_user_state_cluster_events.py
+++ b/tests/unit_tests/test_sky/test_global_user_state_cluster_events.py
@@ -375,3 +375,54 @@ def test_latest_cluster_events_batched(tmp_path, monkeypatch):
     }
     assert not global_user_state.get_latest_cluster_events([], [progress])
     assert not global_user_state.get_latest_cluster_events(['c-a'], [])
+
+
+def test_latest_cluster_events_ties_are_deterministic(tmp_path, monkeypatch):
+    """transitioned_at is whole seconds, and the Slurm provisioner writes two
+    launch-progress events inside one: it records the allocation, then polls
+    for a reason. Without a second sort key the winner was whatever the
+    database happened to return, so `details` could show the allocation id
+    instead of the wait reason it is read for.
+    """
+    _fresh_db(tmp_path, monkeypatch)
+    _add_cluster('c-a')
+    progress = global_user_state.ClusterEventType.LAUNCH_PROGRESS
+    for reason in ('Launching (Slurm job 17269 on dev-slurm)',
+                   'Launching (pending: Resources; partition: dev)'):
+        global_user_state.add_cluster_event('c-a',
+                                            None,
+                                            reason,
+                                            progress,
+                                            transitioned_at=1000)
+    for _ in range(5):
+        events = global_user_state.get_latest_cluster_events(['c-a'],
+                                                             [progress])
+        assert events == {
+            'c-a': ('Launching (pending: Resources; partition: dev)', 1000)
+        }
+
+
+def test_latest_cluster_events_chunks_the_name_list(tmp_path, monkeypatch):
+    """SQLite caps a statement at 999 bound parameters. Unchunked, a
+    deployment with that many clusters provisioning at once raised -- and the
+    caller swallows the error, so *every* cluster lost its launch reason
+    rather than the excess.
+    """
+    _fresh_db(tmp_path, monkeypatch)
+    monkeypatch.setattr(global_user_state, '_CLUSTER_IN_QUERY_CHUNK_SIZE', 2)
+    progress = global_user_state.ClusterEventType.LAUNCH_PROGRESS
+    names = []
+    for i in range(5):
+        name = f'chunk-{i}'
+        _add_cluster(name)
+        names.append(name)
+        global_user_state.add_cluster_event(name,
+                                            None,
+                                            f'Launching (pending: r{i})',
+                                            progress,
+                                            transitioned_at=1000 + i)
+    events = global_user_state.get_latest_cluster_events(names, [progress])
+    # Every cluster answered, across three batches of at most two names.
+    assert events == {
+        f'chunk-{i}': (f'Launching (pending: r{i})', 1000 + i) for i in range(5)
+    }

--- a/tests/unit_tests/test_sky/test_global_user_state_cluster_events.py
+++ b/tests/unit_tests/test_sky/test_global_user_state_cluster_events.py
@@ -336,3 +336,42 @@ def test_get_cluster_events_multiple_types_merged_and_ordered(
     assert global_user_state.get_cluster_events(
         cluster_name=None, cluster_hash=cluster_hash, event_type=both,
         limit=2) == ['Launching (pulling)', 'Cluster provisioned']
+
+
+def test_latest_cluster_events_batched(tmp_path, monkeypatch):
+    _fresh_db(tmp_path, monkeypatch)
+    for name in ('c-a', 'c-b', 'c-c'):
+        _add_cluster(name)
+    progress = global_user_state.ClusterEventType.LAUNCH_PROGRESS
+    # Explicit transitioned_at: no sleeping for the 1s timestamp resolution.
+    global_user_state.add_cluster_event('c-a',
+                                        None,
+                                        'Launching (pending: Resources)',
+                                        progress,
+                                        transitioned_at=1000)
+    global_user_state.add_cluster_event('c-a',
+                                        None,
+                                        'Launching (pending: QOSGrpGRES)',
+                                        progress,
+                                        transitioned_at=2000)
+    # A different type on c-b must not be picked up by a progress-only query.
+    global_user_state.add_cluster_event(
+        'c-b',
+        status_lib.ClusterStatus.INIT,
+        'init',
+        global_user_state.ClusterEventType.STATUS_CHANGE,
+        transitioned_at=1500)
+
+    events = global_user_state.get_latest_cluster_events(
+        ['c-a', 'c-b', 'c-c', 'missing'], [progress])
+    assert events == {'c-a': ('Launching (pending: QOSGrpGRES)', 2000)}
+    # Both types requested: c-b's status change is returned with its stamp.
+    both = global_user_state.get_latest_cluster_events(
+        ['c-a', 'c-b'],
+        [progress, global_user_state.ClusterEventType.STATUS_CHANGE])
+    assert both == {
+        'c-a': ('Launching (pending: QOSGrpGRES)', 2000),
+        'c-b': ('init', 1500),
+    }
+    assert not global_user_state.get_latest_cluster_events([], [progress])
+    assert not global_user_state.get_latest_cluster_events(['c-a'], [])

--- a/tests/unit_tests/test_sky/test_global_user_state_cluster_events.py
+++ b/tests/unit_tests/test_sky/test_global_user_state_cluster_events.py
@@ -377,29 +377,31 @@ def test_latest_cluster_events_batched(tmp_path, monkeypatch):
     assert not global_user_state.get_latest_cluster_events(['c-a'], [])
 
 
-def test_latest_cluster_events_ties_are_deterministic(tmp_path, monkeypatch):
-    """transitioned_at is whole seconds, and the Slurm provisioner writes two
-    launch-progress events inside one: it records the allocation, then polls
-    for a reason. Without a second sort key the winner was whatever the
-    database happened to return, so `details` could show the allocation id
-    instead of the wait reason it is read for.
+def test_latest_cluster_events_ties_are_stable(tmp_path, monkeypatch):
+    """transitioned_at is whole seconds and the table has no insertion order,
+    so two events written inside one second need a second sort key for the
+    answer to be stable at all. *Which* of the two wins is the database's
+    collation, so it is deliberately not asserted -- see the ordering comment
+    in get_latest_cluster_events.
     """
     _fresh_db(tmp_path, monkeypatch)
     _add_cluster('c-a')
     progress = global_user_state.ClusterEventType.LAUNCH_PROGRESS
-    for reason in ('Launching (Slurm job 17269 on dev-slurm)',
-                   'Launching (pending: Resources; partition: dev)'):
+    reasons = {'Launching (one thing)', 'Launching (another thing)'}
+    for reason in reasons:
         global_user_state.add_cluster_event('c-a',
                                             None,
                                             reason,
                                             progress,
                                             transitioned_at=1000)
-    for _ in range(5):
-        events = global_user_state.get_latest_cluster_events(['c-a'],
-                                                             [progress])
-        assert events == {
-            'c-a': ('Launching (pending: Resources; partition: dev)', 1000)
-        }
+    seen = {
+        global_user_state.get_latest_cluster_events(['c-a'], [progress])['c-a']
+        for _ in range(5)
+    }
+    assert len(seen) == 1
+    reason, transitioned_at = seen.pop()
+    assert reason in reasons
+    assert transitioned_at == 1000
 
 
 def test_latest_cluster_events_chunks_the_name_list(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

A managed job that is waiting says nothing about why. On Slurm — where the wait is a scheduler queue rather than an API call — that is the whole question, and today it is answered only by reading the controller log or by having login-node access.

**`details` answers it.** `sky jobs queue -v` already explains backoff, recovery, a priority wait and a cancellation; it now also carries the latest launch-progress event of the cluster being provisioned, so a Slurm pending reason or a Kubernetes image pull is one command away.

```
$ sky jobs queue -v
ID     NAME   STATUS    ...  DETAILS
56266  train  STARTING  ...  Launching (pending: Resources; partition: dev)
```

**The provisioner records what it is the only place to see.** The `squeue` reason on every change — so a job that went `Resources → Priority → Resources` leaves three events and one that never moved leaves one — with the partition it is queued in, because Slurm's reason code alone cannot say *where* the job was waiting and by the time anyone looks the allocation may be gone.

It also records the allocation, as two rows that say different things. Its **identity** (`Slurm allocation 17388 on dev-slurm`) is a `DEBUG` event written at submission: the cluster row carries the same fact but teardown removes it, so this is what lets a job that is over — or was cancelled while still queued — still be asked what its allocation did. The **progress** milestone (`Launching (nodes allocated; Slurm job 17388 on dev-slurm)`) is written once the nodes are granted, and leads with the transition rather than the id, because the end of the queue wait is what a reader watching `details` is waiting for.

Keeping the identity out of `LAUNCH_PROGRESS` is the point of the split. Written at submission it landed in the same second as the first pending reason, and with `transitioned_at` at whole-second resolution and no insertion order in the table, which of the two `details` showed came down to the database's text collation: SQLite's binary ordering happens to prefer the pending reason, a locale collation prefers the allocation id. Since the pending callback only writes on *change*, that was not a one-second window — on PostgreSQL the allocation id would sit in `details` for the whole wait, in place of the reason this change exists to surface.

Node counts are deliberately not recorded. They are a snapshot, and a "3 idle nodes" claim still sitting in the event log an hour later is worse than no claim.

**`ManagedJobRunner` grows an `events` method.** Queue, cancel and logs already go through it so a runner can answer them differently; events now do too, with the current behaviour as the default. That is the seam an enterprise runner uses to add what the infrastructure knows about the same job — on Slurm, what the allocation waited on and for how long, which `squeue` forgets `MinJobAge` after the job ends. The method deliberately takes no `handle`/`backend`: it reads the API server's own `spot_jobs` and `global_user_state`, which is what this endpoint has always done, and the seam exists to *add* to that answer rather than move where it comes from.

**Two fixes the above surfaced:**

- A `task` filter for `/jobs/events`, resolved server-side the way `sky jobs logs` resolves it, and per-task cluster derivation — a pipeline launches one cluster per task, and the job-level DAG name reconstructed the wrong one. `limit` is exactly the most recent N rows of the merged list. Reserving a share for the infrastructure rows was tried and dropped: it made the window neither "the most recent N" nor reliably inclusive — a job with ten recent transitions gave 40% of a `limit=10` window to provisioning rows from long ago, while a cluster row *newer* than every job row could still lose its slot to an older one. "Why has this not started" is answered by `details`, which is guaranteed rather than budget-dependent.
- A recovery or pending reason is applied only to the task it is about, and the cancellation deliberately is not: cancelling a job cancels every task in it, so it is the right answer on a sibling's row too, and it stays the first branch. Both maps are keyed by job id, which was invisible while they were the only reasons a row could get; adding a per-task launch reason made it visible, so in a job group a STARTING task inherited a RECOVERING sibling's reason and its own launch reason was hidden.

**`cluster_events` is indexed by name.** The table is keyed `(cluster_hash, reason, transitioned_at)`, but the two readers that have to survive a cluster's teardown filter on `name` — and one of them feeds the `details` column of **every** `sky jobs queue -v`. Neither `name` nor `type` was indexed, so both scanned the whole table on a request path documented as `SHORT`.

## Test plan

Unit tests, 854 across the touched areas:

```
pytest tests/unit_tests/test_jobs_events_merge.py                          # 18
pytest tests/unit_tests/test_sky/jobs/                                     # 563
pytest tests/unit_tests/test_sky/provision/slurm/                          # 260
pytest tests/unit_tests/test_sky/test_global_user_state_cluster_events.py  # 12
pytest tests/unit_tests/test_api_version_consistency.py                    # 1
```

Each commit passes independently (verified by extracting each with `git archive` and running the two most relevant files), so the history is bisectable.

Verified live on a Slurm 24.11 cluster (3 nodes, one partition) that `details` carries the reason and the partition, for two different reasons:

```bash
# Occupy the partition so the next allocation has to queue.
ssh <login-node> 'sbatch -N 3 --exclusive --time=00:04:00 --wrap "sleep 230"'
sky jobs launch -y -d --infra slurm/<cluster> --num-nodes 3 -n pend 'echo hi'
sky jobs queue -v          # Launching (pending: Resources; partition: dev)
ssh <login-node> 'scontrol update JobId=<alloc> StartTime=now+1hour'
sky jobs queue -v          # Launching (pending: BeginTime; partition: dev)
```

Worth exercising in review: the migration against an existing database, and the read path against Postgres — the collation reasoning above is why the same-second ordering is not something a test on SQLite can check. Cancelling a job while it is STARTING with a pending allocation is now pinned by a test rather than left to review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10692" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

