### PR TITLE
[Catalog] Serialize concurrent lazy catalog loads

### DIFF
--- a/sky/catalog/common.py
+++ b/sky/catalog/common.py
@@ -5,6 +5,7 @@ import hashlib
 import math
 import os
 import tempfile
+import threading
 import time
 import typing
 from typing import Any, Callable, Dict, List, NamedTuple, Optional, Tuple, Union
@@ -165,9 +166,16 @@ class LazyDataFrame:
         self._filename = filename
         self._df: Optional['pd.DataFrame'] = None
         self._update_if_stale_func = update_if_stale_func
+        self._load_lock = threading.RLock()
+
+    def _load_df(self) -> 'pd.DataFrame':
+        # lru_cache allows concurrent misses. Lock before the cache lookup so
+        # threads share one catalog read and freshness check per request.
+        with self._load_lock:
+            return self._load_df_cached()
 
     @annotations.lru_cache(scope='request')
-    def _load_df(self) -> 'pd.DataFrame':
+    def _load_df_cached(self) -> 'pd.DataFrame':
         if self._update_if_stale_func() or self._df is None:
             try:
                 self._df = pd.read_csv(self._filename)

--- a/tests/unit_tests/test_catalog.py
+++ b/tests/unit_tests/test_catalog.py
@@ -1,5 +1,7 @@
+import concurrent.futures
 import os
 import tempfile
+import threading
 import time
 from unittest import mock
 
@@ -18,6 +20,85 @@ def test_rtxpro6000_in_common_gpus():
     # list so that `sky show-gpus` surfaces it across clouds. Naming matches
     # the AWS and RunPod catalogs (no hyphens), not GCP's `nvidia-rtx-pro-6000`.
     assert 'RTXPRO6000' in catalog.get_common_gpus()
+
+
+@pytest.mark.parametrize('refresh', [False, True])
+def test_concurrent_catalog_loads_once(refresh):
+    """Cold and stale catalogs share a read and request-level freshness check."""
+    ready = threading.Barrier(8)
+    entered = threading.Event()
+    duplicate = threading.Event()
+    release = threading.Event()
+    expected = pd.DataFrame({'cost': [2]})
+    update = mock.Mock(return_value=False)
+    frame = catalog_common.LazyDataFrame('catalog.csv', update)
+    if refresh:
+        with mock.patch.object(catalog_common.pd,
+                               'read_csv',
+                               return_value=pd.DataFrame({'cost': [1]})):
+            frame._load_df()
+        annotations.clear_request_level_cache()
+        update.reset_mock()
+        update.return_value = True
+
+    calls = 0
+    guard = threading.Lock()
+
+    def read_csv(filename):
+        nonlocal calls
+        assert filename == 'catalog.csv'
+        with guard:
+            calls += 1
+            if calls > 1:
+                duplicate.set()
+        entered.set()
+        assert release.wait(timeout=5)
+        return expected
+
+    def read():
+        ready.wait(timeout=5)
+        return frame._load_df()
+
+    with mock.patch.object(catalog_common.pd, 'read_csv', side_effect=read_csv):
+        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
+            futures = [executor.submit(read) for _ in range(8)]
+            try:
+                assert entered.wait(timeout=5)
+                assert not duplicate.wait(timeout=0.2)
+            finally:
+                release.set()
+            assert all(
+                future.result(timeout=5) is expected for future in futures)
+    assert calls == 1
+    assert update.call_count == 1
+
+
+def test_catalog_read_failure_can_retry():
+    expected = pd.DataFrame({'cost': [1]})
+    frame = catalog_common.LazyDataFrame('catalog.csv', lambda: False)
+    with mock.patch.object(catalog_common.pd,
+                           'read_csv',
+                           side_effect=[ValueError('bad csv'), expected]):
+        with pytest.raises(ValueError, match='bad csv'):
+            frame._load_df()
+        assert frame._load_df() is expected
+
+
+def test_independent_catalogs_load_concurrently():
+    ready = threading.Barrier(2)
+
+    def read_csv(filename):
+        ready.wait(timeout=5)
+        return pd.DataFrame({'source': [filename]})
+
+    frames = [
+        catalog_common.LazyDataFrame(name, lambda: False) for name in ('a', 'b')
+    ]
+    with mock.patch.object(catalog_common.pd, 'read_csv', side_effect=read_csv):
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+            futures = [executor.submit(frame._load_df) for frame in frames]
+            assert [future.result(timeout=5).iloc[0, 0] for future in futures
+                   ] == ['a', 'b']
 
 
 @mock.patch('sky.catalog.common.requests.get')


### PR DESCRIPTION
Concurrent pricing threads in a cost report can all miss `LazyDataFrame._load_df`'s request-level LRU cache and parse the same CSV simultaneously. `functools.lru_cache` protects its cache, but permits the wrapped function to run concurrently on a miss. This duplicates catalog allocations and freshness checks.

Acquire a per-instance lock before looking up the cached load. Waiting readers then reuse the published DataFrame and the request-level freshness result. Independent catalogs retain concurrent loading, and the existing request-cache clearing behavior is preserved.

In two diagnostic subprocesses reading the same 398-row, one-day cost report on SkyPilot 0.13.1rc1, per-catalog serialization reduced Azure CSV parses from **31 to 1** and peak process RSS from **660.9 to 295.0 MiB**. Both returned 398 records. These are single-request measurements of duplicate allocations, not a claim that this fixes all controller memory growth.

Tested:

- [x] `pytest tests/unit_tests/test_catalog.py -n 0 -o addopts= -q` — 59 passed.
- [x] Both new concurrent cold-load and stale-refresh cases fail with unchanged upstream `sky/catalog/common.py` and pass with this change.
- [x] Existing request-boundary refresh test still passes; new tests cover retry after a read failure and independent catalogs loading concurrently.
- [x] Python formatting, import sorting, mypy, and source pylint using the repository's pinned tool versions.

Manual verification: run `pytest tests/unit_tests/test_catalog.py -n 0 -o addopts= -q -k 'concurrent_catalog or catalog_read_failure or independent_catalogs or read_catalog_triggers'`. Expect five passing cases. Each concurrent test releases eight simultaneous readers while holding the CSV read open; only one reader should enter `read_csv`, all should receive the same DataFrame, and freshness should be checked once. The existing stale-file case verifies a new request can fetch changed contents.

No cloud workloads are required for these tests.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10694" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->