### PR TITLE
[Server] Report stuck threads in on-demand thread executors

### DIFF
--- a/sky/metrics/utils.py
+++ b/sky/metrics/utils.py
@@ -326,6 +326,31 @@ SKY_APISERVER_THREADS_MAX = prom.Gauge(
     multiprocess_mode='liveall',
 )
 
+# Threads whose task has run longer than the executor's stuck threshold, per
+# process. A pool that only runs short lookups should read 0 here; a value
+# that climbs while sky_apiserver_threads_active climbs with it is a pool
+# being consumed by tasks that never return, long before it is exhausted.
+# 'liveall' for the same reason as sky_apiserver_threads_active.
+SKY_APISERVER_THREADS_STUCK = prom.Gauge(
+    'sky_apiserver_threads_stuck',
+    'Threads in on-demand thread executors running longer than the '
+    'executor\'s stuck threshold, per process',
+    ['pid', 'name'],
+    multiprocess_mode='liveall',
+)
+
+# Age of the longest-running task in each executor, per process. Unlike the
+# stuck count this needs no threshold, so it also serves pools whose tasks
+# may legitimately run for hours: a monotonically growing age on a pool that
+# should turn over in milliseconds is the earliest signal of a pinned thread.
+SKY_APISERVER_THREADS_OLDEST_AGE_SECONDS = prom.Gauge(
+    'sky_apiserver_threads_oldest_age_seconds',
+    'Age of the longest-running task in each on-demand thread executor, per '
+    'process',
+    ['pid', 'name'],
+    multiprocess_mode='liveall',
+)
+
 # A gauge scraped every N seconds can miss short bursts that hit the limit;
 # this counter is the reliable signal that exhaustion actually happened.
 SKY_APISERVER_THREADS_EXHAUSTED_TOTAL = prom.Counter(

--- a/sky/server/hung_threads.py
+++ b/sky/server/hung_threads.py
@@ -479,6 +479,14 @@ def _peer_hex_forms(peers: Iterable[Tuple[str, int]]) -> Set[str]:
     return out
 
 
+def _recv_q(row: Tuple[str, str, str, str, str]) -> int:
+    """Unread bytes of a /proc/net/tcp row ('tx_queue:rx_queue' hex)."""
+    try:
+        return int(row[3].split(':')[1], 16)
+    except (IndexError, ValueError):
+        return -1
+
+
 def scan_ownerless_sockets(extra_peers: Iterable[Tuple[str,
                                                        int]] = ()) -> List[str]:
     """List established TCP connections in this network namespace that no
@@ -503,7 +511,9 @@ def scan_ownerless_sockets(extra_peers: Iterable[Tuple[str,
 
     Costs one read of ``/proc/net/tcp`` plus a walk of every readable
     ``/proc/<pid>/fd`` -- tens to a few hundred milliseconds on a busy pod --
-    so callers keep it rare. Returns log lines; the first is a summary.
+    so callers keep it rare. Returns log lines; the first is a summary, then
+    at most _MAX_SCAN_RESULTS connections, the ones with the most unread
+    bytes first.
     """
     started = time.monotonic()
     try:
@@ -516,6 +526,11 @@ def scan_ownerless_sockets(extra_peers: Iterable[Tuple[str,
             row for row in rows
             if row[4] != '0' and row[4] not in owned and row[1] in peers
         ]
+        # An orphan whose peer answered and nobody read the reply is the one
+        # that holds a lock; other ownerless connections (another container
+        # in the pod, a process whose descriptors we cannot read) must not
+        # push it past the report limit. Stable, so ties keep table order.
+        suspects.sort(key=_recv_q, reverse=True)
         elapsed_ms = (time.monotonic() - started) * 1000
         summary = (f'ownerless sockets: {len(suspects)} established/'
                    f'close-wait connection(s) to a peer this host talks to '

--- a/sky/server/hung_threads.py
+++ b/sky/server/hung_threads.py
@@ -35,10 +35,10 @@ whatever is allocated next, and the thread's dump shows the *new* owner of
 the number (often a perfectly healthy-looking socket of the same kind) while
 the real connection sits established with unread data and no descriptor
 pointing at it. The scan lists such sockets, restricted to peers that some
-process here is also connected to, so a sidecar's own connections in a shared
-namespace do not show up. It parses ``/proc/net/tcp`` and walks every
-readable ``/proc/<pid>/fd``, so callers rate-limit it well below the
-per-thread dump.
+process here is also connected to or that the caller names, minus peers the
+caller excludes, so a sidecar's own connections in a shared namespace do not
+show up. It parses ``/proc/net/tcp`` and walks every readable
+``/proc/<pid>/fd``, so callers rate-limit it well below the per-thread dump.
 
 Everything here is best effort: any step may fail on a non-Linux host, a
 hardened container, or a thread that resumed between two reads, and a
@@ -487,14 +487,20 @@ def _recv_q(row: Tuple[str, str, str, str, str]) -> int:
         return -1
 
 
-def scan_ownerless_sockets(extra_peers: Iterable[Tuple[str,
-                                                       int]] = ()) -> List[str]:
+def scan_ownerless_sockets(
+        extra_peers: Iterable[Tuple[str, int]] = (),
+        exclude_peers: Iterable[Tuple[str, int]] = (),
+) -> List[str]:
     """List established TCP connections in this network namespace that no
     process we can see owns, restricted to peers some visible process is
     also connected to, plus ``extra_peers`` (host, port) the caller knows it
     talks to -- typically the database, whose orphaned connections are the
     ones that hold locks. Without ``extra_peers`` an orphan to a peer nobody
     happens to be connected to at scan time goes unreported.
+    ``exclude_peers`` are left out even when a visible process is connected
+    to them: the database behind a sidecar pooler is one, because the
+    pooler's own connections to it come from another process namespace and
+    every one of them would look ownerless here.
 
     A descriptor number closed while another thread sleeps in ``poll`` on it
     leaves the kernel socket alive with no descriptor pointing at it. The
@@ -522,6 +528,7 @@ def scan_ownerless_sockets(extra_peers: Iterable[Tuple[str,
             _socket_inodes_by_process(started + _SCAN_TIME_BUDGET_SECONDS))
         peers = {rem for _, rem, _, _, ino in rows if ino in owned}
         peers |= _peer_hex_forms(extra_peers)
+        peers -= _peer_hex_forms(exclude_peers)
         suspects = [
             row for row in rows
             if row[4] != '0' and row[4] not in owned and row[1] in peers

--- a/sky/server/hung_threads.py
+++ b/sky/server/hung_threads.py
@@ -1,0 +1,542 @@
+"""Describe a thread that has been running for too long.
+
+The on-demand thread executors (``sky/server/requests/threads.py``) hand each
+task its own thread and count it against a per-process limit. A task that
+never returns keeps its slot forever, and once every slot is held that way
+the executor rejects everything. When that happens the useful question is
+"what are those threads doing?", and the answer has to come from inside the
+process: a production pod rarely has py-spy or ``ss``, and by the time
+someone could attach a tool the worker has usually been recycled.
+
+``describe`` builds that answer from what the interpreter and the kernel
+already expose, with no extra tooling:
+
+- the Python stack of the thread from ``sys._current_frames()``. This is the
+  frame the thread will resume in, so for a thread parked in a C call it names
+  the call (``cursor.execute``, ``connection.commit``, ``socket.recv``).
+- the kernel's view of the thread from ``/proc/self/task/<tid>/``: scheduler
+  state, ``wchan`` and, where the kernel exposes it, the syscall the thread
+  sleeps in with its arguments. For ``poll``/``ppoll`` the ``pollfd`` array is
+  read back from our own address space through ``/proc/self/mem`` (a stale
+  pointer then reads as an error instead of a segfault) so the dump names the
+  file descriptor being waited on and whether the wait has a timeout.
+- what that descriptor is *now* (``/proc/self/fd``) and, for a socket, its
+  peer, TCP state and receive/send queue lengths. These come from a
+  ``dup`` of the descriptor via ``getsockopt(TCP_INFO)``, ``getpeername`` and
+  ``ioctl(FIONREAD)``: constant cost per descriptor, no parsing of
+  ``/proc/net/tcp`` (which grows with every TIME_WAIT entry in the network
+  namespace and can take tens of milliseconds to read on a busy pod).
+
+``scan_ownerless_sockets`` answers a second question that the per-thread view
+cannot: is there a connection in this network namespace that no process owns
+any more? A descriptor closed under a sleeping ``poll`` leaves exactly that
+behind -- the poll keeps the kernel socket alive, the number gets reused by
+whatever is allocated next, and the thread's dump shows the *new* owner of
+the number (often a perfectly healthy-looking socket of the same kind) while
+the real connection sits established with unread data and no descriptor
+pointing at it. The scan lists such sockets, restricted to peers that some
+process here is also connected to, so a sidecar's own connections in a shared
+namespace do not show up. It parses ``/proc/net/tcp`` and walks every
+readable ``/proc/<pid>/fd``, so callers rate-limit it well below the
+per-thread dump.
+
+Everything here is best effort: any step may fail on a non-Linux host, a
+hardened container, or a thread that resumed between two reads, and a
+failure only shortens the description. Nothing raises to the caller.
+"""
+import fcntl
+import os
+import platform
+import socket
+import struct
+import sys
+import threading
+import time
+import traceback
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
+
+# Syscall numbers for the waits worth naming. Anything else is reported by
+# number. Only the two architectures we ship containers for.
+_SYSCALLS_X86_64 = {
+    0: 'read',
+    1: 'write',
+    3: 'close',
+    7: 'poll',
+    23: 'select',
+    35: 'nanosleep',
+    42: 'connect',
+    44: 'sendto',
+    45: 'recvfrom',
+    47: 'recvmsg',
+    202: 'futex',
+    219: 'restart_syscall',
+    230: 'clock_nanosleep',
+    232: 'epoll_wait',
+    270: 'pselect6',
+    271: 'ppoll',
+    281: 'epoll_pwait',
+}
+_SYSCALLS_AARCH64 = {
+    22: 'epoll_pwait',
+    57: 'close',
+    63: 'read',
+    64: 'write',
+    72: 'pselect6',
+    73: 'ppoll',
+    98: 'futex',
+    101: 'nanosleep',
+    115: 'clock_nanosleep',
+    128: 'restart_syscall',
+    203: 'connect',
+    206: 'sendto',
+    207: 'recvfrom',
+    212: 'recvmsg',
+}
+_SYSCALLS = {
+    'x86_64': _SYSCALLS_X86_64,
+    'aarch64': _SYSCALLS_AARCH64,
+}.get(platform.machine(), {})
+# Syscalls whose first argument is a file descriptor.
+_FD_ARG0 = frozenset({
+    'read', 'write', 'close', 'connect', 'sendto', 'recvfrom', 'recvmsg',
+    'epoll_wait', 'epoll_pwait'
+})
+_TCP_STATES = {
+    1: 'ESTABLISHED',
+    2: 'SYN_SENT',
+    3: 'SYN_RECV',
+    4: 'FIN_WAIT1',
+    5: 'FIN_WAIT2',
+    6: 'TIME_WAIT',
+    7: 'CLOSE',
+    8: 'CLOSE_WAIT',
+    9: 'LAST_ACK',
+    10: 'LISTEN',
+    11: 'CLOSING',
+}
+# Bounds so one description stays small: pollfd entries decoded, frames kept.
+_MAX_POLLFDS = 8
+_MAX_FRAMES = 16
+_POLLFD_SIZE = 8  # struct pollfd: int fd; short events; short revents
+# Sockets reported by one scan, and the time budget it may spend walking
+# /proc/<pid>/fd (a container with hundreds of processes takes tens of ms).
+_MAX_SCAN_RESULTS = 16
+_SCAN_TIME_BUDGET_SECONDS = 2.0
+# Linux ioctl numbers; SIOCINQ/SIOCOUTQ on sockets are FIONREAD/TIOCOUTQ.
+_FIONREAD = 0x541B
+_TIOCOUTQ = 0x5411
+
+
+def _read(path: str) -> Optional[str]:
+    try:
+        with open(path, 'r', encoding='utf-8', errors='replace') as fh:
+            return fh.read().strip()
+    except OSError:
+        return None
+
+
+def _read_own_memory(addr: int, size: int) -> Optional[bytes]:
+    """Read ``size`` bytes at ``addr`` in this process via /proc/self/mem.
+
+    Deliberately not ctypes: the address comes from another thread's
+    in-progress syscall and may be gone by the time we read; a bad address
+    here is an OSError, a bad ctypes read is a segfault.
+    """
+    try:
+        fd = os.open('/proc/self/mem', os.O_RDONLY)
+    except OSError:
+        return None
+    try:
+        return os.pread(fd, size, addr)
+    except (OSError, OverflowError):
+        return None
+    finally:
+        os.close(fd)
+
+
+def _format_addr(addr: Any) -> str:
+    """Render a sockaddr tuple (or unix path) as host:port."""
+    if isinstance(addr, tuple) and len(addr) >= 2:
+        host, port = addr[0], addr[1]
+        if ':' in str(host):
+            return f'[{host}]:{port}'
+        return f'{host}:{port}'
+    if isinstance(addr, (str, bytes)):
+        return repr(addr) if addr else '(unnamed)'
+    return repr(addr)
+
+
+def _queue_length(fd: int, request: int) -> Optional[int]:
+    try:
+        buf = fcntl.ioctl(fd, request, struct.pack('i', 0))
+        return struct.unpack('i', buf)[0]
+    except OSError:
+        return None
+
+
+def socket_info(fd: int) -> Optional[str]:
+    """Peer, state and queue lengths of the socket at ``fd``, or None.
+
+    Works on a ``dup`` of the descriptor so the socket object created here
+    never closes the caller's number. Constant cost; nothing is parsed.
+    Returns None when ``fd`` is not a socket (or cannot be inspected).
+    """
+    try:
+        dup = os.dup(fd)
+    except OSError:
+        return None
+    try:
+        try:
+            sock = socket.socket(fileno=dup)
+        except OSError:
+            # Not a socket (ENOTSOCK) or not inspectable. The constructor
+            # failed before taking ownership, so the dup is still ours.
+            os.close(dup)
+            return None
+        with sock:
+            parts: List[str] = []
+            if sock.family == socket.AF_INET:
+                parts.append('tcp' if sock.type == socket.
+                             SOCK_STREAM else f'inet type={int(sock.type)}')
+            elif sock.family == socket.AF_INET6:
+                parts.append('tcp6' if sock.type == socket.
+                             SOCK_STREAM else f'inet6 type={int(sock.type)}')
+            elif sock.family == socket.AF_UNIX:
+                parts.append('unix')
+            else:
+                parts.append(f'family={int(sock.family)}')
+            try:
+                parts.append(_format_addr(sock.getsockname()))
+            except OSError:
+                parts.append('?')
+            try:
+                parts.append('-> ' + _format_addr(sock.getpeername()))
+            except OSError:
+                parts.append('(not connected)')
+            if (sock.family in (socket.AF_INET, socket.AF_INET6) and
+                    sock.type == socket.SOCK_STREAM):
+                try:
+                    info = sock.getsockopt(socket.IPPROTO_TCP, socket.TCP_INFO,
+                                           8)
+                    state = info[0]
+                    parts.append(_TCP_STATES.get(state, f'state={state}'))
+                except OSError:
+                    pass
+            recv_q = _queue_length(dup, _FIONREAD)
+            send_q = _queue_length(dup, _TIOCOUTQ)
+            if recv_q is not None:
+                parts.append(f'recv-q={recv_q}')
+            if send_q is not None:
+                parts.append(f'send-q={send_q}')
+            return ' '.join(parts)
+    except Exception:  # pylint: disable=broad-except
+        return None
+
+
+def describe_fd(fd: int) -> str:
+    """What descriptor ``fd`` is right now, e.g. 'fd 12: socket:[123] tcp
+    127.0.0.1:5432 -> 127.0.0.1:6432 ESTABLISHED recv-q=0 send-q=0' or
+    'fd 12: not open in this process (Bad file descriptor)'."""
+    try:
+        target = os.readlink(f'/proc/self/fd/{fd}')
+    except OSError as e:
+        return f'fd {fd}: not open in this process ({e.strerror})'
+    if target.startswith('socket:['):
+        info = socket_info(fd)
+        if info is not None:
+            return f'fd {fd}: {target} {info}'
+    return f'fd {fd}: {target}'
+
+
+def kernel_view(native_tid: int) -> Dict[str, Any]:
+    """Scheduler state, wchan and current syscall (with fds) of a thread."""
+    base = f'/proc/self/task/{native_tid}'
+    view: Dict[str, Any] = {}
+    stat = _read(f'{base}/stat')
+    if stat:
+        # The state letter follows the parenthesised comm, which may itself
+        # contain spaces or parentheses.
+        end = stat.rfind(')')
+        if 0 <= end and end + 2 < len(stat):
+            view['state'] = stat[end + 2]
+    view['wchan'] = _read(f'{base}/wchan')
+    raw = _read(f'{base}/syscall')
+    if not raw:
+        return view
+    parts = raw.split()
+    try:
+        nr = int(parts[0])
+    except ValueError:
+        # 'running', or '-1 <sp> <pc>' for a thread blocked outside a syscall.
+        view['syscall'] = parts[0]
+        return view
+    name = _SYSCALLS.get(nr, f'syscall_{nr}')
+    view['syscall'] = name
+    try:
+        args = [int(x, 16) for x in parts[1:7]]
+    except ValueError:
+        return view
+    if len(args) < 3:
+        return view
+    fds: List[int] = []
+    if name in _FD_ARG0:
+        fds.append(args[0])
+    elif name in ('poll', 'ppoll'):
+        addr, nfds = args[0], args[1]
+        if name == 'poll':
+            timeout = args[2]
+            # poll(2) takes an int; -1 shows up as 0xffffffff (or
+            # sign-extended to 64 bits, depending on the kernel).
+            if timeout in (0xffffffff, 0xffffffffffffffff):
+                view['timeout'] = 'infinite'
+            else:
+                view['timeout'] = f'{timeout} ms'
+        else:
+            view['timeout'] = 'infinite' if args[2] == 0 else 'set'
+        n = min(nfds, _MAX_POLLFDS)
+        buf = _read_own_memory(addr, _POLLFD_SIZE * n) if n > 0 else None
+        if buf is not None and len(buf) == _POLLFD_SIZE * n:
+            entries = []
+            for i in range(n):
+                fd, events, revents = struct.unpack_from(
+                    'ihh', buf, _POLLFD_SIZE * i)
+                fds.append(fd)
+                entries.append(f'fd={fd} events={events:#x} '
+                               f'revents={revents:#x}')
+            view['pollfds'] = entries
+        else:
+            view['pollfds'] = f'{nfds} entries, unreadable'
+    view['fds'] = fds
+    return view
+
+
+def python_stack(thread: threading.Thread) -> List[str]:
+    """Innermost ``_MAX_FRAMES`` frames of ``thread`` as 'file:line name'."""
+    frame = None
+    if thread.ident is not None:
+        frame = sys._current_frames().get(thread.ident)  # pylint: disable=protected-access
+    if frame is None:
+        return ['<thread has no frame; it is not running>']
+    frames: List[traceback.FrameSummary] = list(traceback.extract_stack(frame))
+    dropped = len(frames) - _MAX_FRAMES
+    lines = []
+    if dropped > 0:
+        lines.append(f'... {dropped} outer frame(s) elided')
+        frames = frames[dropped:]
+    for fs in frames:
+        lines.append(f'{fs.filename}:{fs.lineno} {fs.name}')
+    return lines
+
+
+def describe(thread: threading.Thread,
+             age_seconds: float,
+             task: str = '',
+             deadline_seconds: Optional[float] = None) -> str:
+    """Multi-line description of a long-running thread.
+
+    The frame and the syscall say what kind of wait this is; they do not say
+    whether this thread is the one holding everyone else up. A thread that
+    blocks others (a connection whose reply was never read, say) and the
+    threads waiting on it can sit in the very same frame and syscall. Age
+    orders them: the blocker is necessarily older than the threads it
+    blocks, which is why callers describe threads oldest first.
+    """
+    header = (f'thread {thread.name!r} native_tid={thread.native_id} '
+              f'running {age_seconds:.1f}s')
+    if deadline_seconds is not None:
+        header += f' (limit {deadline_seconds:g}s)'
+    if task:
+        header += f' task={task}'
+    lines = [header]
+    try:
+        kv = kernel_view(thread.native_id) if thread.native_id else {}
+        kernel = (f'  kernel: state={kv.get("state")} '
+                  f'wchan={kv.get("wchan")} syscall={kv.get("syscall")}')
+        if 'timeout' in kv:
+            kernel += f' timeout={kv["timeout"]}'
+        if 'pollfds' in kv:
+            kernel += f' pollfds={kv["pollfds"]}'
+        lines.append(kernel)
+        for fd in kv.get('fds') or []:
+            lines.append('  ' + describe_fd(fd))
+    except Exception as e:  # pylint: disable=broad-except
+        lines.append(f'  kernel view unavailable: {e!r}')
+    try:
+        lines.append('  python stack (innermost last):')
+        lines.extend('    ' + l for l in python_stack(thread))
+    except Exception as e:  # pylint: disable=broad-except
+        lines.append(f'  python stack unavailable: {e!r}')
+    return '\n'.join(lines)
+
+
+def _hex_addr(hexaddr: str) -> str:
+    """Decode a /proc/net/tcp address ('0100007F:1920' -> '127.0.0.1:6432')."""
+    try:
+        ip, port = hexaddr.split(':')
+        if len(ip) == 8:
+            octets = bytes.fromhex(ip)[::-1]
+            return f'{".".join(str(b) for b in octets)}:{int(port, 16)}'
+        if len(ip) == 32:
+            # Four little-endian 32-bit words.
+            raw = b''.join(
+                bytes.fromhex(ip[i:i + 8])[::-1] for i in range(0, 32, 8))
+            return f'[{socket.inet_ntop(socket.AF_INET6, raw)}]:{int(port, 16)}'
+        return hexaddr
+    except (ValueError, OSError):
+        return hexaddr
+
+
+def _tcp_rows() -> List[Tuple[str, str, str, str, str]]:
+    """(local, remote, state, queues, inode) hex fields of every ESTABLISHED
+    or CLOSE_WAIT row in /proc/net/tcp{,6}. Fields stay undecoded; only the
+    few rows that get reported are decoded.
+
+    The kernel serves these files a page at a time and does not freeze the
+    table between pages, so a row can appear twice (or be missed) while
+    connections churn; rows are de-duplicated by inode. TIME_WAIT rows --
+    the bulk of the file on a host that opens and closes many connections --
+    are skipped before the split.
+    """
+    rows: List[Tuple[str, str, str, str, str]] = []
+    seen: Set[str] = set()
+    for path in ('/proc/net/tcp', '/proc/net/tcp6'):
+        text = _read(path)
+        if not text:
+            continue
+        for line in text.splitlines()[1:]:
+            if ' 01 ' not in line and ' 08 ' not in line:
+                continue
+            parts = line.split()
+            if len(parts) < 10:
+                continue
+            state, inode = parts[3], parts[9]
+            if state not in ('01', '08') or inode in seen:
+                continue
+            seen.add(inode)
+            rows.append((parts[1], parts[2], state, parts[4], inode))
+    return rows
+
+
+def _socket_inodes_by_process(
+        deadline: float) -> Tuple[Set[str], int, int, int, bool]:
+    """Socket inodes owned by every process whose /proc/<pid>/fd we can read.
+
+    Returns (inodes, readable processes, unreadable processes, descriptors
+    looked at, whether the walk finished within the deadline).
+    """
+    owned: Set[str] = set()
+    readable = unreadable = nfds = 0
+    complete = True
+    try:
+        pids = [p for p in os.listdir('/proc') if p.isdigit()]
+    except OSError:
+        return owned, 0, 0, 0, False
+    for pid in pids:
+        if time.monotonic() > deadline:
+            complete = False
+            break
+        try:
+            fds = os.listdir(f'/proc/{pid}/fd')
+        except OSError:
+            unreadable += 1
+            continue
+        readable += 1
+        for fd in fds:
+            nfds += 1
+            try:
+                target = os.readlink(f'/proc/{pid}/fd/{fd}')
+            except OSError:
+                continue
+            if target.startswith('socket:['):
+                owned.add(target[8:-1])
+    return owned, readable, unreadable, nfds, complete
+
+
+def _peer_hex_forms(peers: Iterable[Tuple[str, int]]) -> Set[str]:
+    """/proc/net/tcp 'rem_address' forms of (host, port) peers; hostnames are
+    resolved, every address of a name is included."""
+    out: Set[str] = set()
+    for host, port in peers:
+        try:
+            infos = socket.getaddrinfo(host, port, proto=socket.IPPROTO_TCP)
+        except (OSError, TypeError, ValueError):
+            continue
+        for family, _, _, _, sockaddr in infos:
+            try:
+                raw = socket.inet_pton(family, str(sockaddr[0]))
+            except (OSError, ValueError):
+                continue
+            # Little-endian 32-bit words, upper-case hex, like the kernel.
+            words = [
+                raw[i:i + 4][::-1].hex().upper() for i in range(0, len(raw), 4)
+            ]
+            out.add(f'{"".join(words)}:{port:04X}')
+            if family == socket.AF_INET:
+                # An IPv4 peer of an IPv6 socket appears in /proc/net/tcp6
+                # as a v4-mapped address.
+                mapped = ('0000000000000000' + 'FFFF0000' + words[0])
+                out.add(f'{mapped}:{port:04X}')
+    return out
+
+
+def scan_ownerless_sockets(extra_peers: Iterable[Tuple[str,
+                                                       int]] = ()) -> List[str]:
+    """List established TCP connections in this network namespace that no
+    process we can see owns, restricted to peers some visible process is
+    also connected to, plus ``extra_peers`` (host, port) the caller knows it
+    talks to -- typically the database, whose orphaned connections are the
+    ones that hold locks. Without ``extra_peers`` an orphan to a peer nobody
+    happens to be connected to at scan time goes unreported.
+
+    A descriptor number closed while another thread sleeps in ``poll`` on it
+    leaves the kernel socket alive with no descriptor pointing at it. The
+    per-thread dump cannot show that socket (it shows whatever now holds the
+    number), so this is the only in-process evidence of that failure, and
+    its ``recv-q`` tells whether the peer's reply arrived and was never read.
+
+    Restricting to known peers keeps another container's connections (a
+    sidecar in a shared pod namespace) out of the list, unless it talks to
+    the same peer. Processes whose
+    ``/proc/<pid>/fd`` is unreadable (another user) would also make their
+    sockets look ownerless; the summary line counts them so a reader can
+    weigh the result.
+
+    Costs one read of ``/proc/net/tcp`` plus a walk of every readable
+    ``/proc/<pid>/fd`` -- tens to a few hundred milliseconds on a busy pod --
+    so callers keep it rare. Returns log lines; the first is a summary.
+    """
+    started = time.monotonic()
+    try:
+        rows = _tcp_rows()
+        owned, readable, unreadable, nfds, complete = (
+            _socket_inodes_by_process(started + _SCAN_TIME_BUDGET_SECONDS))
+        peers = {rem for _, rem, _, _, ino in rows if ino in owned}
+        peers |= _peer_hex_forms(extra_peers)
+        suspects = [
+            row for row in rows
+            if row[4] != '0' and row[4] not in owned and row[1] in peers
+        ]
+        elapsed_ms = (time.monotonic() - started) * 1000
+        summary = (f'ownerless sockets: {len(suspects)} established/'
+                   f'close-wait connection(s) to a peer this host talks to '
+                   f'have no owner among {readable} readable process(es) '
+                   f'({unreadable} unreadable, {nfds} descriptors, '
+                   f'{len(rows)} connections, {elapsed_ms:.0f} ms')
+        if not complete:
+            summary += ', walk cut short by time budget'
+        summary += ')'
+        lines = [summary]
+        for local, rem, state, queues, ino in suspects[:_MAX_SCAN_RESULTS]:
+            try:
+                tx_q, rx_q = (int(x, 16) for x in queues.split(':'))
+            except ValueError:
+                tx_q = rx_q = -1
+            state_name = _TCP_STATES.get(int(state, 16), state)
+            lines.append(f'  socket:[{ino}] {_hex_addr(local)} -> '
+                         f'{_hex_addr(rem)} {state_name} recv-q={rx_q} '
+                         f'send-q={tx_q} owner=none')
+        if len(suspects) > _MAX_SCAN_RESULTS:
+            lines.append(f'  ... {len(suspects) - _MAX_SCAN_RESULTS} more')
+        return lines
+    except Exception as e:  # pylint: disable=broad-except
+        return [f'ownerless sockets: scan failed ({e!r})']

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -104,6 +104,12 @@ _REQUEST_THREADS_LIMIT = 128
 # point where the sheer number of threads in one process starts slowing its
 # request handling down.
 _AUTH_THREADS_LIMIT = 32
+# An auth lookup still running after this long is reported as stuck (see
+# OnDemandThreadExecutor.stuck_after_seconds). The callers give up on a
+# lookup after a few seconds (db_lookup.AUTH_DB_TIMEOUT_SECONDS, 5 s by
+# default), so a thread still running well past that is holding a slot for
+# work nobody is waiting for any more.
+_AUTH_THREAD_STUCK_SECONDS = 30.0
 
 # Max length of the retry reason in a request's backoff status message; the
 # reason comes from the exception message, so truncate to keep it readable.
@@ -157,7 +163,9 @@ def get_auth_thread_executor() -> threads.OnDemandThreadExecutor:
     with _AUTH_THREAD_EXECUTOR_LOCK:
         if _AUTH_THREAD_EXECUTOR is None:
             _AUTH_THREAD_EXECUTOR = threads.OnDemandThreadExecutor(
-                name='auth_thread_executor', max_workers=_AUTH_THREADS_LIMIT)
+                name='auth_thread_executor',
+                max_workers=_AUTH_THREADS_LIMIT,
+                stuck_after_seconds=_AUTH_THREAD_STUCK_SECONDS)
         return _AUTH_THREAD_EXECUTOR
 
 

--- a/sky/server/requests/threads.py
+++ b/sky/server/requests/threads.py
@@ -2,17 +2,24 @@
 
 import asyncio
 import concurrent.futures
+import itertools
 import os
 import sys
 import threading
-from typing import Callable, Optional, Set, TypeVar
+import time
+from typing import (Callable, Dict, FrozenSet, List, NamedTuple, Optional,
+                    Tuple, TypeVar)
+import urllib.parse
+import weakref
 
 import prometheus_client as prom
 
 from sky import exceptions
 from sky import sky_logging
 from sky.metrics import utils as metrics_utils
+from sky.server import hung_threads
 from sky.utils import atomic
+from sky.utils.db import db_utils
 
 # pylint: disable=ungrouped-imports
 if sys.version_info >= (3, 10):
@@ -24,6 +31,115 @@ _P = ParamSpec('_P')
 _T = TypeVar('_T')
 
 logger = sky_logging.init_logger(__name__)
+
+# How often the per-process watchdog refreshes the stuck/oldest-age metrics
+# of every executor and looks for threads past their executor's threshold.
+_WATCHDOG_INTERVAL_SECONDS = 10.0
+# Thread dumps are written when the set of stuck threads changes (a new
+# thread crossed the threshold) or when an exhausted executor's slots are
+# held by a set not yet reported, never more often than the minimum interval
+# per executor. While nothing changes, a heartbeat dump repeats the picture
+# at intervals that double from the minimum up to the maximum, so a thread
+# pinned for a day costs a handful of dumps rather than one per minute.
+_DUMP_MIN_INTERVAL_SECONDS = 60.0
+_DUMP_MAX_INTERVAL_SECONDS = 3600.0
+# Full descriptions (stack + kernel view) are written for at most this many
+# threads per dump, oldest first; the rest are counted. Keeps one dump to a
+# few tens of KB even for an executor with hundreds of workers.
+_MAX_DESCRIBED_THREADS = 8
+# The ownerless-socket scan reads /proc/net/tcp and walks every readable
+# /proc/<pid>/fd; it runs at most this often per process, and only as part
+# of a dump. It is the only in-process evidence of a descriptor closed under
+# a sleeping thread (see hung_threads.scan_ownerless_sockets).
+_SCAN_INTERVAL_SECONDS = 300.0
+
+_executors: 'weakref.WeakSet[OnDemandThreadExecutor]' = weakref.WeakSet()
+_watchdog_lock = threading.Lock()
+_watchdog_pid: Optional[int] = None
+_scan_lock = threading.Lock()
+_last_scan: float = float('-inf')
+_db_peers: Optional[List[Tuple[str, int]]] = None
+
+
+def _ensure_watchdog() -> None:
+    """Start the per-process watchdog thread once (again after a fork)."""
+    global _watchdog_pid
+    pid = os.getpid()
+    with _watchdog_lock:
+        if _watchdog_pid == pid:
+            return
+        _watchdog_pid = pid
+        threading.Thread(target=_watchdog_loop,
+                         name='thread-executor-watchdog',
+                         daemon=True).start()
+
+
+def _watchdog_loop() -> None:
+    while True:
+        time.sleep(_WATCHDOG_INTERVAL_SECONDS)
+        for executor in list(_executors):
+            try:
+                executor.observe()
+            except Exception as e:  # pylint: disable=broad-except
+                logger.debug(f'Executor [{executor.name}] watchdog: {e!r}')
+
+
+def _state_db_peers() -> List[Tuple[str, int]]:
+    """(host, port) of the state database as this process reaches it: the
+    pooler if one is configured, and the database itself. A connection to
+    one of these that no process owns any more is exactly what a stray close
+    under a sleeping database call leaves behind, and it can hold locks."""
+    global _db_peers
+    if _db_peers is None:
+        peers: List[Tuple[str, int]] = []
+        for direct in (False, True):
+            try:
+                # pylint: disable-next=protected-access
+                conn_string = db_utils._resolve_conn_string(direct)
+                if not conn_string:
+                    continue
+                parts = urllib.parse.urlsplit(conn_string)
+                if parts.hostname:
+                    peers.append((parts.hostname, parts.port or 5432))
+            except Exception:  # pylint: disable=broad-except
+                continue
+        _db_peers = peers
+    return _db_peers
+
+
+def _maybe_scan_ownerless_sockets() -> List[str]:
+    """Run the ownerless-socket scan if none ran recently in this process."""
+    global _last_scan
+    now = time.monotonic()
+    with _scan_lock:
+        if now - _last_scan < _SCAN_INTERVAL_SECONDS:
+            return []
+        _last_scan = now
+    return hung_threads.scan_ownerless_sockets(_state_db_peers())
+
+
+_task_seq = itertools.count(1)
+
+
+class _Task(NamedTuple):
+    started: float
+    deadline: Optional[float]
+    name: str
+    # Process-wide unique. Thread identifiers (pthread_t) are reused as soon
+    # as a thread exits, so they cannot tell "the same threads are still
+    # stuck" from "different threads are stuck now".
+    seq: int
+
+
+class _RunningTask(NamedTuple):
+    age: float
+    thread: threading.Thread
+    task: _Task
+
+    @property
+    def over_deadline(self) -> bool:
+        return (self.task.deadline is not None and
+                time.monotonic() > self.task.deadline)
 
 
 class OnDemandThreadExecutor(concurrent.futures.Executor):
@@ -42,18 +158,49 @@ class OnDemandThreadExecutor(concurrent.futures.Executor):
     need to support configuring the queuing behavior (exception or queueing).
     """
 
-    def __init__(self, name: str, max_workers: int):
+    def __init__(self,
+                 name: str,
+                 max_workers: int,
+                 stuck_after_seconds: Optional[float] = None):
+        """Create an executor.
+
+        Args:
+            name: Executor name, used in thread names, logs and metrics.
+            max_workers: Concurrent tasks allowed; further submits raise.
+            stuck_after_seconds: A task still running after this long is
+                reported as stuck: counted in
+                ``sky_apiserver_threads_stuck`` and described (Python stack
+                plus the syscall it sleeps in) in the log. Set it for pools
+                whose tasks have a known short bound, such as the auth
+                lookups; leave None for pools where a task may legitimately
+                run for hours (a log stream), in which case only the
+                exhaustion dump reports the oldest tasks.
+        """
         self.name: str = name
         self.max_workers: int = max_workers
+        self.stuck_after_seconds: Optional[float] = stuck_after_seconds
         self.running: atomic.AtomicInt = atomic.AtomicInt(0)
         self._shutdown: bool = False
         self._shutdown_lock: threading.Lock = threading.Lock()
-        self._threads: Set[threading.Thread] = set()
+        # Running thread -> its task (start time, deadline, name). The start
+        # time is what lets the watchdog and the exhaustion path tell a
+        # thread that is merely busy from one that never came back.
+        self._threads: Dict[threading.Thread, _Task] = {}
         self._threads_lock: threading.Lock = threading.Lock()
+        # Dump bookkeeping, guarded by _dump_lock: when the last dump was
+        # written, which stuck threads it covered, the current heartbeat
+        # interval, and which set the last exhaustion dump covered.
+        self._dump_lock: threading.Lock = threading.Lock()
+        self._last_dump: float = float('-inf')
+        self._dumped_stuck: FrozenSet[int] = frozenset()
+        self._dumped_exhausted: FrozenSet[int] = frozenset()
+        self._heartbeat_interval: float = _DUMP_MIN_INTERVAL_SECONDS
         # Cache the labeled metric children to avoid the label lookup on
         # every submit/complete.
         self._active_gauge: Optional[prom.Gauge] = None
         self._exhausted_counter: Optional[prom.Counter] = None
+        self._stuck_gauge: Optional[prom.Gauge] = None
+        self._oldest_age_gauge: Optional[prom.Gauge] = None
         if metrics_utils.METRICS_ENABLED:
             pid = os.getpid()
             self._active_gauge = (
@@ -64,10 +211,147 @@ class OnDemandThreadExecutor(concurrent.futures.Executor):
                     name=name))
             metrics_utils.SKY_APISERVER_THREADS_MAX.labels(
                 pid=pid, name=name).set(max_workers)
+            self._stuck_gauge = (
+                metrics_utils.SKY_APISERVER_THREADS_STUCK.labels(pid=pid,
+                                                                 name=name))
+            self._oldest_age_gauge = (
+                metrics_utils.SKY_APISERVER_THREADS_OLDEST_AGE_SECONDS.labels(
+                    pid=pid, name=name))
+        _executors.add(self)
+        _ensure_watchdog()
 
     def _cleanup_thread(self, thread: threading.Thread):
         with self._threads_lock:
-            self._threads.discard(thread)
+            self._threads.pop(thread, None)
+
+    def _snapshot(self) -> List[_RunningTask]:
+        """Every running task, oldest first.
+
+        Threads that are no longer alive are dropped: after a fork the child
+        inherits the parent's table but none of its threads.
+        """
+        now = time.monotonic()
+        items: List[_RunningTask] = []
+        with self._threads_lock:
+            dead = [t for t in self._threads if not t.is_alive()]
+            for t in dead:
+                del self._threads[t]
+            for thread, task in self._threads.items():
+                items.append(_RunningTask(now - task.started, thread, task))
+        items.sort(key=lambda item: item.age, reverse=True)
+        return items
+
+    @staticmethod
+    def _stuck(snapshot: List[_RunningTask]) -> List[_RunningTask]:
+        return [item for item in snapshot if item.over_deadline]
+
+    @staticmethod
+    def _keys(items: List[_RunningTask]) -> FrozenSet[int]:
+        return frozenset(item.task.seq for item in items)
+
+    def observe(self) -> Tuple[int, float]:
+        """Refresh the stuck/oldest-age metrics; dump stuck threads.
+
+        Called by the per-process watchdog every _WATCHDOG_INTERVAL_SECONDS.
+        Returns (stuck thread count, oldest running task age in seconds).
+        """
+        snapshot = self._snapshot()
+        oldest = snapshot[0].age if snapshot else 0.0
+        stuck = self._stuck(snapshot)
+        if self._stuck_gauge is not None:
+            self._stuck_gauge.set(len(stuck))
+        if self._oldest_age_gauge is not None:
+            self._oldest_age_gauge.set(oldest)
+        if stuck:
+            self._dump_if_due(
+                snapshot,
+                stuck,
+                reason=(f'{len(stuck)} thread(s) running longer than '
+                        f'{self.stuck_after_seconds:g}s'))
+        else:
+            with self._dump_lock:
+                self._dumped_stuck = frozenset()
+                self._heartbeat_interval = _DUMP_MIN_INTERVAL_SECONDS
+        return len(stuck), oldest
+
+    def _dump_if_due(self, snapshot: List[_RunningTask],
+                     stuck: List[_RunningTask], reason: str) -> bool:
+        """Watchdog path: dump when a thread newly crossed the threshold, or
+        when the heartbeat interval elapsed with the same threads stuck."""
+        now = time.monotonic()
+        keys = self._keys(stuck)
+        with self._dump_lock:
+            since_last = now - self._last_dump
+            if since_last < _DUMP_MIN_INTERVAL_SECONDS:
+                return False
+            if keys - self._dumped_stuck:
+                self._heartbeat_interval = _DUMP_MIN_INTERVAL_SECONDS
+            elif since_last < self._heartbeat_interval:
+                return False
+            else:
+                self._heartbeat_interval = min(self._heartbeat_interval * 2,
+                                               _DUMP_MAX_INTERVAL_SECONDS)
+                reason += (f' (unchanged for {since_last:.0f}s; next report '
+                           f'in {self._heartbeat_interval:.0f}s)')
+            self._last_dump = now
+            self._dumped_stuck = keys
+        self._dump(snapshot, stuck, reason)
+        return True
+
+    def _dump(self, snapshot: List[_RunningTask], describe: List[_RunningTask],
+              reason: str) -> None:
+        """Log what the longest-running threads are doing."""
+        to_describe = (describe or snapshot)[:_MAX_DESCRIBED_THREADS]
+        parts = [
+            f'Executor [{self.name}]: {reason}; {len(snapshot)} of '
+            f'{self.max_workers} workers running, describing the '
+            f'{len(to_describe)} longest-running (oldest first):'
+        ]
+        for item in to_describe:
+            parts.append(
+                hung_threads.describe(
+                    item.thread,
+                    item.age,
+                    item.task.name,
+                    deadline_seconds=self.stuck_after_seconds))
+        parts.extend(_maybe_scan_ownerless_sockets())
+        logger.warning('\n'.join(parts))
+
+    def _dump_on_exhaustion(self) -> None:
+        """Exhaustion path: describe the threads holding the slots.
+
+        Runs in its own short-lived thread so the rejected caller (often the
+        event loop) is not held for the /proc reads. A saturated executor
+        rejects every submit, so this dumps only when the threads holding
+        the slots (the stuck ones, or the oldest if the executor has no
+        threshold) differ from the last exhaustion dump, and never more than
+        once per _DUMP_MIN_INTERVAL_SECONDS. The watchdog heartbeat keeps
+        repeating an unchanged picture at its backed-off interval.
+        """
+        if time.monotonic() - self._last_dump < _DUMP_MIN_INTERVAL_SECONDS:
+            return
+
+        def _dump():
+            try:
+                snapshot = self._snapshot()
+                stuck = self._stuck(snapshot)
+                holders = stuck or snapshot[:_MAX_DESCRIBED_THREADS]
+                keys = self._keys(holders)
+                now = time.monotonic()
+                with self._dump_lock:
+                    if (now - self._last_dump < _DUMP_MIN_INTERVAL_SECONDS or
+                            keys == self._dumped_exhausted):
+                        return
+                    self._last_dump = now
+                    self._dumped_exhausted = keys
+                    self._dumped_stuck = self._keys(stuck)
+                self._dump(snapshot, stuck, 'all workers busy, submit rejected')
+            except Exception as e:  # pylint: disable=broad-except
+                logger.debug(f'Executor [{self.name}] dump failed: {e!r}')
+
+        threading.Thread(target=_dump,
+                         name=f'{self.name}-exhaustion-dump',
+                         daemon=True).start()
 
     def _task_wrapper(self, fn: Callable, fut: concurrent.futures.Future, /,
                       *args, **kwargs):
@@ -120,6 +404,7 @@ class OnDemandThreadExecutor(concurrent.futures.Executor):
             self.running.decrement()
             if self._exhausted_counter is not None:
                 self._exhausted_counter.inc()
+            self._dump_on_exhaustion()
             raise exceptions.ConcurrentWorkerExhaustedError(
                 f'Maximum concurrent workers {self.max_workers} of threads '
                 f'executor [{self.name}] reached')
@@ -143,8 +428,13 @@ class OnDemandThreadExecutor(concurrent.futures.Executor):
                                       args=(fn, fut, *args),
                                       kwargs=kwargs,
                                       daemon=True)
+            started = time.monotonic()
+            deadline = (None if self.stuck_after_seconds is None else started +
+                        self.stuck_after_seconds)
             with self._threads_lock:
-                self._threads.add(thread)
+                self._threads[thread] = _Task(started, deadline,
+                                              _describe_task(fn),
+                                              next(_task_seq))
             try:
                 thread.start()
             except Exception as e:
@@ -169,3 +459,27 @@ class OnDemandThreadExecutor(concurrent.futures.Executor):
             threads = list(self._threads)
         for t in threads:
             t.join()
+
+
+def _describe_task(fn: Callable) -> str:
+    """Short name of a submitted callable for the dumps.
+
+    ``to_thread_with_executor`` wraps everything in
+    ``functools.partial(contextvars.Context.run, func, ...)``; unwrap that so
+    the dump names the function that was actually submitted.
+    """
+    seen = 0
+    while seen < 4:
+        seen += 1
+        args = getattr(fn, 'args', None)
+        inner = getattr(fn, 'func', None)
+        if inner is None:
+            break
+        if getattr(inner, '__name__', '') == 'run' and args:
+            fn = args[0]
+            continue
+        fn = inner
+    module = getattr(fn, '__module__', None) or ''
+    name = getattr(fn, '__qualname__', None) or getattr(fn, '__name__',
+                                                        None) or repr(fn)
+    return f'{module}.{name}' if module else name

--- a/sky/server/requests/threads.py
+++ b/sky/server/requests/threads.py
@@ -52,7 +52,15 @@ _MAX_DESCRIBED_THREADS = 8
 # of a dump. It is the only in-process evidence of a descriptor closed under
 # a sleeping thread (see hung_threads.scan_ownerless_sockets).
 _SCAN_INTERVAL_SECONDS = 300.0
+# A saturated executor rejects every submit. The exhaustion path starts a
+# short-lived dump thread to look at the slot holders, at most this often
+# per executor, so a storm of rejections costs the rejecting thread (often
+# the event loop) one thread start per second rather than one per reject.
+_EXHAUSTION_CHECK_INTERVAL_SECONDS = 1.0
 
+# Executors of this process, watched by the watchdog thread. Registration
+# and the watchdog's copy of the set both take _watchdog_lock: a WeakSet
+# raises RuntimeError when it changes size while being iterated.
 _executors: 'weakref.WeakSet[OnDemandThreadExecutor]' = weakref.WeakSet()
 _watchdog_lock = threading.Lock()
 _watchdog_pid: Optional[int] = None
@@ -61,11 +69,13 @@ _last_scan: float = float('-inf')
 _db_peers: Optional[List[Tuple[str, int]]] = None
 
 
-def _ensure_watchdog() -> None:
-    """Start the per-process watchdog thread once (again after a fork)."""
+def _register(executor: 'OnDemandThreadExecutor') -> None:
+    """Add an executor to the watched set and start the per-process watchdog
+    thread the first time (again after a fork)."""
     global _watchdog_pid
     pid = os.getpid()
     with _watchdog_lock:
+        _executors.add(executor)
         if _watchdog_pid == pid:
             return
         _watchdog_pid = pid
@@ -75,13 +85,30 @@ def _ensure_watchdog() -> None:
 
 
 def _watchdog_loop() -> None:
+    """Observe every executor, forever. Nothing that happens in one tick may
+    end this thread: it is what reports a stuck process, and _register never
+    starts a second one for the same process."""
     while True:
         time.sleep(_WATCHDOG_INTERVAL_SECONDS)
-        for executor in list(_executors):
-            try:
-                executor.observe()
-            except Exception as e:  # pylint: disable=broad-except
-                logger.debug(f'Executor [{executor.name}] watchdog: {e!r}')
+        try:
+            _watchdog_tick()
+        except Exception as e:  # pylint: disable=broad-except
+            logger.debug(f'Thread executor watchdog tick failed: {e!r}')
+
+
+def _watchdog_tick() -> None:
+    """One pass over the executors of this process."""
+    with _watchdog_lock:
+        # Registration takes the same lock, so an executor being built on
+        # another thread cannot change the set while it is copied. An
+        # executor garbage collected on another thread at this moment can
+        # still make the copy raise; the loop tolerates that.
+        executors = list(_executors)
+    for executor in executors:
+        try:
+            executor.observe()
+        except Exception as e:  # pylint: disable=broad-except
+            logger.debug(f'Executor [{executor.name}] watchdog: {e!r}')
 
 
 def _state_db_peers() -> List[Tuple[str, int]]:
@@ -138,8 +165,9 @@ class _RunningTask(NamedTuple):
 
     @property
     def over_deadline(self) -> bool:
+        # started + age is the clock reading the snapshot was taken at.
         return (self.task.deadline is not None and
-                time.monotonic() > self.task.deadline)
+                self.task.started + self.age > self.task.deadline)
 
 
 class OnDemandThreadExecutor(concurrent.futures.Executor):
@@ -195,6 +223,10 @@ class OnDemandThreadExecutor(concurrent.futures.Executor):
         self._dumped_stuck: FrozenSet[int] = frozenset()
         self._dumped_exhausted: FrozenSet[int] = frozenset()
         self._heartbeat_interval: float = _DUMP_MIN_INTERVAL_SECONDS
+        # When the exhaustion path last started a dump thread. Read and
+        # written without a lock: two rejects in the same instant may both
+        # start one, which the dump's own lock then reconciles.
+        self._last_exhaustion_check: float = float('-inf')
         # Cache the labeled metric children to avoid the label lookup on
         # every submit/complete.
         self._active_gauge: Optional[prom.Gauge] = None
@@ -217,8 +249,7 @@ class OnDemandThreadExecutor(concurrent.futures.Executor):
             self._oldest_age_gauge = (
                 metrics_utils.SKY_APISERVER_THREADS_OLDEST_AGE_SECONDS.labels(
                     pid=pid, name=name))
-        _executors.add(self)
-        _ensure_watchdog()
+        _register(self)
 
     def _cleanup_thread(self, thread: threading.Thread):
         with self._threads_lock:
@@ -227,13 +258,19 @@ class OnDemandThreadExecutor(concurrent.futures.Executor):
     def _snapshot(self) -> List[_RunningTask]:
         """Every running task, oldest first.
 
-        Threads that are no longer alive are dropped: after a fork the child
-        inherits the parent's table but none of its threads.
+        Threads that ran and exited are dropped: after a fork the child
+        inherits the parent's table but none of its threads. A thread that
+        is registered but not started yet (submit() inserts it, then starts
+        it) also reports is_alive() False; it has no ident until it starts,
+        and it must stay, or its task would never be tracked.
         """
         now = time.monotonic()
         items: List[_RunningTask] = []
         with self._threads_lock:
-            dead = [t for t in self._threads if not t.is_alive()]
+            dead = [
+                t for t in self._threads
+                if t.ident is not None and not t.is_alive()
+            ]
             for t in dead:
                 del self._threads[t]
             for thread, task in self._threads.items():
@@ -325,11 +362,20 @@ class OnDemandThreadExecutor(concurrent.futures.Executor):
         rejects every submit, so this dumps only when the threads holding
         the slots (the stuck ones, or the oldest if the executor has no
         threshold) differ from the last exhaustion dump, and never more than
-        once per _DUMP_MIN_INTERVAL_SECONDS. The watchdog heartbeat keeps
-        repeating an unchanged picture at its backed-off interval.
+        once per _DUMP_MIN_INTERVAL_SECONDS; the dump thread itself is
+        started at most once per _EXHAUSTION_CHECK_INTERVAL_SECONDS. The
+        watchdog heartbeat keeps repeating an unchanged picture at its
+        backed-off interval. For an executor without a threshold the slot
+        holders are merely the oldest tasks of a busy pool; describing them
+        once per distinct set is still cheaper than the per-request error
+        the caller logs.
         """
-        if time.monotonic() - self._last_dump < _DUMP_MIN_INTERVAL_SECONDS:
+        now = time.monotonic()
+        if (now - self._last_dump < _DUMP_MIN_INTERVAL_SECONDS or
+                now - self._last_exhaustion_check <
+                _EXHAUSTION_CHECK_INTERVAL_SECONDS):
             return
+        self._last_exhaustion_check = now
 
         def _dump():
             try:

--- a/sky/server/requests/threads.py
+++ b/sky/server/requests/threads.py
@@ -66,22 +66,32 @@ _watchdog_lock = threading.Lock()
 _watchdog_pid: Optional[int] = None
 _scan_lock = threading.Lock()
 _last_scan: float = float('-inf')
-_db_peers: Optional[List[Tuple[str, int]]] = None
+_db_peers: Optional['_DbPeers'] = None
 
 
 def _register(executor: 'OnDemandThreadExecutor') -> None:
     """Add an executor to the watched set and start the per-process watchdog
-    thread the first time (again after a fork)."""
+    thread the first time (again after a fork).
+
+    Building an executor must not fail because the process cannot start one
+    more thread: if the watchdog cannot be started, the executors stay
+    unwatched and the next registration tries again.
+    """
     global _watchdog_pid
     pid = os.getpid()
     with _watchdog_lock:
         _executors.add(executor)
         if _watchdog_pid == pid:
             return
+        try:
+            threading.Thread(target=_watchdog_loop,
+                             name='thread-executor-watchdog',
+                             daemon=True).start()
+        except Exception as e:  # pylint: disable=broad-except
+            logger.debug(
+                f'Thread executor watchdog could not be started: {e!r}')
+            return
         _watchdog_pid = pid
-        threading.Thread(target=_watchdog_loop,
-                         name='thread-executor-watchdog',
-                         daemon=True).start()
 
 
 def _watchdog_loop() -> None:
@@ -111,14 +121,33 @@ def _watchdog_tick() -> None:
             logger.debug(f'Executor [{executor.name}] watchdog: {e!r}')
 
 
-def _state_db_peers() -> List[Tuple[str, int]]:
-    """(host, port) of the state database as this process reaches it: the
-    pooler if one is configured, and the database itself. A connection to
-    one of these that no process owns any more is exactly what a stray close
-    under a sleeping database call leaves behind, and it can hold locks."""
+class _DbPeers(NamedTuple):
+    # (host, port) the ownerless-socket scan looks at, and ones it must not.
+    scan: List[Tuple[str, int]]
+    skip: List[Tuple[str, int]]
+
+
+def _state_db_peers() -> _DbPeers:
+    """Where this process reaches the state database, for the scan.
+
+    ``scan`` is the endpoint the process connects to for state-database
+    work: the pooler when one is configured, else the database itself. A
+    connection to it that no process owns any more is what a stray close
+    under a sleeping database call leaves behind, and it can hold locks.
+
+    ``skip`` is the database behind a pooler. The process opens a few
+    connections to it directly (session-level advisory locks), but a
+    sidecar pooler's server connections go to the same endpoint from
+    another process namespace of the same network namespace, so every one
+    of them would look ownerless from here: up to the pooler's pool size of
+    false positives per scan, whether the endpoint is named or picked up
+    from a direct connection open at scan time. The scan leaves it out, so
+    an orphaned direct connection is not reported when a pooler is
+    configured; the pooled path carries the request-time database calls.
+    """
     global _db_peers
     if _db_peers is None:
-        peers: List[Tuple[str, int]] = []
+        endpoints: Dict[bool, Tuple[str, int]] = {}
         for direct in (False, True):
             try:
                 # pylint: disable-next=protected-access
@@ -127,10 +156,16 @@ def _state_db_peers() -> List[Tuple[str, int]]:
                     continue
                 parts = urllib.parse.urlsplit(conn_string)
                 if parts.hostname:
-                    peers.append((parts.hostname, parts.port or 5432))
+                    endpoints[direct] = (parts.hostname, parts.port or 5432)
             except Exception:  # pylint: disable=broad-except
                 continue
-        _db_peers = peers
+        pooled = endpoints.get(False)
+        direct_endpoint = endpoints.get(True)
+        scan = [pooled] if pooled is not None else []
+        # Without a pooler both strings are the same URI: nothing to skip.
+        skip = ([direct_endpoint] if direct_endpoint is not None and
+                direct_endpoint != pooled else [])
+        _db_peers = _DbPeers(scan, skip)
     return _db_peers
 
 
@@ -142,7 +177,9 @@ def _maybe_scan_ownerless_sockets() -> List[str]:
         if now - _last_scan < _SCAN_INTERVAL_SECONDS:
             return []
         _last_scan = now
-    return hung_threads.scan_ownerless_sockets(_state_db_peers())
+    peers = _state_db_peers()
+    return hung_threads.scan_ownerless_sockets(peers.scan,
+                                               exclude_peers=peers.skip)
 
 
 _task_seq = itertools.count(1)
@@ -369,6 +406,11 @@ class OnDemandThreadExecutor(concurrent.futures.Executor):
         holders are merely the oldest tasks of a busy pool; describing them
         once per distinct set is still cheaper than the per-request error
         the caller logs.
+
+        A process at its thread limit cannot start the dump thread. That
+        costs the dump, nothing else: the caller still gets the executor's
+        own ConcurrentWorkerExhaustedError, which is what the submit sites
+        handle.
         """
         now = time.monotonic()
         if (now - self._last_dump < _DUMP_MIN_INTERVAL_SECONDS or
@@ -395,9 +437,14 @@ class OnDemandThreadExecutor(concurrent.futures.Executor):
             except Exception as e:  # pylint: disable=broad-except
                 logger.debug(f'Executor [{self.name}] dump failed: {e!r}')
 
-        threading.Thread(target=_dump,
-                         name=f'{self.name}-exhaustion-dump',
-                         daemon=True).start()
+        try:
+            threading.Thread(target=_dump,
+                             name=f'{self.name}-exhaustion-dump',
+                             daemon=True).start()
+        except Exception as e:  # pylint: disable=broad-except
+            logger.debug(
+                f'Executor [{self.name}] could not start the dump thread: '
+                f'{e!r}')
 
     def _task_wrapper(self, fn: Callable, fut: concurrent.futures.Future, /,
                       *args, **kwargs):

--- a/tests/unit_tests/test_sky/server/requests/test_executor.py
+++ b/tests/unit_tests/test_sky/server/requests/test_executor.py
@@ -1851,6 +1851,22 @@ def test_auth_and_request_executors_are_distinct():
         _reset_thread_executors()
 
 
+def test_auth_executor_reports_stuck_threads_after_thirty_seconds():
+    """The auth pool is the one production pool with a stuck threshold: its
+    callers give up after a few seconds, so a thread still running at 30 s
+    is holding a slot for nobody. The request pool has none (streams run
+    for hours)."""
+    _reset_thread_executors()
+    try:
+        auth_executor = executor.get_auth_thread_executor()
+        assert auth_executor.max_workers == executor._AUTH_THREADS_LIMIT  # pylint: disable=protected-access
+        assert auth_executor.stuck_after_seconds == 30.0
+        assert executor.get_request_thread_executor(
+        ).stuck_after_seconds is None
+    finally:
+        _reset_thread_executors()
+
+
 def test_saturating_request_executor_does_not_block_auth():
     """The point of the split: streaming work filling the request executor
     must not make authentication fail.

--- a/tests/unit_tests/test_sky/server/requests/test_threads.py
+++ b/tests/unit_tests/test_sky/server/requests/test_threads.py
@@ -239,7 +239,7 @@ def _fake_clock(monkeypatch):
     monkeypatch.setattr(threads_mod, 'time', clock)
     # No ownerless-socket scan in these tests (covered in test_hung_threads).
     monkeypatch.setattr(threads_mod, '_last_scan', float('inf'))
-    monkeypatch.setattr(threads_mod, '_db_peers', [])
+    monkeypatch.setattr(threads_mod, '_db_peers', threads_mod._DbPeers([], []))  # pylint: disable=protected-access
     return clock
 
 
@@ -499,10 +499,13 @@ def test_exhaustion_dump_only_when_slot_holders_change(monkeypatch):
 def test_dump_includes_rate_limited_ownerless_socket_scan(monkeypatch):
     clock = _fake_clock(monkeypatch)
     monkeypatch.setattr(threads_mod, '_last_scan', float('-inf'))
+    pooler, database = ('127.0.0.1', 6432), ('db.example.internal', 5432)
+    monkeypatch.setattr(threads_mod, '_db_peers',
+                        threads_mod._DbPeers([pooler], [database]))  # pylint: disable=protected-access
     calls = []
 
-    def fake_scan(extra_peers=()):
-        calls.append((clock.now, list(extra_peers)))
+    def fake_scan(extra_peers=(), exclude_peers=()):
+        calls.append((clock.now, list(extra_peers), list(exclude_peers)))
         return ['ownerless sockets: 1 ...', '  socket:[1] a -> b']
 
     monkeypatch.setattr(hung_threads, 'scan_ownerless_sockets', fake_scan)
@@ -516,7 +519,8 @@ def test_dump_includes_rate_limited_ownerless_socket_scan(monkeypatch):
         clock.now += 2
         executor.observe()
         assert len(messages) == 1 and 'ownerless sockets: 1' in messages[0]
-        assert calls == [(1002.0, [])]
+        # The scan looks at the pooler and leaves the database behind it out.
+        assert calls == [(1002.0, [pooler], [database])]
         # A second dump inside the scan interval carries no scan.
         executor.submit(blocking_task, release_b)
         clock.now += 61
@@ -536,19 +540,111 @@ def test_dump_includes_rate_limited_ownerless_socket_scan(monkeypatch):
 
 
 def test_state_db_peers_from_environment(monkeypatch):
+    """The scan looks at the endpoint this process connects to for state
+    database work and leaves the database behind a pooler out: a sidecar
+    pooler's own connections to it live in another process namespace and
+    would all be reported as ownerless."""
+    # pylint: disable=protected-access
     from sky.skylet import constants  # pylint: disable=import-outside-toplevel
-    monkeypatch.setattr(threads_mod, '_db_peers', None)
+    database = ('db.example.internal', 5433)
     monkeypatch.setenv(constants.ENV_VAR_IS_SKYPILOT_SERVER, '1')
     monkeypatch.setenv(constants.ENV_VAR_DB_CONNECTION_URI,
                        'postgresql://u:p@db.example.internal:5433/sky')
+
+    # Pooler as host:port rewrite (the sidecar case).
+    monkeypatch.setattr(threads_mod, '_db_peers', None)
     monkeypatch.setenv(constants.ENV_VAR_DB_POOL_HOSTPORT, '127.0.0.1:6432')
-    assert threads_mod._state_db_peers() == [  # pylint: disable=protected-access
-        ('127.0.0.1', 6432), ('db.example.internal', 5433)
-    ]
+    peers = threads_mod._state_db_peers()
+    assert peers.scan == [('127.0.0.1', 6432)]
+    assert peers.skip == [database]
+
+    # Pooler as a full connection URI.
+    monkeypatch.setattr(threads_mod, '_db_peers', None)
+    monkeypatch.delenv(constants.ENV_VAR_DB_POOL_HOSTPORT)
+    monkeypatch.setenv(constants.ENV_VAR_DB_POOL_CONNECTION_URI,
+                       'postgresql://u:p@pooler.example.internal:6432/sky')
+    peers = threads_mod._state_db_peers()
+    assert peers.scan == [('pooler.example.internal', 6432)]
+    assert peers.skip == [database]
+
+    # No pooler: the database itself is scanned, nothing is skipped.
+    monkeypatch.setattr(threads_mod, '_db_peers', None)
+    monkeypatch.delenv(constants.ENV_VAR_DB_POOL_CONNECTION_URI)
+    peers = threads_mod._state_db_peers()
+    assert peers.scan == [database]
+    assert peers.skip == []
+
+    # No database configured (SQLite): nothing to scan.
     monkeypatch.setattr(threads_mod, '_db_peers', None)
     monkeypatch.delenv(constants.ENV_VAR_DB_CONNECTION_URI)
-    assert threads_mod._state_db_peers() == []  # pylint: disable=protected-access
+    assert threads_mod._state_db_peers() == threads_mod._DbPeers([], [])
     monkeypatch.setattr(threads_mod, '_db_peers', None)
+
+
+def test_saturated_submit_raises_exhausted_when_dump_thread_cannot_start(
+        monkeypatch):
+    """The exhaustion dump runs in a thread of its own. A process at its
+    thread limit cannot start it; the caller must still get the executor's
+    own saturation error, which is what every submit site handles, and not
+    the RuntimeError of the failed start."""
+    debug_messages = []
+    monkeypatch.setattr(threads_mod.logger, 'debug',
+                        lambda msg, *a, **k: debug_messages.append(str(msg)))
+    real_start = threading.Thread.start
+
+    def start_unless_dump(self):
+        if self.name.endswith('-exhaustion-dump'):
+            raise RuntimeError('cannot start new thread (simulated)')
+        return real_start(self)
+
+    monkeypatch.setattr(threading.Thread, 'start', start_unless_dump)
+    executor = OnDemandThreadExecutor(name='nodump_test',
+                                      max_workers=1,
+                                      stuck_after_seconds=30.0)
+    release = threading.Event()
+    try:
+        fut = executor.submit(blocking_task, release)
+        with pytest.raises(exceptions.ConcurrentWorkerExhaustedError):
+            executor.submit(dummy_task)
+        assert any('could not start the dump thread' in m
+                   for m in debug_messages), debug_messages
+        release.set()
+        assert fut.result(timeout=5) is True
+    finally:
+        release.set()
+        executor.shutdown()
+
+
+def test_executor_construction_survives_watchdog_start_failure(monkeypatch):
+    """The first executor built in a process starts the watchdog thread. If
+    the process cannot start it, the executor is still built and usable, and
+    the next executor built tries again."""
+    # pylint: disable=protected-access
+    monkeypatch.setattr(threads_mod, '_watchdog_pid', None)
+    monkeypatch.setattr(threads_mod, '_watchdog_loop', lambda: None)
+    attempts = []
+    real_start = threading.Thread.start
+
+    def start_failing_once(self):
+        if self.name == 'thread-executor-watchdog':
+            attempts.append(self)
+            if len(attempts) == 1:
+                raise RuntimeError('cannot start new thread (simulated)')
+        return real_start(self)
+
+    monkeypatch.setattr(threading.Thread, 'start', start_failing_once)
+    first = OnDemandThreadExecutor(name='wd_fail_a', max_workers=1)
+    try:
+        assert len(attempts) == 1
+        assert threads_mod._watchdog_pid is None
+        assert first.submit(dummy_task).result(timeout=5) is True
+        second = OnDemandThreadExecutor(name='wd_fail_b', max_workers=1)
+        second.shutdown()
+        assert len(attempts) == 2
+        assert threads_mod._watchdog_pid == os.getpid()
+        attempts[1].join(5)
+    finally:
+        first.shutdown()
 
 
 def test_snapshot_drops_dead_threads():

--- a/tests/unit_tests/test_sky/server/requests/test_threads.py
+++ b/tests/unit_tests/test_sky/server/requests/test_threads.py
@@ -3,6 +3,7 @@
 import concurrent.futures
 import os
 import queue
+import sys
 import threading
 import time
 
@@ -11,6 +12,8 @@ import pytest
 
 from sky import exceptions
 from sky.metrics import utils as metrics_utils
+from sky.server import hung_threads
+from sky.server.requests import threads as threads_mod
 from sky.server.requests.threads import OnDemandThreadExecutor
 
 
@@ -192,3 +195,396 @@ def test_on_demand_executor_metrics(monkeypatch):
         assert _gauge_value('sky_apiserver_threads_active', name) == 0
     finally:
         executor.shutdown()
+
+
+# --- stuck-thread detection -------------------------------------------------
+
+
+def _poll_forever(sock):
+    """Block in poll(2) on a socket that never becomes readable, the way a
+    thread parked in libpq does."""
+    import select  # pylint: disable=import-outside-toplevel
+    poller = select.poll()
+    poller.register(sock.fileno(), select.POLLIN)
+    poller.poll(-1)
+    return True
+
+
+def _capture_warnings(monkeypatch):
+    messages = []
+    monkeypatch.setattr(threads_mod.logger, 'warning',
+                        lambda msg, *a, **k: messages.append(str(msg)))
+    return messages
+
+
+class _Clock:
+    """Stand-in for the ``time`` module inside sky.server.requests.threads so
+    the dump policy can be tested without sleeping through its intervals.
+    Only ``monotonic`` is faked; ``sleep`` stays real for the watchdog."""
+
+    def __init__(self):
+        self.now = 1000.0
+
+    def monotonic(self):
+        return self.now
+
+    @staticmethod
+    def sleep(seconds):
+        time.sleep(seconds)
+
+
+def _fake_clock(monkeypatch):
+    clock = _Clock()
+    monkeypatch.setattr(threads_mod, 'time', clock)
+    # No ownerless-socket scan in these tests (covered in test_hung_threads).
+    monkeypatch.setattr(threads_mod, '_last_scan', float('inf'))
+    monkeypatch.setattr(threads_mod, '_db_peers', [])
+    return clock
+
+
+def _wait_for(pred, timeout=5.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if pred():
+            return True
+        time.sleep(0.02)
+    return pred()
+
+
+def test_observe_counts_stuck_threads_and_oldest_age():
+    executor = OnDemandThreadExecutor(name='stuck_test',
+                                      max_workers=2,
+                                      stuck_after_seconds=0.2)
+    release_event = threading.Event()
+    try:
+        assert executor.observe() == (0, 0.0)
+        fut = executor.submit(blocking_task, release_event)
+        stuck, oldest = executor.observe()
+        assert stuck == 0 and 0 <= oldest < 0.2
+        time.sleep(0.35)
+        stuck, oldest = executor.observe()
+        assert stuck == 1
+        assert oldest >= 0.3
+        release_event.set()
+        assert fut.result(timeout=5) is True
+        assert _wait_for(lambda: executor.observe() == (0, 0.0))
+    finally:
+        executor.shutdown()
+
+
+def test_observe_without_threshold_reports_age_only():
+    executor = OnDemandThreadExecutor(name='nothreshold_test', max_workers=1)
+    release_event = threading.Event()
+    try:
+        fut = executor.submit(blocking_task, release_event)
+        time.sleep(0.1)
+        stuck, oldest = executor.observe()
+        assert stuck == 0
+        assert oldest >= 0.1
+        release_event.set()
+        assert fut.result(timeout=5) is True
+    finally:
+        executor.shutdown()
+
+
+def test_task_records_start_and_deadline(monkeypatch):
+    clock = _fake_clock(monkeypatch)
+    executor = OnDemandThreadExecutor(name='deadline_test',
+                                      max_workers=1,
+                                      stuck_after_seconds=30.0)
+    release_event = threading.Event()
+    try:
+        fut = executor.submit(blocking_task, release_event)
+        # pylint: disable=protected-access
+        (task,) = executor._threads.values()
+        assert task.started == 1000.0
+        assert task.deadline == 1030.0
+        assert task.name.endswith('.blocking_task')
+        clock.now = 1029.0
+        assert executor.observe()[0] == 0
+        clock.now = 1031.0
+        assert executor.observe()[0] == 1
+        # pylint: enable=protected-access
+        release_event.set()
+        assert fut.result(timeout=5) is True
+    finally:
+        executor.shutdown()
+
+
+def test_stuck_metrics_gauges(monkeypatch):
+    monkeypatch.setattr(metrics_utils, 'METRICS_ENABLED', True)
+    name = 'stuck_metrics_test'
+    executor = OnDemandThreadExecutor(name=name,
+                                      max_workers=2,
+                                      stuck_after_seconds=0.1)
+    release_event = threading.Event()
+    try:
+        # pylint: disable=protected-access
+        assert (metrics_utils.SKY_APISERVER_THREADS_STUCK._multiprocess_mode ==
+                'liveall')
+        assert (metrics_utils.SKY_APISERVER_THREADS_OLDEST_AGE_SECONDS.
+                _multiprocess_mode == 'liveall')
+        # pylint: enable=protected-access
+        fut = executor.submit(blocking_task, release_event)
+        time.sleep(0.2)
+        executor.observe()
+        assert _gauge_value('sky_apiserver_threads_stuck', name) == 1
+        assert _gauge_value('sky_apiserver_threads_oldest_age_seconds',
+                            name) >= 0.2
+        release_event.set()
+        assert fut.result(timeout=5) is True
+        assert _wait_for(lambda: executor.observe() == (0, 0.0))
+        assert _gauge_value('sky_apiserver_threads_stuck', name) == 0
+        assert _gauge_value('sky_apiserver_threads_oldest_age_seconds',
+                            name) == 0
+    finally:
+        executor.shutdown()
+
+
+def test_exhaustion_dump_describes_blocked_thread(monkeypatch):
+    """Exhaustion with a thread deliberately parked in poll(2): the log names
+    the task, the frame, the syscall and the descriptor; the gauges count it."""
+    import socket  # pylint: disable=import-outside-toplevel
+    monkeypatch.setattr(metrics_utils, 'METRICS_ENABLED', True)
+    messages = _capture_warnings(monkeypatch)
+    name = 'dump_test'
+    executor = OnDemandThreadExecutor(name=name,
+                                      max_workers=1,
+                                      stuck_after_seconds=0.1)
+    a, b = socket.socketpair()
+    try:
+        executor.submit(_poll_forever, a)
+        time.sleep(0.2)
+        with pytest.raises(exceptions.ConcurrentWorkerExhaustedError):
+            executor.submit(dummy_task)
+        assert prometheus_client.REGISTRY.get_sample_value(
+            'sky_apiserver_threads_exhausted_total', {'name': name}) == 1
+        executor.observe()
+        assert _gauge_value('sky_apiserver_threads_stuck', name) == 1
+        assert _gauge_value('sky_apiserver_threads_oldest_age_seconds',
+                            name) >= 0.2
+        # The dump runs in its own thread; wait for it.
+        assert _wait_for(lambda: len(messages) == 1)
+        dump = messages[0]
+        assert 'Executor [dump_test]' in dump
+        assert 'all workers busy' in dump
+        assert '1 of 1 workers running' in dump
+        assert '(limit 0.1s)' in dump
+        # The task name (unwrapped) and the blocking Python frame.
+        assert 'test_threads._poll_forever' in dump
+        assert '_poll_forever' in dump.split('python stack')[1]
+        if sys.platform == 'linux':
+            # The kernel view names the wait and the descriptor, and the
+            # descriptor line says what it is now.
+            assert 'syscall=poll' in dump or 'syscall=ppoll' in dump
+            assert 'timeout=infinite' in dump
+            assert f'fd={a.fileno()}' in dump
+            assert f'fd {a.fileno()}: socket:[' in dump
+            assert 'unix' in dump and 'recv-q=0' in dump
+        # A second exhaustion with the same slot holder dumps nothing.
+        with pytest.raises(exceptions.ConcurrentWorkerExhaustedError):
+            executor.submit(dummy_task)
+        time.sleep(0.2)
+        assert len(messages) == 1
+    finally:
+        # Wake the poller so the executor can shut down.
+        b.sendall(b'x')
+        executor.shutdown()
+        a.close()
+        b.close()
+
+
+def test_watchdog_dump_on_change_then_backoff(monkeypatch):
+    """The watchdog dumps when a thread newly crosses the threshold, then
+    repeats at doubling intervals while the stuck set is unchanged."""
+    clock = _fake_clock(monkeypatch)
+    monkeypatch.setattr(threads_mod, '_DUMP_MIN_INTERVAL_SECONDS', 60.0)
+    monkeypatch.setattr(threads_mod, '_DUMP_MAX_INTERVAL_SECONDS', 240.0)
+    messages = _capture_warnings(monkeypatch)
+    executor = OnDemandThreadExecutor(name='backoff_test',
+                                      max_workers=4,
+                                      stuck_after_seconds=30.0)
+    release_a, release_b = threading.Event(), threading.Event()
+    try:
+        fut_a = executor.submit(blocking_task, release_a)
+        clock.now += 31  # A crosses the threshold.
+        assert executor.observe()[0] == 1
+        assert len(messages) == 1
+        assert 'running longer than 30s' in messages[0]
+        assert 'unchanged' not in messages[0]
+        # Same set, inside the minimum interval: nothing.
+        clock.now += 59
+        executor.observe()
+        assert len(messages) == 1
+        # Heartbeat at 60 s, then 120 s, then 240 s (the cap).
+        clock.now += 2
+        executor.observe()
+        assert len(messages) == 2
+        assert 'unchanged for 61s; next report in 120s' in messages[1]
+        clock.now += 100
+        executor.observe()
+        assert len(messages) == 2
+        clock.now += 25
+        executor.observe()
+        assert len(messages) == 3
+        assert 'next report in 240s' in messages[2]
+        clock.now += 245
+        executor.observe()
+        assert len(messages) == 4
+        assert 'next report in 240s' in messages[3]  # capped
+        # A new thread crossing the threshold dumps at once (past the
+        # minimum interval) and resets the backoff.
+        fut_b = executor.submit(blocking_task, release_b)
+        clock.now += 61
+        assert executor.observe()[0] == 2
+        assert len(messages) == 5
+        assert 'unchanged' not in messages[4]
+        assert '2 thread(s) running longer' in messages[4]
+        clock.now += 61
+        executor.observe()
+        assert len(messages) == 6
+        assert 'next report in 120s' in messages[5]
+        # Everything returns: state resets.
+        release_a.set()
+        release_b.set()
+        assert fut_a.result(timeout=5) is True
+        assert fut_b.result(timeout=5) is True
+        assert _wait_for(lambda: executor.observe() == (0, 0.0))
+        assert len(messages) == 6
+    finally:
+        release_a.set()
+        release_b.set()
+        executor.shutdown()
+
+
+def test_exhaustion_dump_only_when_slot_holders_change(monkeypatch):
+    """A saturated executor without a threshold dumps its oldest tasks once
+    per distinct set of slot holders, not once per rejected submit."""
+    clock = _fake_clock(monkeypatch)
+    messages = _capture_warnings(monkeypatch)
+    executor = OnDemandThreadExecutor(name='holders_test', max_workers=1)
+    release_a, release_b = threading.Event(), threading.Event()
+    try:
+        fut_a = executor.submit(blocking_task, release_a)
+        with pytest.raises(exceptions.ConcurrentWorkerExhaustedError):
+            executor.submit(dummy_task)
+        assert _wait_for(lambda: len(messages) == 1)
+        assert 'all workers busy' in messages[0]
+        assert 'test_threads.blocking_task' in messages[0]
+        # Same holder, an hour later: nothing new to say.
+        clock.now += 3600
+        with pytest.raises(exceptions.ConcurrentWorkerExhaustedError):
+            executor.submit(dummy_task)
+        time.sleep(0.2)
+        assert len(messages) == 1
+        # A different holder: dumped again.
+        release_a.set()
+        assert fut_a.result(timeout=5) is True
+        fut_b = executor.submit(blocking_task, release_b)
+        clock.now += 61
+        with pytest.raises(exceptions.ConcurrentWorkerExhaustedError):
+            executor.submit(dummy_task)
+        assert _wait_for(lambda: len(messages) == 2)
+        release_b.set()
+        assert fut_b.result(timeout=5) is True
+    finally:
+        release_a.set()
+        release_b.set()
+        executor.shutdown()
+
+
+def test_dump_includes_rate_limited_ownerless_socket_scan(monkeypatch):
+    clock = _fake_clock(monkeypatch)
+    monkeypatch.setattr(threads_mod, '_last_scan', float('-inf'))
+    calls = []
+
+    def fake_scan(extra_peers=()):
+        calls.append((clock.now, list(extra_peers)))
+        return ['ownerless sockets: 1 ...', '  socket:[1] a -> b']
+
+    monkeypatch.setattr(hung_threads, 'scan_ownerless_sockets', fake_scan)
+    messages = _capture_warnings(monkeypatch)
+    executor = OnDemandThreadExecutor(name='scan_test',
+                                      max_workers=2,
+                                      stuck_after_seconds=1.0)
+    release_a, release_b = threading.Event(), threading.Event()
+    try:
+        executor.submit(blocking_task, release_a)
+        clock.now += 2
+        executor.observe()
+        assert len(messages) == 1 and 'ownerless sockets: 1' in messages[0]
+        assert calls == [(1002.0, [])]
+        # A second dump inside the scan interval carries no scan.
+        executor.submit(blocking_task, release_b)
+        clock.now += 61
+        executor.observe()
+        assert len(messages) == 2 and 'ownerless' not in messages[1]
+        assert len(calls) == 1
+        # Past the scan interval it runs again.
+        release_a.set()
+        clock.now += 300
+        executor.observe()
+        assert len(messages) == 3 and 'ownerless' in messages[2]
+        assert [c[0] for c in calls] == [1002.0, 1363.0]
+    finally:
+        release_a.set()
+        release_b.set()
+        executor.shutdown()
+
+
+def test_state_db_peers_from_environment(monkeypatch):
+    from sky.skylet import constants  # pylint: disable=import-outside-toplevel
+    monkeypatch.setattr(threads_mod, '_db_peers', None)
+    monkeypatch.setenv(constants.ENV_VAR_IS_SKYPILOT_SERVER, '1')
+    monkeypatch.setenv(constants.ENV_VAR_DB_CONNECTION_URI,
+                       'postgresql://u:p@db.example.internal:5433/sky')
+    monkeypatch.setenv(constants.ENV_VAR_DB_POOL_HOSTPORT, '127.0.0.1:6432')
+    assert threads_mod._state_db_peers() == [  # pylint: disable=protected-access
+        ('127.0.0.1', 6432), ('db.example.internal', 5433)
+    ]
+    monkeypatch.setattr(threads_mod, '_db_peers', None)
+    monkeypatch.delenv(constants.ENV_VAR_DB_CONNECTION_URI)
+    assert threads_mod._state_db_peers() == []  # pylint: disable=protected-access
+    monkeypatch.setattr(threads_mod, '_db_peers', None)
+
+
+def test_snapshot_drops_dead_threads():
+    """After a fork the child inherits the table but not the threads; a dead
+    entry must not be reported as stuck forever."""
+    executor = OnDemandThreadExecutor(name='dead_test',
+                                      max_workers=2,
+                                      stuck_after_seconds=0.01)
+    try:
+        ghost = threading.Thread(target=lambda: None)
+        ghost.start()
+        ghost.join()
+        # pylint: disable=protected-access
+        executor._threads[ghost] = threads_task(time.monotonic() - 100)
+        assert executor.observe() == (0, 0.0)
+        assert ghost not in executor._threads
+        # pylint: enable=protected-access
+    finally:
+        executor.shutdown()
+
+
+def threads_task(started):
+    return threads_mod._Task(started, started + 0.01, 'ghost', 0)  # pylint: disable=protected-access
+
+
+def test_describe_task_unwraps_context_run():
+    import contextvars  # pylint: disable=import-outside-toplevel
+    import functools  # pylint: disable=import-outside-toplevel
+
+    # What context_utils.to_thread_with_executor submits.
+    wrapped = functools.partial(contextvars.copy_context().run, dummy_task,
+                                0.01)
+    assert threads_mod._describe_task(wrapped) == (  # pylint: disable=protected-access
+        f'{dummy_task.__module__}.dummy_task')
+    assert threads_mod._describe_task(dummy_task).endswith('.dummy_task')  # pylint: disable=protected-access
+
+
+def test_watchdog_thread_started_once():
+    OnDemandThreadExecutor(name='wd_a', max_workers=1).shutdown()
+    OnDemandThreadExecutor(name='wd_b', max_workers=1).shutdown()
+    names = [t.name for t in threading.enumerate()]
+    assert names.count('thread-executor-watchdog') == 1

--- a/tests/unit_tests/test_sky/server/requests/test_threads.py
+++ b/tests/unit_tests/test_sky/server/requests/test_threads.py
@@ -6,6 +6,7 @@ import queue
 import sys
 import threading
 import time
+import weakref
 
 import prometheus_client
 import pytest
@@ -381,7 +382,9 @@ def test_exhaustion_dump_describes_blocked_thread(monkeypatch):
             assert f'fd={a.fileno()}' in dump
             assert f'fd {a.fileno()}: socket:[' in dump
             assert 'unix' in dump and 'recv-q=0' in dump
-        # A second exhaustion with the same slot holder dumps nothing.
+        # A second exhaustion moments later starts no dump thread (the
+        # per-second start gate and the 60 s floor). The same-holder check
+        # is covered by test_exhaustion_dump_only_when_slot_holders_change.
         with pytest.raises(exceptions.ConcurrentWorkerExhaustedError):
             executor.submit(dummy_task)
         time.sleep(0.2)
@@ -588,3 +591,208 @@ def test_watchdog_thread_started_once():
     OnDemandThreadExecutor(name='wd_b', max_workers=1).shutdown()
     names = [t.name for t in threading.enumerate()]
     assert names.count('thread-executor-watchdog') == 1
+
+
+def test_snapshot_keeps_registered_but_unstarted_thread(monkeypatch):
+    """submit() registers the thread, then starts it. A snapshot landing in
+    between (a watchdog tick or an exhaustion dump) sees is_alive() False
+    and must not purge the entry, or the task runs untracked for life."""
+    executor = OnDemandThreadExecutor(name='prestart_test',
+                                      max_workers=2,
+                                      stuck_after_seconds=0.05)
+    seen = {}
+    orig_start = threading.Thread.start
+
+    def start_after_snapshot(self):
+        if self.name.startswith('prestart_test-'):
+            # pylint: disable-next=protected-access
+            seen['tracked_during_start'] = len(executor._snapshot())
+        return orig_start(self)
+
+    monkeypatch.setattr(threading.Thread, 'start', start_after_snapshot)
+    release = threading.Event()
+    try:
+        fut = executor.submit(blocking_task, release)
+        assert seen['tracked_during_start'] == 1
+        time.sleep(0.1)
+        # Still tracked, and now past the threshold.
+        assert executor.observe()[0] == 1
+        release.set()
+        assert fut.result(timeout=5) is True
+        assert _wait_for(lambda: executor.observe() == (0, 0.0))
+    finally:
+        release.set()
+        executor.shutdown()
+
+
+class _Registry(weakref.WeakSet):
+    """Stand-in for the module's executor set: iterates in name order (a set
+    has none) and records whether the watchdog lock was held while doing so."""
+
+    def __init__(self):
+        super().__init__()
+        self.locked_during_iteration = []
+
+    def __iter__(self):
+        # pylint: disable-next=protected-access
+        self.locked_during_iteration.append(threads_mod._watchdog_lock.locked())
+        return iter(sorted(super().__iter__(), key=lambda e: e.name))
+
+
+def test_watchdog_tick_isolates_a_failing_executor(monkeypatch):
+    """One executor whose observe() raises must not cost the others their
+    observation, and the tick must return normally."""
+    registry = _Registry()
+    bad = OnDemandThreadExecutor(name='wd_a_bad', max_workers=1)
+    good = OnDemandThreadExecutor(name='wd_b_good', max_workers=1)
+    registry.add(bad)
+    registry.add(good)
+    monkeypatch.setattr(threads_mod, '_executors', registry)
+    observed = []
+
+    def failing_observe():
+        raise RuntimeError('observe failed')
+
+    monkeypatch.setattr(bad, 'observe', failing_observe)
+    monkeypatch.setattr(good, 'observe', lambda: observed.append(1) or (0, 0.0))
+    try:
+        threads_mod._watchdog_tick()  # pylint: disable=protected-access
+        threads_mod._watchdog_tick()  # pylint: disable=protected-access
+    finally:
+        bad.shutdown()
+        good.shutdown()
+    assert observed == [1, 1]
+    # The set is copied under the lock that registration takes, so a
+    # concurrent constructor cannot change it mid-iteration.
+    assert registry.locked_during_iteration == [True, True]
+
+
+def test_watchdog_loop_survives_failed_ticks_under_registration_churn(
+        monkeypatch):
+    """The real loop keeps ticking after ticks raised, while executors are
+    built and dropped on another thread (the WeakSet changes size)."""
+    monkeypatch.setattr(threads_mod, '_WATCHDOG_INTERVAL_SECONDS', 0.001)
+    real_tick = threads_mod._watchdog_tick  # pylint: disable=protected-access
+    state = {'calls': 0, 'good': 0}
+    under_test = {}
+
+    def tick():
+        if threading.current_thread() is not under_test.get('thread'):
+            # The process's own watchdog is not part of this test.
+            return real_tick()
+        state['calls'] += 1
+        if state['calls'] <= 3:
+            raise RuntimeError('Set changed size during iteration')
+        real_tick()
+        state['good'] += 1
+        if state['good'] >= 100:
+            # Ends this loop thread; threading ignores SystemExit silently.
+            raise SystemExit
+        return None
+
+    monkeypatch.setattr(threads_mod, '_watchdog_tick', tick)
+    stop = threading.Event()
+
+    def churn():
+        while not stop.is_set():
+            OnDemandThreadExecutor(name='churn', max_workers=1).shutdown()
+
+    churner = threading.Thread(target=churn, name='churn', daemon=True)
+    loop = threading.Thread(
+        target=threads_mod._watchdog_loop,  # pylint: disable=protected-access
+        name='watchdog-under-test',
+        daemon=True)
+    under_test['thread'] = loop
+    churner.start()
+    loop.start()
+    try:
+        assert _wait_for(lambda: state['good'] >= 100, timeout=20)
+    finally:
+        stop.set()
+        churner.join(timeout=5)
+    loop.join(timeout=5)
+    assert not loop.is_alive()
+    assert state['calls'] >= 103
+
+
+def test_watchdog_dump_floor_applies_to_a_newly_stuck_thread(monkeypatch):
+    """A thread crossing the threshold within the minimum interval of the
+    previous dump waits for the interval; this is the guard that bounds a
+    ramp to one dump per minute per executor."""
+    clock = _fake_clock(monkeypatch)
+    monkeypatch.setattr(threads_mod, '_DUMP_MIN_INTERVAL_SECONDS', 60.0)
+    messages = _capture_warnings(monkeypatch)
+    executor = OnDemandThreadExecutor(name='floor_test',
+                                      max_workers=4,
+                                      stuck_after_seconds=30.0)
+    release = threading.Event()
+    try:
+        fut_a = executor.submit(blocking_task, release)
+        clock.now += 31  # A crosses the threshold and is dumped.
+        assert executor.observe()[0] == 1
+        assert len(messages) == 1
+        fut_b = executor.submit(blocking_task, release)
+        clock.now += 31  # B crosses; only 31 s since the last dump.
+        assert executor.observe()[0] == 2
+        assert len(messages) == 1
+        clock.now += 30  # 61 s since the last dump: B is reported.
+        executor.observe()
+        assert len(messages) == 2
+        assert '2 thread(s) running longer' in messages[1]
+        assert 'unchanged' not in messages[1]
+        release.set()
+        assert fut_a.result(timeout=5) is True
+        assert fut_b.result(timeout=5) is True
+    finally:
+        release.set()
+        executor.shutdown()
+
+
+def test_exhaustion_dump_thread_started_at_most_once_per_second(monkeypatch):
+    """A saturated executor rejects every submit; the reject path must not
+    start a dump thread per rejection once the picture is unchanged."""
+    clock = _fake_clock(monkeypatch)
+    messages = _capture_warnings(monkeypatch)
+    executor = OnDemandThreadExecutor(name='throttle_test', max_workers=1)
+    release = threading.Event()
+    snapshots = []
+    real_snapshot = executor._snapshot  # pylint: disable=protected-access
+
+    def counting_snapshot():
+        snapshots.append(threading.current_thread().name)
+        return real_snapshot()
+
+    def dump_thread_snapshots():
+        return [n for n in snapshots if n.endswith('-exhaustion-dump')]
+
+    monkeypatch.setattr(executor, '_snapshot', counting_snapshot)
+
+    def reject(n):
+        for _ in range(n):
+            with pytest.raises(exceptions.ConcurrentWorkerExhaustedError):
+                executor.submit(dummy_task)
+
+    try:
+        fut = executor.submit(blocking_task, release)
+        reject(50)
+        assert _wait_for(lambda: len(messages) == 1)
+        time.sleep(0.1)
+        assert len(dump_thread_snapshots()) == 1
+        # Past the dump floor, same slot holder: every reject passes the
+        # floor check, but only the first in a second starts a thread.
+        clock.now += 61
+        reject(50)
+        assert _wait_for(lambda: len(dump_thread_snapshots()) == 2)
+        time.sleep(0.1)
+        assert len(dump_thread_snapshots()) == 2
+        assert len(messages) == 1
+        # The next second lets another look happen.
+        clock.now += 1
+        reject(1)
+        assert _wait_for(lambda: len(dump_thread_snapshots()) == 3)
+        assert len(messages) == 1
+        release.set()
+        assert fut.result(timeout=5) is True
+    finally:
+        release.set()
+        executor.shutdown()

--- a/tests/unit_tests/test_sky/server/test_hung_threads.py
+++ b/tests/unit_tests/test_sky/server/test_hung_threads.py
@@ -1,0 +1,245 @@
+"""Unit tests for sky/server/hung_threads.py (Linux /proc based)."""
+import os
+import select
+import socket
+import sys
+import threading
+import time
+
+import pytest
+
+from sky.server import hung_threads
+
+linux_only = pytest.mark.skipif(sys.platform != 'linux',
+                                reason='/proc is Linux only')
+
+
+def _blocked_in_poll(fd, ready: threading.Event):
+    poller = select.poll()
+    poller.register(fd, select.POLLIN)
+    ready.set()
+    poller.poll(-1)
+
+
+def _blocked_in_recv(sock, ready: threading.Event):
+    ready.set()
+    sock.recv(1)
+
+
+def _start_blocked(target, arg):
+    ready = threading.Event()
+    thread = threading.Thread(target=target, args=(arg, ready), daemon=True)
+    thread.start()
+    ready.wait(5)
+    time.sleep(0.1)  # let it enter the syscall
+    return thread
+
+
+@pytest.fixture(name='blocked')
+def _blocked_fixture(request):
+    target = request.param
+    a, b = socket.socketpair()
+    thread = _start_blocked(target,
+                            a.fileno() if target is _blocked_in_poll else a)
+    yield thread, a
+    b.sendall(b'x')
+    thread.join(5)
+    a.close()
+    b.close()
+
+
+def _open_fds():
+    return len(os.listdir('/proc/self/fd'))
+
+
+@linux_only
+@pytest.mark.parametrize('blocked', [_blocked_in_poll], indirect=True)
+def test_kernel_view_decodes_poll(blocked):
+    thread, sock = blocked
+    view = hung_threads.kernel_view(thread.native_id)
+    assert view['state'] == 'S'
+    assert view['syscall'] in ('poll', 'ppoll')
+    assert sock.fileno() in view['fds']
+    assert view['pollfds'] and f'fd={sock.fileno()}' in view['pollfds'][0]
+    assert view['timeout'] == 'infinite'
+
+
+@linux_only
+@pytest.mark.parametrize('blocked', [_blocked_in_recv], indirect=True)
+def test_kernel_view_decodes_recv(blocked):
+    thread, sock = blocked
+    view = hung_threads.kernel_view(thread.native_id)
+    assert view['syscall'] in ('recvfrom', 'read', 'recvmsg')
+    assert view['fds'] == [sock.fileno()]
+
+
+@linux_only
+def test_describe_fd_socket_and_closed():
+    a, b = socket.socketpair()
+    try:
+        desc = hung_threads.describe_fd(a.fileno())
+        assert desc.startswith(f'fd {a.fileno()}: socket:[')
+        assert 'unix' in desc and 'recv-q=0' in desc
+    finally:
+        fd = a.fileno()
+        a.close()
+        b.close()
+    assert 'not open' in hung_threads.describe_fd(fd)
+
+
+@linux_only
+def test_describe_fd_tcp_peer_state_and_queues():
+    srv = socket.socket()
+    srv.bind(('127.0.0.1', 0))
+    srv.listen(1)
+    cli = socket.create_connection(srv.getsockname())
+    acc, _ = srv.accept()
+    before = _open_fds()
+    try:
+        desc = hung_threads.describe_fd(cli.fileno())
+        assert 'tcp' in desc and 'ESTABLISHED' in desc
+        assert f'-> 127.0.0.1:{srv.getsockname()[1]}' in desc
+        assert 'recv-q=0' in desc
+        # Unread bytes from the peer show up as the receive queue: the
+        # discriminator between "reply never arrived" and "reply arrived and
+        # was never read".
+        acc.sendall(b'x' * 68)
+        time.sleep(0.05)
+        assert 'recv-q=68' in hung_threads.describe_fd(cli.fileno())
+        # The inspection works on a dup and leaks nothing.
+        assert _open_fds() == before
+    finally:
+        cli.close()
+        acc.close()
+        srv.close()
+
+
+@linux_only
+def test_describe_fd_non_socket():
+    r, w = os.pipe()
+    before = _open_fds()
+    try:
+        desc = hung_threads.describe_fd(r)
+        assert desc.startswith(f'fd {r}: pipe:[')
+        assert 'recv-q' not in desc
+        assert hung_threads.socket_info(r) is None
+        assert _open_fds() == before
+    finally:
+        os.close(r)
+        os.close(w)
+
+
+@pytest.mark.parametrize('blocked', [_blocked_in_poll], indirect=True)
+def test_python_stack_names_blocking_frame(blocked):
+    thread, _ = blocked
+    lines = hung_threads.python_stack(thread)
+    assert any('_blocked_in_poll' in l for l in lines)
+
+
+@pytest.mark.parametrize('blocked', [_blocked_in_poll], indirect=True)
+def test_describe_is_bounded_and_never_raises(blocked):
+    thread, sock = blocked
+    text = hung_threads.describe(thread,
+                                 12.5,
+                                 task='mod.fn',
+                                 deadline_seconds=5)
+    assert text.startswith(f'thread {thread.name!r}')
+    assert 'running 12.5s (limit 5s) task=mod.fn' in text
+    assert 'python stack' in text
+    if sys.platform == 'linux':
+        assert 'syscall=' in text
+        assert f'fd {sock.fileno()}: socket:[' in text
+    assert len(text) < 8192
+
+
+def test_kernel_view_bad_tid_is_empty():
+    assert hung_threads.kernel_view(2**30) == {'wchan': None}
+
+
+def test_peer_hex_forms():
+    # pylint: disable=protected-access
+    forms = hung_threads._peer_hex_forms([('127.0.0.1', 6432)])
+    assert '0100007F:1920' in forms
+    assert '0000000000000000FFFF00000100007F:1920' in forms  # tcp6 v4-mapped
+    forms = hung_threads._peer_hex_forms([('::1', 5432)])
+    assert '00000000000000000000000001000000:1538' in forms
+    assert hung_threads._peer_hex_forms([('no.such.host.invalid', 1)]) == set()
+
+
+def test_hex_addr():
+    # pylint: disable=protected-access
+    assert hung_threads._hex_addr('0100007F:1920') == '127.0.0.1:6432'
+    assert hung_threads._hex_addr(
+        '00000000000000000000000001000000:1538') == '[::1]:5432'
+    assert hung_threads._hex_addr('garbage') == 'garbage'
+
+
+@linux_only
+def test_scan_finds_socket_closed_under_a_sleeping_poll():
+    """Reproduce, without a database, the failure the scan exists for: a
+    thread sleeps in poll() on a TCP socket; another thread closes that
+    descriptor number and the number is reused; the peer then sends a reply.
+    The connection stays established with the reply unread and no descriptor
+    pointing at it. The per-thread view now shows the new owner of the
+    number; only the scan shows the orphan."""
+    srv = socket.socket()
+    srv.bind(('127.0.0.1', 0))
+    srv.listen(5)
+    port = srv.getsockname()[1]
+    # A healthy connection to the same peer, so the peer counts as one this
+    # host talks to (the scan is scoped to such peers).
+    healthy = socket.create_connection(srv.getsockname())
+    healthy_acc, _ = srv.accept()
+    victim = socket.create_connection(srv.getsockname())
+    victim_acc, _ = srv.accept()
+    victim_port = victim.getsockname()[1]
+    fd = victim.detach()  # the raw number, owned by this test now
+    thread = _start_blocked(_blocked_in_poll, fd)
+    pipe = None
+    try:
+        lines = hung_threads.scan_ownerless_sockets()
+        assert lines[0].startswith('ownerless sockets: ')
+        assert not any(f'127.0.0.1:{victim_port} ->' in l for l in lines)
+
+        os.close(fd)  # the stray close
+        pipe = os.pipe()  # the next allocation takes the number
+        assert pipe[0] == fd
+        victim_acc.sendall(b'x' * 68)  # the reply, landing unread
+        time.sleep(0.1)
+        assert thread.is_alive()
+
+        # The thread's descriptor is now the pipe: nothing there says a
+        # socket is missing.
+        assert hung_threads.describe_fd(fd).startswith(f'fd {fd}: pipe:[')
+        lines = hung_threads.scan_ownerless_sockets()
+        hits = [l for l in lines if f'127.0.0.1:{victim_port} ->' in l]
+        assert len(hits) == 1, lines
+        assert f'-> 127.0.0.1:{port} ESTABLISHED' in hits[0]
+        assert 'recv-q=68' in hits[0]
+        assert 'owner=none' in hits[0]
+        assert ' ms)' in lines[0]
+
+        # Without any owned connection to the peer the orphan is invisible
+        # (nothing says this host talks to that peer) -- unless the caller
+        # names the peer, which is what the executor does for the database.
+        healthy.close()
+        healthy_acc.close()
+        time.sleep(0.05)
+        lines = hung_threads.scan_ownerless_sockets()
+        assert not any(f'127.0.0.1:{victim_port} ->' in l for l in lines)
+        lines = hung_threads.scan_ownerless_sockets(extra_peers=[('localhost',
+                                                                  port)])
+        hits = [l for l in lines if f'127.0.0.1:{victim_port} ->' in l]
+        assert len(hits) == 1 and 'recv-q=68' in hits[0], lines
+    finally:
+        if pipe is not None:
+            os.write(pipe[1], b'x')  # wakes the poller (it polls the pipe)
+            thread.join(5)
+            os.close(pipe[0])
+            os.close(pipe[1])
+        for s in (victim_acc, srv):
+            s.close()
+    # With the poll gone the kernel dropped the orphan's last reference.
+    time.sleep(0.1)
+    lines = hung_threads.scan_ownerless_sockets()
+    assert not any(f'127.0.0.1:{victim_port} ->' in l for l in lines)

--- a/tests/unit_tests/test_sky/server/test_hung_threads.py
+++ b/tests/unit_tests/test_sky/server/test_hung_threads.py
@@ -175,13 +175,17 @@ def test_hex_addr():
 
 
 @linux_only
-def test_scan_finds_socket_closed_under_a_sleeping_poll():
+def test_scan_finds_socket_closed_under_a_sleeping_poll(monkeypatch):
     """Reproduce, without a database, the failure the scan exists for: a
     thread sleeps in poll() on a TCP socket; another thread closes that
     descriptor number and the number is reused; the peer then sends a reply.
     The connection stays established with the reply unread and no descriptor
     pointing at it. The per-thread view now shows the new owner of the
     number; only the scan shows the orphan."""
+    # A shared development host can have dozens of ownerless connections of
+    # its own (processes whose descriptors this user cannot read); do not let
+    # the report limit hide the one this test creates.
+    monkeypatch.setattr(hung_threads, '_MAX_SCAN_RESULTS', 10000)
     srv = socket.socket()
     srv.bind(('127.0.0.1', 0))
     srv.listen(5)
@@ -243,3 +247,24 @@ def test_scan_finds_socket_closed_under_a_sleeping_poll():
     time.sleep(0.1)
     lines = hung_threads.scan_ownerless_sockets()
     assert not any(f'127.0.0.1:{victim_port} ->' in l for l in lines)
+
+
+def test_scan_lists_unread_replies_first(monkeypatch):
+    """More ownerless connections than the report limit: the one with unread
+    bytes (the orphan that holds a lock) is listed first, not cut."""
+    peer = '0100007F:1920'  # 127.0.0.1:6432
+    rows = [('0100007F:0001', peer, '01', '00000000:00000000', '999')]
+    rows += [(f'0100007F:{1000 + i:04X}', peer, '01', '00000000:00000000',
+              str(2000 + i)) for i in range(20)]
+    rows.append(('0100007F:BEEF', peer, '01', '00000000:00000044', '3000'))
+    monkeypatch.setattr(hung_threads, '_tcp_rows', lambda: rows)
+    monkeypatch.setattr(hung_threads, '_socket_inodes_by_process',
+                        lambda deadline: ({'999'}, 1, 0, 3, True))
+    monkeypatch.setattr(hung_threads, '_MAX_SCAN_RESULTS', 16)
+    lines = hung_threads.scan_ownerless_sockets()
+    assert lines[0].startswith('ownerless sockets: 21 ')
+    assert len(lines) == 1 + 16 + 1
+    assert lines[1] == ('  socket:[3000] 127.0.0.1:48879 -> 127.0.0.1:6432 '
+                        'ESTABLISHED recv-q=68 send-q=0 owner=none')
+    assert lines[2].startswith('  socket:[2000] ')  # ties keep table order
+    assert lines[-1] == '  ... 5 more'

--- a/tests/unit_tests/test_sky/server/test_hung_threads.py
+++ b/tests/unit_tests/test_sky/server/test_hung_threads.py
@@ -268,3 +268,33 @@ def test_scan_lists_unread_replies_first(monkeypatch):
                         'ESTABLISHED recv-q=68 send-q=0 owner=none')
     assert lines[2].startswith('  socket:[2000] ')  # ties keep table order
     assert lines[-1] == '  ... 5 more'
+
+
+def test_scan_leaves_excluded_peers_out(monkeypatch):
+    """The database behind a sidecar pooler: this process holds a direct
+    connection to it (an advisory-lock session), so the endpoint would count
+    as one this host talks to, and the pooler's own server connections to it
+    come from another process namespace and all look ownerless. The caller
+    excludes the endpoint; the orphan to the pooler is still reported."""
+    pooler = '0100007F:1920'  # 127.0.0.1:6432
+    database = '0500000A:1538'  # 10.0.0.5:5432
+    rows = [
+        ('0100007F:0001', pooler, '01', '00000000:00000000', '100'),  # owned
+        ('0600000A:0002', database, '01', '00000000:00000000', '101'),  # owned
+        ('0100007F:BEEF', pooler, '01', '00000000:00000044', '200'),  # orphan
+    ]
+    # The pooler's server connections, no owner among visible processes.
+    rows += [(f'0600000A:{1000 + i:04X}', database, '01', '00000000:00000000',
+              str(300 + i)) for i in range(5)]
+    monkeypatch.setattr(hung_threads, '_tcp_rows', lambda: rows)
+    monkeypatch.setattr(hung_threads, '_socket_inodes_by_process',
+                        lambda deadline: ({'100', '101'}, 1, 0, 2, True))
+    lines = hung_threads.scan_ownerless_sockets([('127.0.0.1', 6432)])
+    assert lines[0].startswith('ownerless sockets: 6 '), lines
+    lines = hung_threads.scan_ownerless_sockets([('127.0.0.1', 6432)],
+                                                exclude_peers=[('10.0.0.5',
+                                                                5432)])
+    assert lines[0].startswith('ownerless sockets: 1 '), lines
+    assert len(lines) == 2
+    assert lines[1] == ('  socket:[200] 127.0.0.1:48879 -> 127.0.0.1:6432 '
+                        'ESTABLISHED recv-q=68 send-q=0 owner=none')


### PR DESCRIPTION
## Problem

`OnDemandThreadExecutor` (the API server's `auth_thread_executor`, 32 threads per uvicorn worker, and its `request_thread_executor`) starts one thread per task and counts it as running until the task returns or raises. A task that never returns keeps its slot for the life of the process. The callers' `asyncio.wait_for` deadline (5 s on the auth path) frees the caller, not the thread. Once every slot is held that way the executor rejects every submit with `ConcurrentWorkerExhaustedError` and the worker answers "The server has exhausted its concurrent worker limit" to everything.

Today that state is visible only as counts: `sky_apiserver_threads_active` pegged at `sky_apiserver_threads_max` and `sky_apiserver_threads_exhausted_total` climbing. Nothing tells 32 busy threads from 32 dead ones, nothing says how long they have been there, and nothing says what they are stuck on. A production pod rarely has `py-spy` or `ss`, and attaching a debugger to the worker can itself change the state under investigation (a blocking `ptrace` attach makes a sleeping `poll()` return). In the incident behind #10681 a thread parked in libpq `poll()` on a descriptor number that had been closed and reused held a slot and an open transaction for the better part of an hour; the pool then filled with threads waiting on the row lock it held, 13 minutes passed between the first pinned thread and the first rejection, and the evidence had to be reconstructed afterwards from logs and metrics. The fix for that cause is #10689; this PR makes the state observable from inside the process, whatever the cause.

## Change

Record the start time (and, when the executor has a threshold, the deadline) of each task, and add:

- **Two gauges**, `liveall` per process like `sky_apiserver_threads_active`:
  - `sky_apiserver_threads_stuck{pid,name}`: tasks running longer than the executor's `stuck_after_seconds`. The auth pool is built with 30 s (six times the callers' 5 s deadline, `_AUTH_THREAD_STUCK_SECONDS`); the request pool has no threshold because its tasks may stream logs for hours. No user-facing knob.
  - `sky_apiserver_threads_oldest_age_seconds{pid,name}`: age of the longest-running task. Threshold-free, so it also serves the request pool; on a pool that should turn over in milliseconds a pinned thread shows as a linearly growing age, the earliest signal there is.
- **A thread dump at WARNING** when a task newly crosses the threshold (watchdog path: one daemon thread per process, 10 s tick) or when an exhausted executor's slots are held by threads not yet reported (exhaustion path: in a short-lived thread, so the rejected caller, usually the event loop, does not do the `/proc` reads). Dumps are change-triggered with a 60 s floor per executor; while nothing changes, a heartbeat repeats the picture at intervals doubling from 1 min to 1 h. Each dump describes the eight oldest threads, oldest first: the Python stack; the kernel's view of the thread (`/proc/self/task/<tid>`: state, wchan, the syscall it sleeps in and, for `poll`/`ppoll`, the descriptors and timeout, read back from `/proc/self/mem`); and what each descriptor is right now, with, for a socket, peer, TCP state and receive/send queue lengths taken from a `dup` of the descriptor (`getsockopt(TCP_INFO)`, `getpeername`, `FIONREAD`/`TIOCOUTQ`: constant cost, no `/proc/net/tcp` parse on this path).
- **An ownerless-socket scan**, at most once per 5 minutes per process and only inside a dump: established connections to the state database's endpoint (the pooler when one is configured, else the database) or to any peer a visible process talks to, that no readable `/proc/<pid>/fd` owns, with their receive queue, most unread bytes first. A descriptor closed while another thread sleeps in `poll()` on it leaves exactly such a socket: the sleeping `poll` keeps the kernel socket alive, the number is reused, the thread's own descriptor line shows the new owner of the number (often a healthy-looking socket of the same kind), and the real connection sits established with an unread reply and can hold database locks. The scan is the only in-process evidence of that state. When a pooler sidecar is configured, the database endpoint behind it is excluded: the pooler's own server connections live in another pid namespace of the same network namespace and would otherwise all be listed.

Everything is best effort and bounded: a `/proc` read that fails only shortens the description; a failed dump-thread start is logged at debug and the caller still gets `ConcurrentWorkerExhaustedError`; the watchdog tick is guarded and a failing executor is isolated from the others; nothing raises to the caller. Dumps identify "the same threads" by a per-task sequence number, not `Thread.ident`, which glibc reuses as soon as a thread exits. Dead threads are purged from the table (a forked child inherits the table, not the threads); registered-but-unstarted threads are kept.

### What a dump looks like

Captured from this branch with a 2-slot executor and one task parked in `poll(2)` on a socket whose peer never writes (paths shortened):

```
WARNING sky.server.requests.threads: Executor [example_pool]: 1 thread(s) running longer than 0.5s; 1 of 2 workers running, describing the 1 longest-running (oldest first):
thread 'example_pool-1' native_tid=322981 running 1.0s (limit 0.5s) task=__main__.park_forever
  kernel: state=S wchan=do_poll.constprop.0 syscall=poll timeout=infinite pollfds=['fd=4 events=0x1 revents=0x0']
  fd 4: socket:[22547228] tcp 127.0.0.1:39602 -> 127.0.0.1:35997 ESTABLISHED recv-q=0 send-q=0
  python stack (innermost last):
    .../threading.py:973 _bootstrap
    .../threading.py:1016 _bootstrap_inner
    .../threading.py:953 run
    .../sky/server/requests/threads.py:452 _task_wrapper
    .../example_dump.py:32 park_forever
ownerless sockets: 0 established/close-wait connection(s) to a peer this host talks to have no owner among 83 readable process(es) (2 unreadable, 1306 descriptors, 66 connections, 9 ms)
```

For a thread pinned in a DB call the stack ends in `cursor.execute` / `connection.commit` and the descriptor line shows the connection to the database or pooler. When the descriptor was closed under the thread and its number reused, the descriptor line describes the *new* owner of the number (a pipe, or another connection with `recv-q=0`), and the scan line is what shows the real connection, e.g. `socket:[…] tcp 127.0.0.1:51756 -> 127.0.0.1:6432 ESTABLISHED recv-q=65 send-q=0 owner=none` (from the container check below: the reply arrived and nobody will ever read it).

## Why no cancellation

Each of these was tried against a thread parked in a libpq wait (a lock waiter, and an idle-in-transaction session whose reply never comes), each in its own process:

- `PyThreadState_SetAsyncExc`: the exception lands at the next bytecode boundary; a thread inside a C wait never reaches one.
- Signals (`pthread_kill`): libpq and CPython both retry `EINTR`, and with no handler installed the worker dies. When the descriptor number was stolen, forcing the `poll` to return does release the orphaned socket (the poll held its last reference, so the lock it protected is released), but libpq then re-arms the poll on the number's current owner: when that owner's next reply arrives, the pinned thread reads it as its own result, commits on the wrong connection, and `PQfinish` closes the descriptor under its owner (observed; the owner's request fails with `EBADF`). A `SIGSTOP`/`SIGCONT` of the process has the same effect (`restart_syscall`).
- psycopg2 `connection.cancel()`: frees a lock waiter only, does nothing for an idle-in-transaction session, needs the connection object (the executor holds a callable), and runs `PQcancel` with the GIL held, so a hung cancel round-trip freezes the whole worker, event loop included.
- `connection.close()` from another thread blocks forever on the connection mutex held by the pinned thread.
- `shutdown(SHUT_RDWR)` on the polled descriptor frees every socket-blocked thread, but acts on whatever owns the number now, which in the stolen-number case is someone else's connection. `os.close()` does not wake `poll` at all and hands the number to the next allocation.
- `pthread_cancel`: kills the thread at the C level; Python still sees it alive; the slot is never returned; the connection mutex stays locked.
- Recycling the worker process is the only thing that reaches an orphaned socket, but `SIGTERM` to a uvicorn worker triggers the server's request drain for the whole replica (`sky/server/uvicorn.py`, `_wait_requests`), and any recycle closes every WebSocket on that worker. A detector-gated recycle through uvicorn's own `should_exit` may be worth building later, once this has run in production for a while; not here.

A hung call has to be bounded where it is made: #10684 (auth-path `SET LOCAL` timeouts) and #10687 (idle-in-transaction bound on every engine transaction) do that, and #10689 removes the cause of the pins seen so far.

## Cost (measured, Python 3.10, x86_64, shared 16-vCPU host under load)

| | master | this branch |
|---|---|---|
| `submit()` / round trip, 3000 serial submits, median | 77 / 80 us | 79 / 76 us (within run-to-run noise) |
| rejected `submit()` inside the 60 s floor | 1.5 us | 1.6-2.4 us |
| `sys._current_frames()` at 128 / 300 / 800 threads | | 8 / 15 / 43 us |
| `observe()` at 128 / 300 / 800 tracked threads (once per 10 s per executor) | | 0.1 / 0.3 / 0.8 ms |
| full 8-thread dump without the scan | | 0.8-1.9 ms, ~6.6 KB; longest GIL stall seen on a busy thread 2.2 ms (at 800 threads) |
| ownerless-socket scan (at most 1 per 5 min per process, dump thread only) | | 12 ms here (100-200 connections, 100-170 readable processes); expect 100-300 ms on a pod with 5-25k `/proc/net/tcp` rows and ~900 processes |

Log volume: a saturated executor rejecting 450k submits/s with 32 pinned threads produced 8 dumps in a 40 s run with all intervals scaled down 30x (one change-triggered, then heartbeats doubling to the cap), and a churn scenario (stuck set changing every tick) produced exactly one dump per floor interval. For the incident shape (first pin, 32/32 thirteen minutes later, pod replaced an hour after that) this is about 18 dumps of ~6 KB in the first hour, then one per hour; a thread pinned for 36 h costs about 43 dumps instead of ~2,100 at one per minute.

## Tests

- `tests/unit_tests/test_sky/server/requests/test_threads.py` (+25): start/deadline recorded; gauges; exhaustion dump content with a thread deliberately parked in `poll(2)` (asserts `syscall=poll timeout=infinite` and the descriptor line with `recv-q`); dump only when the slot holders change; change-then-backoff schedule with a fake clock; 60 s floor for a newly stuck thread; at most one dump-thread start per second; a saturated submit still raises `ConcurrentWorkerExhaustedError` when the dump thread cannot start; executor construction survives a failed watchdog start and the next one retries; registered-but-unstarted threads stay tracked; the watchdog tick isolates a failing executor and copies the set under the lock; the real watchdog loop survives failed ticks while executors are built and dropped concurrently; dead-thread purge; DB peer selection for four deployment shapes (pooler as host:port, pooler as URI, no pooler, no database); task-name unwrapping; single watchdog thread per process.
- `tests/unit_tests/test_sky/server/test_hung_threads.py` (+15): `poll`/`recv` decoding; socket peer, state and queues; non-socket descriptors; no fd leak; IPv6 hex forms; bounded output on a bad tid; the stolen-descriptor shape reproduced without a database (a thread in `poll(-1)`, the descriptor closed under it and the number reused by a pipe, the peer writes 68 bytes: invisible without a known peer, found with one, gone once the poll returns); excluded peers left out; unread-reply rows listed first.
- `tests/unit_tests/test_sky/server/requests/test_executor.py` (+1): the auth pool is built with the 30 s threshold.
- 41/41 locally with `pytest -n 2` (this run; an independent re-run of the same set plus one more executor test: 42/42, twice).
- Container check: a `python:3.10` container joined to a PgBouncer 1.20 container's network namespace with its own pid namespace, Postgres 16 behind it in transaction mode. The pooler's server connections are not listed, with or without a direct advisory-lock connection open from the scanning process; a pooled connection orphaned under a sleeping `poll` (descriptor closed, number taken by a pipe, reply landed) is listed as exactly one ownerless socket with `recv-q=65`.
- Mutation check: 16 deliberate regressions (each fix or feature removed one at a time, incl. the four review findings below) each fail exactly the test meant to catch them.
- `format.sh` clean (yapf, isort, mypy; pylint 10/10 on the two modules).

## Known limitations (deliberate; follow-ups)

- No cancellation or recycle (see above).
- An orphaned *direct* connection (the server holds a few for session-level advisory locks) is not reported when a pooler is configured: from this process's `/proc` it cannot be told apart from the pooler's own server connections. `shareProcessNamespace: true` on the pod would make the pooler's descriptors visible and allow re-including that endpoint.
- The scan's auto-discovered peers include every remote that any visible process talks to; another sidecar in the same network namespace talking to a shared peer can add rows. The receive-queue ordering keeps a real orphan at the top, and the summary line counts processes whose descriptors were unreadable.
- A multi-host libpq URI (`host1:5432,host2:5432`) leaves the exclusion list empty, so for that URI shape the pooler's server connections are listed; the pooler itself is still scanned.
- The watchdog thread is not restarted after `fork()` unless the child builds a new executor (no forked child uses these executors today).
- The scan resolves the configured DB hostnames each time it runs (once per 5 min, in the dump thread).
- The request pool's `threads_oldest_age_seconds` is legitimately large (long log streams); alert on the auth pool only, e.g. `sky_apiserver_threads_oldest_age_seconds{name="auth_thread_executor"} > 60` sustained for 2 minutes (a dead worker's per-process gauge file is reaped within about a minute).
- Pre-existing and untouched: `shutdown(wait=True)` can `join()` a thread that was registered but not yet started.
- `db_utils._resolve_conn_string` is called as a private helper to learn the configured endpoints; a public accessor is a small follow-up if preferred.

## Review

Before opening: two adversarial code reviews and two design critiques, each with runs of their own; the last round accepted this head with no blocking finding. Every blocking finding along the way was fixed with a regression test, and the fixes are separate commits: pre-start threads purged from the table (untracked for life); the watchdog killed by a concurrent executor construction (`WeakSet` changed size during iteration); `RuntimeError` escaping a saturated `submit()` at the process thread ceiling instead of `ConcurrentWorkerExhaustedError`; a pooler sidecar's server connections reported as ownerless.

Related: #10681 (the mechanism that produced the pinned threads), #10689 (its fix), #10684 and #10687 (bounds on the DB calls themselves).

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below): see Tests above
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

-Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
