### PR TITLE
[Server] Give auth-path DB calls a deadline the DB layer honours, so a hung query frees the executor thread

### DIFF
--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -38,6 +38,7 @@ from sky.utils import registry
 from sky.utils import status_lib
 from sky.utils import yaml_utils
 from sky.utils.db import db_utils
+from sky.utils.db import deadline as db_deadline
 from sky.utils.db import migration_utils
 from sky.utils.db import retries as db_retries
 
@@ -450,6 +451,14 @@ initialize_and_get_db = _db_manager.get_engine
 #   connection (the FATAL was sent while nobody was reading).
 # At the default 5 s deadline these are 3900 / 4000 / 5000 ms.
 #
+# These explicit statements are for callers with no deadline of their own
+# (the request executor's per-request upsert, the user-management
+# endpoints). On the auth path, where the caller sets a thread-local
+# deadline, the engine listener in `sky.utils.db.deadline` sizes the same
+# three timeouts from the *remaining* budget and prepends them to the first
+# statement of the transaction instead (no extra round trips), and the
+# explicit statements are skipped -- see `add_or_update_user`.
+#
 # `SET LOCAL` is transaction-scoped: it applies to this transaction only and
 # resets at COMMIT/ROLLBACK, so it is safe through a transaction-mode
 # connection pooler and leaks nothing into later transactions on the same
@@ -537,8 +546,16 @@ def add_or_update_user(
     if created_at is None:
         created_at = int(time.time())
     with orm.Session(engine) as session:
-        if engine.dialect.name == db_utils.SQLAlchemyDialect.POSTGRESQL.value:
+        if (engine.dialect.name == db_utils.SQLAlchemyDialect.POSTGRESQL.value
+                and not db_deadline.is_bounding(engine)):
             # First statements of the transaction; see the constants above.
+            # Skipped only when this engine's listener in
+            # `sky.utils.db.deadline` is about to bound the transaction itself
+            # (auth-path deadline set AND the listener attached to this
+            # engine): it sizes the same three timeouts from the remaining
+            # budget, with no extra round trips. Callers with no deadline (the
+            # request executor's per-request upsert, the user-management
+            # endpoints) and any engine without the listener keep these.
             _bound_user_upsert_transaction(session)
 
         # Check for duplicate names if not allowed (within the same transaction)

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -440,8 +440,10 @@ initialize_and_get_db = _db_manager.get_engine
 #   generic statement cancel (57014);
 # - statement_timeout bounds each statement itself;
 # - idle_in_transaction_session_timeout terminates a session that goes
-#   quiet inside the transaction (the orphan case; 57P05 on that session's
-#   next statement), which releases the row lock it holds.
+#   quiet inside the transaction (the orphan case), which releases the row
+#   lock it holds. The terminated session's own next statement fails: with
+#   SQLSTATE 25P03 if the client reads the FATAL, otherwise as a closed
+#   connection (the FATAL was sent while nobody was reading).
 #
 # `SET LOCAL` is transaction-scoped: it applies to this transaction only and
 # resets at COMMIT/ROLLBACK, so it is safe through a transaction-mode

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -467,7 +467,10 @@ def _user_upsert_timeouts_ms() -> Tuple[int, int, int]:
     percentage of the configured auth deadline (see the note above).
     Computed per call: the deadline lookup is one environment read, which is
     nothing next to the statements it bounds, and it lets tests vary the
-    deadline.
+    deadline. The read sees the server's own setting only: the variable is
+    stripped from client request payloads and from the per-request
+    environment overlay (`executor.override_request_env_and_config`) before
+    the request worker calls this.
 
     Raises:
         ValueError: if the configured deadline is not a positive number (see

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -425,33 +425,71 @@ initialize_and_get_db = _db_manager.get_engine
 #
 # The upsert runs on the request authentication path for every request, on
 # the API server's bounded auth thread pool, under a client-side deadline
-# (`AUTH_DB_TIMEOUT_SECONDS` in `sky.server.auth.db_lookup`, 5 s; not
-# imported here because this module is not server-only). That deadline frees
-# the caller but not the thread: a thread that waits on the users row lock,
-# or a session that stops talking inside its open transaction, keeps its
-# thread and its connection for as long as the database allows. One orphaned
+# (`AUTH_DB_TIMEOUT_SECONDS` in `sky.server.auth.db_lookup`; not imported
+# here because this module is not server-only). That deadline frees the
+# caller but not the thread: a thread that waits on the users row lock, or a
+# session that stops talking inside its open transaction, keeps its thread
+# and its connection for as long as the database allows. One orphaned
 # session holding a single users row then pins every later upsert of that
 # row until the pool is exhausted.
 #
-# These values MUST stay at or below that deadline, so the database gives up
-# before (or as) the caller does and the thread is released:
-# - lock_timeout < statement_timeout, so a row-lock wait reports the
-#   distinct "lock not available" error (SQLSTATE 55P03) instead of a
-#   generic statement cancel (57014);
-# - statement_timeout bounds each statement itself;
-# - idle_in_transaction_session_timeout terminates a session that goes
-#   quiet inside the transaction (the orphan case), which releases the row
-#   lock it holds. The terminated session's own next statement fails: with
-#   SQLSTATE 25P03 if the client reads the FATAL, otherwise as a closed
+# The three timeouts are therefore derived from that same deadline, read
+# through `db_utils.get_auth_db_timeout_seconds()` (the one place the
+# configured value is parsed), as these percentages of it. They MUST stay at
+# or below the deadline so the database gives up before (or as) the caller
+# does and the thread is released:
+# - lock_timeout (78 %) < statement_timeout (80 %), so a row-lock wait
+#   reports the distinct "lock not available" error (SQLSTATE 55P03) instead
+#   of a generic statement cancel (57014);
+# - statement_timeout (80 %) bounds each statement itself, with a little
+#   headroom under the deadline for the round trip;
+# - idle_in_transaction_session_timeout (100 %) terminates a session that
+#   goes quiet inside the transaction (the orphan case), which releases the
+#   row lock it holds. The terminated session's own next statement fails:
+#   with SQLSTATE 25P03 if the client reads the FATAL, otherwise as a closed
 #   connection (the FATAL was sent while nobody was reading).
+# At the default 5 s deadline these are 3900 / 4000 / 5000 ms.
 #
 # `SET LOCAL` is transaction-scoped: it applies to this transaction only and
 # resets at COMMIT/ROLLBACK, so it is safe through a transaction-mode
 # connection pooler and leaks nothing into later transactions on the same
 # server connection.
-_USER_UPSERT_LOCK_TIMEOUT_MS = 3900
-_USER_UPSERT_STATEMENT_TIMEOUT_MS = 4000
-_USER_UPSERT_IDLE_IN_TRANSACTION_TIMEOUT_MS = 5000
+_USER_UPSERT_LOCK_TIMEOUT_PERCENT = 78
+_USER_UPSERT_STATEMENT_TIMEOUT_PERCENT = 80
+_USER_UPSERT_IDLE_IN_TRANSACTION_TIMEOUT_PERCENT = 100
+
+
+def _user_upsert_timeouts_ms() -> Tuple[int, int, int]:
+    """The users upsert's server-side timeouts, in whole milliseconds.
+
+    Returns ``(lock_timeout, statement_timeout,
+    idle_in_transaction_session_timeout)``, each the corresponding
+    percentage of the configured auth deadline (see the note above).
+    Computed per call: the deadline lookup is one environment read, which is
+    nothing next to the statements it bounds, and it lets tests vary the
+    deadline.
+
+    Raises:
+        ValueError: if the configured deadline is not a positive number (see
+            `db_utils.get_auth_db_timeout_seconds`), or is so small that the
+            three values would not be distinct, ordered, positive integers.
+            Postgres treats a timeout of ``0`` as *disabled*, so a rounding
+            to zero must never reach the database.
+    """
+    deadline_ms = db_utils.get_auth_db_timeout_seconds() * 1000
+    lock_ms = round(deadline_ms * _USER_UPSERT_LOCK_TIMEOUT_PERCENT / 100)
+    statement_ms = round(deadline_ms * _USER_UPSERT_STATEMENT_TIMEOUT_PERCENT /
+                         100)
+    idle_ms = round(deadline_ms *
+                    _USER_UPSERT_IDLE_IN_TRANSACTION_TIMEOUT_PERCENT / 100)
+    if not 0 < lock_ms < statement_ms < idle_ms:
+        raise ValueError(
+            f'{constants.ENV_VAR_AUTH_DB_TIMEOUT_SECONDS} is too small '
+            f'({deadline_ms} ms) to derive distinct server-side timeouts for '
+            f'the users upsert (got lock_timeout={lock_ms}ms, '
+            f'statement_timeout={statement_ms}ms, '
+            f'idle_in_transaction_session_timeout={idle_ms}ms).')
+    return lock_ms, statement_ms, idle_ms
 
 
 def _bound_user_upsert_transaction(session: orm.Session) -> None:
@@ -464,14 +502,14 @@ def _bound_user_upsert_transaction(session: orm.Session) -> None:
     through SQLAlchemy's normal error handling and reaches the caller as a
     regular DB error.
     """
+    lock_ms, statement_ms, idle_ms = _user_upsert_timeouts_ms()
     for parameter, value_ms in (
-        ('lock_timeout', _USER_UPSERT_LOCK_TIMEOUT_MS),
-        ('statement_timeout', _USER_UPSERT_STATEMENT_TIMEOUT_MS),
-        ('idle_in_transaction_session_timeout',
-         _USER_UPSERT_IDLE_IN_TRANSACTION_TIMEOUT_MS),
+        ('lock_timeout', lock_ms),
+        ('statement_timeout', statement_ms),
+        ('idle_in_transaction_session_timeout', idle_ms),
     ):
-        # SET does not accept bind parameters; the values are module
-        # constants, never user input.
+        # SET does not accept bind parameters; the values are integers
+        # derived from a validated setting, never user input.
         session.execute(
             sqlalchemy.text(f'SET LOCAL {parameter} = \'{value_ms}ms\''))
 

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -421,6 +421,58 @@ _db_manager = db_utils.DatabaseManager(
     'state', create_table, post_init_fn=lambda _: _sqlite_supports_returning())
 initialize_and_get_db = _db_manager.get_engine
 
+# Server-side bounds on the `users` upsert transaction (Postgres only).
+#
+# The upsert runs on the request authentication path for every request, on
+# the API server's bounded auth thread pool, under a client-side deadline
+# (`AUTH_DB_TIMEOUT_SECONDS` in `sky.server.auth.db_lookup`, 5 s; not
+# imported here because this module is not server-only). That deadline frees
+# the caller but not the thread: a thread that waits on the users row lock,
+# or a session that stops talking inside its open transaction, keeps its
+# thread and its connection for as long as the database allows. One orphaned
+# session holding a single users row then pins every later upsert of that
+# row until the pool is exhausted.
+#
+# These values MUST stay at or below that deadline, so the database gives up
+# before (or as) the caller does and the thread is released:
+# - lock_timeout < statement_timeout, so a row-lock wait reports the
+#   distinct "lock not available" error (SQLSTATE 55P03) instead of a
+#   generic statement cancel (57014);
+# - statement_timeout bounds each statement itself;
+# - idle_in_transaction_session_timeout terminates a session that goes
+#   quiet inside the transaction (the orphan case; 57P05 on that session's
+#   next statement), which releases the row lock it holds.
+#
+# `SET LOCAL` is transaction-scoped: it applies to this transaction only and
+# resets at COMMIT/ROLLBACK, so it is safe through a transaction-mode
+# connection pooler and leaks nothing into later transactions on the same
+# server connection.
+_USER_UPSERT_LOCK_TIMEOUT_MS = 3900
+_USER_UPSERT_STATEMENT_TIMEOUT_MS = 4000
+_USER_UPSERT_IDLE_IN_TRANSACTION_TIMEOUT_MS = 5000
+
+
+def _bound_user_upsert_transaction(session: orm.Session) -> None:
+    """Issue the `SET LOCAL` timeouts for the users upsert transaction.
+
+    Must run before any other statement in the session: the Session
+    auto-begins its transaction on the first statement, and `SET LOCAL`
+    only takes effect inside that transaction. Issued explicitly through
+    the Session (not from an engine event hook) so a failure here goes
+    through SQLAlchemy's normal error handling and reaches the caller as a
+    regular DB error.
+    """
+    for parameter, value_ms in (
+        ('lock_timeout', _USER_UPSERT_LOCK_TIMEOUT_MS),
+        ('statement_timeout', _USER_UPSERT_STATEMENT_TIMEOUT_MS),
+        ('idle_in_transaction_session_timeout',
+         _USER_UPSERT_IDLE_IN_TRANSACTION_TIMEOUT_MS),
+    ):
+        # SET does not accept bind parameters; the values are module
+        # constants, never user input.
+        session.execute(
+            sqlalchemy.text(f'SET LOCAL {parameter} = \'{value_ms}ms\''))
+
 
 @metrics_lib.time_me
 def add_or_update_user(
@@ -442,6 +494,10 @@ def add_or_update_user(
     if created_at is None:
         created_at = int(time.time())
     with orm.Session(engine) as session:
+        if engine.dialect.name == db_utils.SQLAlchemyDialect.POSTGRESQL.value:
+            # First statements of the transaction; see the constants above.
+            _bound_user_upsert_transaction(session)
+
         # Check for duplicate names if not allowed (within the same transaction)
         if not allow_duplicate_name:
             existing_user = session.query(user_table).filter(

--- a/sky/metrics/utils.py
+++ b/sky/metrics/utils.py
@@ -334,6 +334,32 @@ SKY_APISERVER_THREADS_EXHAUSTED_TOTAL = prom.Counter(
     ['name'],
 )
 
+# Auth-path DB lookups that gave up at their own deadline instead of pinning
+# the executor thread. Small fixed label set (one value per way the deadline
+# fired):
+#   lock_timeout / statement_timeout / idle_in_transaction -- the server
+#     enforced the bound (a held row lock, a slow statement, an orphaned
+#     transaction);
+#   client_deadline -- the client gave up waiting on the socket (server
+#     unreachable/frozen);
+#   connect_timeout -- the DSN's connect_timeout passed during the connection
+#     handshake (an unreachable server or pooler);
+#   client_deadline_fd_stolen / client_deadline_fd_closed -- the socket's fd
+#     no longer identified our connection when the deadline fired (the
+#     stolen-fd class): a per-worker production detector for the fd double
+#     close, independent of the RCA;
+#   db_error -- a non-deadline transient DB error (connection dropped) mapped
+#     to a retryable 503 rather than a bare 500;
+#   caller_timeout -- asyncio.wait_for fired while the thread was still
+#     running, i.e. a bound below it did NOT free the thread. After this
+#     change it should stay ~0; a sustained rate is the "thread pinned"
+#     alarm.
+SKY_APISERVER_AUTH_DB_DEADLINE_TOTAL = prom.Counter(
+    'sky_apiserver_auth_db_deadline_total',
+    'Auth-path DB lookups that hit their own deadline, by how it fired',
+    ['reason'],
+)
+
 # Time a request spends waiting in the task queue (from creation to dequeue).
 SKY_APISERVER_QUEUE_WAIT_SECONDS = prom.Histogram(
     'sky_apiserver_queue_wait_seconds',

--- a/sky/server/auth/db_lookup.py
+++ b/sky/server/auth/db_lookup.py
@@ -23,7 +23,6 @@ only, so an exception raised in a middleware surfaces as a bare 500,
 which clients do not retry.
 """
 import asyncio
-import os
 from typing import Any, Callable, Optional
 
 import fastapi
@@ -34,6 +33,7 @@ from sky.server.requests import executor
 from sky.users import permission
 from sky.utils import common_utils
 from sky.utils import context_utils
+from sky.utils.db import db_utils
 
 logger = sky_logging.init_logger(__name__)
 
@@ -42,14 +42,20 @@ logger = sky_logging.init_logger(__name__)
 # trouble, while staying well below the SQLAlchemy pool checkout timeout
 # (30s) and typical pooler queue-wait timeouts so requests fail fast
 # before executor threads pile up.
-AUTH_DB_TIMEOUT_SECONDS = float(
-    os.environ.get('SKYPILOT_AUTH_DB_TIMEOUT_SECONDS', '5'))
+#
+# Configured by `constants.ENV_VAR_AUTH_DB_TIMEOUT_SECONDS` (default 5 s),
+# read through the shared helper so the server-side timeouts the users
+# upsert derives from the same value cannot drift from this one. A value
+# that is not a positive number fails here, at server startup, with a
+# message naming the variable.
+AUTH_DB_TIMEOUT_SECONDS = db_utils.get_auth_db_timeout_seconds()
 
 # Postgres SQLSTATE codes raised when the database itself gives up on an
 # auth-path call at a server-side timeout. The users upsert sets these
-# timeouts on its own transaction (see `global_user_state.add_or_update_user`)
-# at or below `AUTH_DB_TIMEOUT_SECONDS`, so the database normally fails the
-# call *before* `asyncio.wait_for` does -- and, unlike `wait_for`, actually
+# timeouts on its own transaction (see `global_user_state.add_or_update_user`),
+# derived from the same configured deadline as `AUTH_DB_TIMEOUT_SECONDS` and
+# strictly below or equal to it, so the database normally fails the call
+# *before* `asyncio.wait_for` does -- and, unlike `wait_for`, actually
 # releases the executor thread. Such an error is the same condition as the
 # client-side deadline (a slow or locked database) and gets the same
 # retryable 503; anything else still propagates unchanged.

--- a/sky/server/auth/db_lookup.py
+++ b/sky/server/auth/db_lookup.py
@@ -64,9 +64,9 @@ AUTH_DB_TIMEOUT_SECONDS = db_utils.get_auth_db_timeout_seconds()
 # *thread* is freed -- by the server-side SET LOCAL bounds and the psycopg2
 # wait callback in `sky.utils.db.deadline` -- before `wait_for` releases only
 # the caller. The server-side bounds fire a further margin earlier (see
-# `deadline._SERVER_MARGIN_MS`), so at the default deadline
-# (`constants.DEFAULT_AUTH_DB_TIMEOUT_SECONDS`, 5 s) the order is: lock
-# ~3.9s < statement ~4.0s < thread (client) 4.5s < wait_for 5.0s.
+# `deadline._SERVER_MARGIN_MS` / `_LOCK_UNDER_MS`), so for a configured
+# deadline D the order is: lock D-1.1s < statement D-1.0s < thread (client)
+# D-0.5s < wait_for D (e.g. D = 5 s: 3.9 < 4.0 < 4.5 < 5.0).
 _CLIENT_DEADLINE_MARGIN_SECONDS = 0.5
 # Floor on the inner (DB-layer) budget. `db_utils.get_auth_db_timeout_seconds`
 # already refuses a deadline that is not a positive number, and the users

--- a/sky/server/auth/db_lookup.py
+++ b/sky/server/auth/db_lookup.py
@@ -45,16 +45,72 @@ logger = sky_logging.init_logger(__name__)
 AUTH_DB_TIMEOUT_SECONDS = float(
     os.environ.get('SKYPILOT_AUTH_DB_TIMEOUT_SECONDS', '5'))
 
+# Postgres SQLSTATE codes raised when the database itself gives up on an
+# auth-path call at a server-side timeout. The users upsert sets these
+# timeouts on its own transaction (see `global_user_state.add_or_update_user`)
+# at or below `AUTH_DB_TIMEOUT_SECONDS`, so the database normally fails the
+# call *before* `asyncio.wait_for` does -- and, unlike `wait_for`, actually
+# releases the executor thread. Such an error is the same condition as the
+# client-side deadline (a slow or locked database) and gets the same
+# retryable 503; anything else still propagates unchanged.
+_SERVER_TIMEOUT_PGCODES = {
+    '55P03': 'lock_timeout',  # LockNotAvailable
+    '57014': 'statement_timeout',  # QueryCanceled
+    '57P05': 'idle_in_transaction_session_timeout',
+}
+
+
+class AuthDBTimeoutError(asyncio.TimeoutError):
+    """An auth DB call was cut off by the database's own timeout.
+
+    Subclasses ``asyncio.TimeoutError`` so every ``except asyncio.TimeoutError``
+    in the auth middlewares keeps answering ``db_timeout_response()`` unchanged.
+    """
+
+
+def _server_timeout_pgcode(exc: BaseException) -> Optional[str]:
+    """``exc``'s SQLSTATE if it is one of the server-side timeouts, else None.
+
+    ``sqlalchemy.exc.DBAPIError`` wraps the driver's error as ``.orig``; a
+    driver error that escaped unwrapped (raw connections) carries ``pgcode``
+    itself. Duck-typed so this module does not import psycopg2, which is a
+    server-only dependency.
+    """
+    orig = getattr(exc, 'orig', exc)
+    pgcode = getattr(orig, 'pgcode', None)
+    if pgcode in _SERVER_TIMEOUT_PGCODES:
+        return pgcode
+    return None
+
+
+async def _run_with_deadline(pool: Any, func: Callable[..., Any],
+                             *args: Any) -> Any:
+    try:
+        return await asyncio.wait_for(context_utils.to_thread_with_executor(
+            pool, func, *args),
+                                      timeout=AUTH_DB_TIMEOUT_SECONDS)
+    except Exception as e:  # pylint: disable=broad-except
+        pgcode = _server_timeout_pgcode(e)
+        if pgcode is None:
+            raise
+        reason = _SERVER_TIMEOUT_PGCODES[pgcode]
+        logger.warning(f'Auth DB call {getattr(func, "__name__", func)} was '
+                       f'cut off by the database\'s {reason} '
+                       f'(pgcode {pgcode}): '
+                       f'{common_utils.format_exception(e)}')
+        raise AuthDBTimeoutError(reason) from e
+
 
 async def call_with_deadline(func: Callable[..., Any], *args: Any) -> Any:
     """Run a sync auth DB lookup on the auth executor with a total deadline.
 
-    Raises ``asyncio.TimeoutError`` when the deadline elapses and
-    ``ConcurrentWorkerExhaustedError`` when the executor is saturated.
+    Raises ``asyncio.TimeoutError`` when the deadline elapses (or when the
+    database cut the call off at its own, aligned timeout -- see
+    `_SERVER_TIMEOUT_PGCODES`) and ``ConcurrentWorkerExhaustedError`` when
+    the executor is saturated.
     """
-    return await asyncio.wait_for(context_utils.to_thread_with_executor(
-        executor.get_auth_thread_executor(), func, *args),
-                                  timeout=AUTH_DB_TIMEOUT_SECONDS)
+    return await _run_with_deadline(executor.get_auth_thread_executor(), func,
+                                    *args)
 
 
 async def _call_on_request_pool(func: Callable[..., Any], *args: Any) -> Any:
@@ -68,9 +124,8 @@ async def _call_on_request_pool(func: Callable[..., Any], *args: Any) -> Any:
     `POLICY_UPDATE_LOCK_TIMEOUT_SECONDS` would otherwise let a burst of first
     logins exhaust authentication for every other request on this worker.
     """
-    return await asyncio.wait_for(context_utils.to_thread_with_executor(
-        executor.get_request_thread_executor(), func, *args),
-                                  timeout=AUTH_DB_TIMEOUT_SECONDS)
+    return await _run_with_deadline(executor.get_request_thread_executor(),
+                                    func, *args)
 
 
 async def ensure_role_for_authenticated_user(

--- a/sky/server/auth/db_lookup.py
+++ b/sky/server/auth/db_lookup.py
@@ -56,7 +56,7 @@ AUTH_DB_TIMEOUT_SECONDS = float(
 _SERVER_TIMEOUT_PGCODES = {
     '55P03': 'lock_timeout',  # LockNotAvailable
     '57014': 'statement_timeout',  # QueryCanceled
-    '57P05': 'idle_in_transaction_session_timeout',
+    '25P03': 'idle_in_transaction_session_timeout',
 }
 
 

--- a/sky/server/auth/db_lookup.py
+++ b/sky/server/auth/db_lookup.py
@@ -8,14 +8,18 @@ thread running it, for as long as the DB layer allows. At a hold time of
 minutes the bounded auth executor saturates within seconds and every
 authenticated endpoint fails for the duration of the DB incident.
 
-``call_with_deadline`` puts a client-side total deadline on each lookup.
-``asyncio.wait_for`` is deliberately the bounding layer: a server-side
-``statement_timeout`` cannot cover time spent queued inside a transaction
-pooler (no server connection is assigned yet) or waiting for a pool
-checkout. On timeout the request fails fast with a 503 the client retries
-with backoff; note the executor thread itself keeps running until the DB
-layer releases it, so the auth executor still acts as a saturation
-buffer — requests beyond it fail fast with the worker-exhausted 503.
+``call_with_deadline`` puts a total deadline on each lookup, enforced at
+two levels. ``asyncio.wait_for`` bounds the *caller*: it also covers time
+spent queued inside a transaction pooler (no server connection is assigned
+yet) or waiting for a pool checkout, and on timeout the request fails fast
+with a 503 the client retries with backoff. The same deadline is handed to
+the DB layer (`sky.utils.db.deadline`: ``SET LOCAL`` timeouts on the
+transaction, and a psycopg2 wait callback) so the *thread* gives up too.
+Without that, a thread parked in the DB driver keeps running until the DB
+layer releases it, and enough of them saturate the auth executor -- every
+authenticated endpoint then fails until the process restarts. The executor
+still acts as a saturation buffer: requests beyond it fail fast with the
+worker-exhausted 503.
 
 Both timeout and executor exhaustion must be converted to responses
 *inside* the middleware: app-level exception handlers wrap the router
@@ -23,17 +27,21 @@ only, so an exception raised in a middleware surfaces as a bare 500,
 which clients do not retry.
 """
 import asyncio
+import concurrent.futures
+import time
 from typing import Any, Callable, Optional
 
 import fastapi
 
 from sky import exceptions
 from sky import sky_logging
+from sky.metrics import utils as metrics_utils
 from sky.server.requests import executor
 from sky.users import permission
 from sky.utils import common_utils
 from sky.utils import context_utils
 from sky.utils.db import db_utils
+from sky.utils.db import deadline as db_deadline
 
 logger = sky_logging.init_logger(__name__)
 
@@ -43,77 +51,136 @@ logger = sky_logging.init_logger(__name__)
 # (30s) and typical pooler queue-wait timeouts so requests fail fast
 # before executor threads pile up.
 #
-# Configured by `constants.ENV_VAR_AUTH_DB_TIMEOUT_SECONDS` (default 5 s),
-# read through the shared helper so the server-side timeouts the users
-# upsert derives from the same value cannot drift from this one. A value
-# that is not a positive number fails here, at server startup, with a
+# Configured by `constants.ENV_VAR_AUTH_DB_TIMEOUT_SECONDS` (default
+# `constants.DEFAULT_AUTH_DB_TIMEOUT_SECONDS`, 5 s), read through the shared
+# helper so the server-side timeouts derived from the same value -- the users
+# upsert's explicit `SET LOCAL` statements and the deadline-sized ones
+# `sky.utils.db.deadline` adds under this deadline -- cannot drift from it. A
+# value that is not a positive number fails here, at server startup, with a
 # message naming the variable.
 AUTH_DB_TIMEOUT_SECONDS = db_utils.get_auth_db_timeout_seconds()
 
-# Postgres SQLSTATE codes raised when the database itself gives up on an
-# auth-path call at a server-side timeout. The users upsert sets these
-# timeouts on its own transaction (see `global_user_state.add_or_update_user`),
-# derived from the same configured deadline as `AUTH_DB_TIMEOUT_SECONDS` and
-# strictly below or equal to it, so the database normally fails the call
-# *before* `asyncio.wait_for` does -- and, unlike `wait_for`, actually
-# releases the executor thread. Such an error is the same condition as the
-# client-side deadline (a slow or locked database) and gets the same
-# retryable 503; anything else still propagates unchanged.
-_SERVER_TIMEOUT_PGCODES = {
-    '55P03': 'lock_timeout',  # LockNotAvailable
-    '57014': 'statement_timeout',  # QueryCanceled
-    '25P03': 'idle_in_transaction_session_timeout',
-}
+# The DB work gives up this far before the caller's `wait_for`, so the
+# *thread* is freed -- by the server-side SET LOCAL bounds and the psycopg2
+# wait callback in `sky.utils.db.deadline` -- before `wait_for` releases only
+# the caller. The server-side bounds fire a further margin earlier (see
+# `deadline._SERVER_MARGIN_MS`), so at the default deadline
+# (`constants.DEFAULT_AUTH_DB_TIMEOUT_SECONDS`, 5 s) the order is: lock
+# ~3.9s < statement ~4.0s < thread (client) 4.5s < wait_for 5.0s.
+_CLIENT_DEADLINE_MARGIN_SECONDS = 0.5
+# Floor on the inner (DB-layer) budget. `db_utils.get_auth_db_timeout_seconds`
+# already refuses a deadline that is not a positive number, and the users
+# upsert refuses one too small to order its own percentage-derived timeouts
+# (tens of ms); this floor covers the deadlines in between that are shorter
+# than the margin above (< 0.55 s): the DB layer then gets 50 ms rather than
+# nothing, and the SET LOCAL values collapse to their own floor
+# (`deadline._MIN_TIMEOUT_MS`, so lock == statement and a lock wait reports
+# 57014 rather than 55P03). A deadline that small is a misconfiguration, but
+# it must not turn every auth call into an instant failure.
+_MIN_INNER_BUDGET_SECONDS = 0.05
 
 
 class AuthDBTimeoutError(asyncio.TimeoutError):
-    """An auth DB call was cut off by the database's own timeout.
+    """An auth DB call gave up at its deadline -- in the database or the client.
 
     Subclasses ``asyncio.TimeoutError`` so every ``except asyncio.TimeoutError``
     in the auth middlewares keeps answering ``db_timeout_response()`` unchanged.
+    ``reason`` names how it gave up; it is the label of
+    ``sky_apiserver_auth_db_deadline_total`` (see `sky.metrics.utils`).
     """
 
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
 
-def _server_timeout_pgcode(exc: BaseException) -> Optional[str]:
-    """``exc``'s SQLSTATE if it is one of the server-side timeouts, else None.
 
-    ``sqlalchemy.exc.DBAPIError`` wraps the driver's error as ``.orig``; a
-    driver error that escaped unwrapped (raw connections) carries ``pgcode``
-    itself. Duck-typed so this module does not import psycopg2, which is a
-    server-only dependency.
+def install_auth_db_deadline() -> bool:
+    """Install the process-global psycopg2 wait callback (green mode).
+
+    Call once from the API-server process startup (the server lifespan), never
+    at import time: a plugin importing this module in a request-executor
+    process must not turn green mode on there. Idempotent. False (and a
+    warning) when psycopg2 is not importable -- a sqlite-only deployment
+    keeps starting.
     """
-    orig = getattr(exc, 'orig', exc)
-    pgcode = getattr(orig, 'pgcode', None)
-    if pgcode in _SERVER_TIMEOUT_PGCODES:
-        return pgcode
-    return None
+    return db_deadline.install_wait_callback()
 
 
-async def _run_with_deadline(pool: Any, func: Callable[..., Any],
-                             *args: Any) -> Any:
+async def _run_with_deadline(pool: concurrent.futures.Executor,
+                             func: Callable[..., Any], *args: Any) -> Any:
+    """Run a sync auth DB call on ``pool`` with a deadline the DB layer honours.
+
+    Sets a thread-local deadline for the call (same origin as ``wait_for``, so
+    a busy pool or a loop stall cannot make the two disagree). The DB layer --
+    the ``SET LOCAL`` bounds the engine listener adds to the transaction and
+    the psycopg2 wait callback -- gives up at that deadline, which frees the
+    executor thread; ``wait_for`` only ever frees the caller.
+
+    What the DB layer raises is translated, on the worker thread, into
+    ``AuthDBTimeoutError`` (an ``asyncio.TimeoutError``): a deadline the
+    database or the client enforced, and also a transient driver error (the
+    connection dropped under the call), which is the client's bad luck rather
+    than a bad request and gets the same retryable 503 instead of a bare 500.
+    Every other error (a programming or integrity error) propagates unchanged.
+    """
+    budget = AUTH_DB_TIMEOUT_SECONDS
+    inner = max(_MIN_INNER_BUDGET_SECONDS,
+                budget - _CLIENT_DEADLINE_MARGIN_SECONDS)
+    start = time.monotonic()
+    deadline_at = start + inner
+    name = getattr(func, '__name__', repr(func))
+
+    def _run() -> Any:
+        db_deadline.set_deadline(deadline_at)
+        outcome = 'ok'
+        try:
+            return func(*args)
+        except Exception as e:  # pylint: disable=broad-except
+            reason = db_deadline.deadline_reason(e)
+            if reason is None and db_deadline.is_transient_driver_error(e):
+                reason = 'db_error'
+            outcome = reason or type(e).__name__
+            if reason is None:
+                raise
+            raise AuthDBTimeoutError(reason) from e
+        finally:
+            db_deadline.clear_deadline()
+            late = time.monotonic() - (start + budget)
+            if late > 0:
+                # `wait_for` has (almost certainly) already released the
+                # caller and counted `caller_timeout`; this outcome lands on a
+                # cancelled future and would otherwise vanish. Keep it visible:
+                # it says what finally freed a thread the executor may have
+                # reported as stuck.
+                logger.info(f'Auth DB call {name} finished {late:.1f}s after '
+                            f'its caller\'s {budget}s deadline ({outcome}); '
+                            f'the executor thread was held until now.')
+
     try:
         return await asyncio.wait_for(context_utils.to_thread_with_executor(
-            pool, func, *args),
-                                      timeout=AUTH_DB_TIMEOUT_SECONDS)
-    except Exception as e:  # pylint: disable=broad-except
-        pgcode = _server_timeout_pgcode(e)
-        if pgcode is None:
-            raise
-        reason = _SERVER_TIMEOUT_PGCODES[pgcode]
-        logger.warning(f'Auth DB call {getattr(func, "__name__", func)} was '
-                       f'cut off by the database\'s {reason} '
-                       f'(pgcode {pgcode}): '
-                       f'{common_utils.format_exception(e)}')
-        raise AuthDBTimeoutError(reason) from e
+            pool, _run),
+                                      timeout=budget)
+    except AuthDBTimeoutError as e:
+        metrics_utils.SKY_APISERVER_AUTH_DB_DEADLINE_TOTAL.labels(
+            reason=e.reason).inc()
+        logger.warning(f'Auth DB call {name} gave up at its deadline '
+                       f'({e.reason}): '
+                       f'{common_utils.format_exception(e.__cause__ or e)}')
+        raise
+    except asyncio.TimeoutError:
+        # wait_for fired while the thread is still running: no bound below it
+        # freed the thread (a Python-level block, not DB I/O). The alarm label.
+        metrics_utils.SKY_APISERVER_AUTH_DB_DEADLINE_TOTAL.labels(
+            reason='caller_timeout').inc()
+        raise
 
 
 async def call_with_deadline(func: Callable[..., Any], *args: Any) -> Any:
     """Run a sync auth DB lookup on the auth executor with a total deadline.
 
-    Raises ``asyncio.TimeoutError`` when the deadline elapses (or when the
-    database cut the call off at its own, aligned timeout -- see
-    `_SERVER_TIMEOUT_PGCODES`) and ``ConcurrentWorkerExhaustedError`` when
-    the executor is saturated.
+    Raises ``asyncio.TimeoutError`` (``AuthDBTimeoutError``) when the deadline
+    elapses -- whether the database, the client or `wait_for` enforced it --
+    and ``ConcurrentWorkerExhaustedError`` when the executor is saturated.
     """
     return await _run_with_deadline(executor.get_auth_thread_executor(), func,
                                     *args)
@@ -165,15 +232,18 @@ async def ensure_role_for_authenticated_user(
                          f'{user_id}: {e}')
             permission.permission_service.queue_role_repair(user_id)
             return worker_exhausted_response()
-        except asyncio.TimeoutError:
+        except asyncio.TimeoutError as e:
             # Separated from the clause below for the log, not the answer: the
-            # deadline elapsed but the seed is still running in its thread and
-            # usually lands, whereas the cases below have already failed. The
-            # caller gets the same 503 either way -- from a client's side both
-            # are "not ready yet, come back".
+            # seed hit the auth deadline. Either the DB layer cut it off (an
+            # `AuthDBTimeoutError`: the transaction was rolled back and the
+            # thread freed) or `wait_for` fired first and the seed is still
+            # running in its thread. The caller gets the same 503 either way
+            # -- from a client's side both are "not ready yet, come back" --
+            # and the queued repair redoes the seed.
+            how = getattr(e, 'reason', 'caller timeout')
             logger.error(f'Seeding a role for new user {user_id} did not '
-                         f'finish within {AUTH_DB_TIMEOUT_SECONDS}s; queueing '
-                         f'it off the request')
+                         f'finish within {AUTH_DB_TIMEOUT_SECONDS}s ({how}); '
+                         f'queueing it off the request')
             permission.permission_service.queue_role_repair(user_id)
             return role_seed_unavailable_response()
         except Exception as e:  # pylint: disable=broad-except

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -712,6 +712,12 @@ def override_request_env_and_config(
             # Remove the db connection uri from client supplied env vars, as
             # the client should not set the db string on server side.
             request_body.env_vars.pop(constants.ENV_VAR_DB_CONNECTION_URI, None)
+            # Likewise the auth DB deadline: `add_or_update_user` below derives
+            # the server-side timeouts on its own transaction from it, and a
+            # client (in particular an older one that still forwards the
+            # variable) must not be able to loosen or break them.
+            request_body.env_vars.pop(constants.ENV_VAR_AUTH_DB_TIMEOUT_SECONDS,
+                                      None)
             # Remove the in-cluster context name from client supplied env
             # vars. When a client runs inside a Kubernetes pod (e.g., a
             # managed job with api_server_access), its env has

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -103,6 +103,10 @@ def request_body_env_vars() -> dict:
     # Any new environment variables that are server-specific should
     # use SKYPILOT_SERVER_ENV_VAR_PREFIX.
     env_vars.pop(constants.ENV_VAR_DB_CONNECTION_URI, None)
+    # The auth DB deadline is a server-side setting: the server derives the
+    # timeouts it puts on its own users upsert from it, so a client must not
+    # be able to supply it.
+    env_vars.pop(constants.ENV_VAR_AUTH_DB_TIMEOUT_SECONDS, None)
     # Remove the in-cluster context name - this is only meaningful for the
     # local Kubernetes environment and should not be forwarded to the server,
     # which has its own cluster context configuration.

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -1007,6 +1007,13 @@ async def lifespan(app: fastapi.FastAPI):  # pylint: disable=redefined-outer-nam
     """FastAPI lifespan context manager."""
     del app  # unused
 
+    # Bound every psycopg2 wait in this web process by the caller's deadline,
+    # so a hung auth DB lookup gives up and frees its executor thread instead
+    # of pinning it. Installed here (from the process that serves the app),
+    # not as an import side effect, so it never lands in request-executor
+    # processes that merely import the auth modules.
+    db_lookup.install_auth_db_deadline()
+
     # Startup: Run background tasks. Delete any persisted daemon rows whose
     # ids are no longer in INTERNAL_REQUEST_DAEMONS first (daemon renamed /
     # removed in code), then submit each current daemon.

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -734,7 +734,8 @@ ENV_VAR_DB_POOL_HOSTPORT = (f'{SKYPILOT_ENV_VAR_PREFIX}DB_POOL_HOSTPORT')
 # from the same value (`sky.global_user_state.add_or_update_user`), so read
 # it through `sky.utils.db.db_utils.get_auth_db_timeout_seconds()` rather
 # than from the environment directly: that keeps the two from drifting
-# apart.
+# apart. Server-side only: it is stripped from client request payloads and
+# from the per-request environment overlay on the server.
 ENV_VAR_AUTH_DB_TIMEOUT_SECONDS = (
     f'{SKYPILOT_ENV_VAR_PREFIX}AUTH_DB_TIMEOUT_SECONDS')
 DEFAULT_AUTH_DB_TIMEOUT_SECONDS = 5.0

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -728,6 +728,17 @@ ENV_VAR_DB_POOL_CONNECTION_URI = (
     f'{SKYPILOT_ENV_VAR_PREFIX}DB_POOL_CONNECTION_URI')
 ENV_VAR_DB_POOL_HOSTPORT = (f'{SKYPILOT_ENV_VAR_PREFIX}DB_POOL_HOSTPORT')
 
+# Total deadline, in seconds, on each DB lookup the API server's
+# authentication middlewares make (`sky.server.auth.db_lookup`). The users
+# upsert derives the server-side timeouts it sets on its own transaction
+# from the same value (`sky.global_user_state.add_or_update_user`), so read
+# it through `sky.utils.db.db_utils.get_auth_db_timeout_seconds()` rather
+# than from the environment directly: that keeps the two from drifting
+# apart.
+ENV_VAR_AUTH_DB_TIMEOUT_SECONDS = (
+    f'{SKYPILOT_ENV_VAR_PREFIX}AUTH_DB_TIMEOUT_SECONDS')
+DEFAULT_AUTH_DB_TIMEOUT_SECONDS = 5.0
+
 # Environment variable that is set to 'true' if basic
 # authentication is enabled in the API server.
 ENV_VAR_ENABLE_BASIC_AUTH = 'ENABLE_BASIC_AUTH'

--- a/sky/users/permission.py
+++ b/sky/users/permission.py
@@ -22,6 +22,7 @@ from sky.utils import common
 from sky.utils import common_utils
 from sky.utils import locks
 from sky.utils.db import db_utils
+from sky.utils.db import deadline as db_deadline
 from sky.utils.db import kv_cache
 from sky.workspaces import constants as workspace_constants
 from sky.workspaces import utils as workspaces_utils
@@ -699,6 +700,14 @@ class PermissionService:
         try:
             self._load_policy_no_lock()
         except Exception as e:  # pylint: disable=broad-except
+            if db_deadline.is_deadline_error(e):
+                # The reload hit the caller's auth-path deadline (a slow DB or a
+                # held lock). Do NOT swallow it into "no roles" -- that denies
+                # the principal with a non-retryable 403. Re-raise so the
+                # middleware maps it to the retryable 503 it maps every other
+                # auth deadline to. casbin keeps the old policy on a failed
+                # reload (it swaps only on success), so nothing is lost.
+                raise
             logger.warning(f'Policy reload for unrecognized principal '
                            f'{user_id} failed; treating them as role-less: '
                            f'{common_utils.format_exception(e)}')

--- a/sky/utils/db/db_utils.py
+++ b/sky/utils/db/db_utils.py
@@ -2,6 +2,7 @@
 import asyncio
 import contextlib
 import enum
+import math
 import os
 import pathlib
 import sqlite3
@@ -612,6 +613,41 @@ def _pooler_configured() -> bool:
     return bool(
         os.environ.get(constants.ENV_VAR_DB_POOL_CONNECTION_URI) or
         os.environ.get(constants.ENV_VAR_DB_POOL_HOSTPORT))
+
+
+def get_auth_db_timeout_seconds() -> float:
+    """The deadline on the API server's auth-path DB calls, in seconds.
+
+    Read from ``constants.ENV_VAR_AUTH_DB_TIMEOUT_SECONDS`` (default
+    ``constants.DEFAULT_AUTH_DB_TIMEOUT_SECONDS``). This is the single
+    source for that value: ``sky.server.auth.db_lookup`` uses it as the
+    client-side ``asyncio.wait_for`` deadline on every auth DB lookup, and
+    ``sky.global_user_state.add_or_update_user`` derives the server-side
+    ``SET LOCAL`` timeouts on the users upsert from it, so the database
+    always gives up at or before the caller does. The environment is read
+    on each call (a cheap lookup) so tests can vary it.
+
+    Raises:
+        ValueError: if the variable is set but is not a positive, finite
+            number of seconds. A non-positive deadline would fail every
+            auth call client-side, and as a Postgres timeout ``0`` means
+            *disabled* (and a negative value is rejected), so such a value
+            is refused loudly rather than silently substituted.
+    """
+    raw = os.environ.get(constants.ENV_VAR_AUTH_DB_TIMEOUT_SECONDS)
+    if raw is None:
+        return constants.DEFAULT_AUTH_DB_TIMEOUT_SECONDS
+    try:
+        seconds = float(raw)
+    except ValueError:
+        raise ValueError(
+            f'{constants.ENV_VAR_AUTH_DB_TIMEOUT_SECONDS}={raw!r} is not a '
+            'number of seconds.') from None
+    if not (math.isfinite(seconds) and seconds > 0):
+        raise ValueError(
+            f'{constants.ENV_VAR_AUTH_DB_TIMEOUT_SECONDS}={raw!r} must be a '
+            'positive, finite number of seconds.')
+    return seconds
 
 
 # Bound on the connect phase of a no_pool engine. Unlike a pooled checkout,

--- a/sky/utils/db/db_utils.py
+++ b/sky/utils/db/db_utils.py
@@ -20,6 +20,7 @@ from sqlalchemy.ext import asyncio as sqlalchemy_async
 from sky import sky_logging
 from sky.skylet import constants
 from sky.skylet import runtime_utils
+from sky.utils.db import deadline as db_deadline
 from sky.utils.db import sql_metrics
 
 logger = sky_logging.init_logger(__name__)
@@ -793,6 +794,13 @@ def get_engine(
                             pool_pre_ping=True,
                             pool_recycle=1800))
                 sql_metrics.install(_postgres_engine_cache[cache_key], role)
+                # Bound any transaction opened under an auth-path deadline
+                # with SET LOCAL statement/lock/idle-in-transaction timeouts.
+                # Inert unless a thread-local deadline is set, so this is a
+                # no-op for every non-auth caller and for async engines. Keys
+                # on the driver's transaction state, so its position among
+                # the other engine listeners does not matter.
+                db_deadline.install(_postgres_engine_cache[cache_key])
             engine = _postgres_engine_cache[cache_key]
     else:
         assert db_name is not None, 'db_name must be provided for SQLite'

--- a/sky/utils/db/db_utils.py
+++ b/sky/utils/db/db_utils.py
@@ -615,6 +615,14 @@ def _pooler_configured() -> bool:
         os.environ.get(constants.ENV_VAR_DB_POOL_HOSTPORT))
 
 
+# Postgres timeout settings (lock_timeout, statement_timeout,
+# idle_in_transaction_session_timeout) are 32-bit signed milliseconds, so the
+# largest deadline whose derived timeouts the database still accepts is
+# 2147483.647 s; anything above that would make every users upsert fail on
+# the SET LOCAL itself.
+AUTH_DB_TIMEOUT_MAX_SECONDS = 2147483
+
+
 def get_auth_db_timeout_seconds() -> float:
     """The deadline on the API server's auth-path DB calls, in seconds.
 
@@ -625,14 +633,20 @@ def get_auth_db_timeout_seconds() -> float:
     ``sky.global_user_state.add_or_update_user`` derives the server-side
     ``SET LOCAL`` timeouts on the users upsert from it, so the database
     always gives up at or before the caller does. The environment is read
-    on each call (a cheap lookup) so tests can vary it.
+    on each call (a cheap lookup) so tests can vary it; that read always
+    sees the server's own setting, because the variable is stripped from
+    client request payloads (`payloads.request_body_env_vars`) and again
+    from the per-request environment overlay on the server
+    (`executor.override_request_env_and_config`).
 
     Raises:
         ValueError: if the variable is set but is not a positive, finite
-            number of seconds. A non-positive deadline would fail every
-            auth call client-side, and as a Postgres timeout ``0`` means
-            *disabled* (and a negative value is rejected), so such a value
-            is refused loudly rather than silently substituted.
+            number of seconds no greater than
+            ``AUTH_DB_TIMEOUT_MAX_SECONDS``. A non-positive deadline would
+            fail every auth call client-side, and as a Postgres timeout
+            ``0`` means *disabled* (and a negative value is rejected), so
+            such a value is refused loudly rather than silently substituted;
+            a larger one would exceed Postgres' millisecond range.
     """
     raw = os.environ.get(constants.ENV_VAR_AUTH_DB_TIMEOUT_SECONDS)
     if raw is None:
@@ -643,10 +657,12 @@ def get_auth_db_timeout_seconds() -> float:
         raise ValueError(
             f'{constants.ENV_VAR_AUTH_DB_TIMEOUT_SECONDS}={raw!r} is not a '
             'number of seconds.') from None
-    if not (math.isfinite(seconds) and seconds > 0):
+    if not (math.isfinite(seconds) and
+            0 < seconds <= AUTH_DB_TIMEOUT_MAX_SECONDS):
         raise ValueError(
             f'{constants.ENV_VAR_AUTH_DB_TIMEOUT_SECONDS}={raw!r} must be a '
-            'positive, finite number of seconds.')
+            'positive, finite number of seconds, at most '
+            f'{AUTH_DB_TIMEOUT_MAX_SECONDS}.')
     return seconds
 
 

--- a/sky/utils/db/deadline.py
+++ b/sky/utils/db/deadline.py
@@ -1,0 +1,587 @@
+"""Give a bounded DB call a deadline the DB layer itself honours.
+
+The authentication middlewares run their DB lookups on a small thread
+executor under an ``asyncio.wait_for`` deadline. That deadline releases the
+*caller* -- the request gets a fast 503 -- but not the *thread*: a thread
+parked in libpq's ``poll()`` (a lock wait, a slow statement, an unreachable
+server, or a socket whose fd was closed under it) keeps running until the DB
+layer lets go. Enough pinned threads and the executor saturates, and every
+authenticated request fails.
+
+This module makes the DB work give up at (or before) the caller's deadline,
+so the thread is freed too. Two layers, both keyed off one thread-local
+deadline that the caller sets around the DB function:
+
+1. Server side -- an engine listener that prepends ``SET LOCAL
+   statement_timeout / lock_timeout / idle_in_transaction_session_timeout``
+   to the first statement of every transaction opened while a deadline is
+   active. Postgres then leaves a lock queue, cancels a slow statement, and
+   kills an orphaned transaction (releasing its row locks). These are the
+   only things that free the *server*. ``SET LOCAL`` reaches the server on a
+   direct connection and through a transaction-mode pooler, and is scoped to
+   the one transaction. Prepending to the statement text (rather than a
+   separate ``cursor.execute``) costs no extra round trip and keeps the
+   statement inside SQLAlchemy's DBAPI error handling. "First statement of
+   the transaction" is read from the driver's own transaction state
+   (psycopg2 ``conn.status``), not from a per-connection mark, so it holds
+   whatever other engine listeners run first (see ``_bounded_statement``).
+
+2. Client side -- a psycopg2 wait callback ("green mode") that polls the
+   libpq socket in bounded slices and gives up when the thread's deadline
+   passes. This is the only thing that frees the *thread* in the two classes
+   the server cannot help with: a frozen/unreachable server, and a socket
+   whose fd number was closed and reused under the thread. It also enforces
+   ``connect_timeout`` (libpq applies it only in its own blocking connect
+   loop, not in the ``PQconnectPoll`` path green mode uses) and refuses to
+   hand a fd back to libpq once the fd no longer identifies the connection's
+   own socket -- letting libpq ``recv()`` on a foreign blocking socket would
+   freeze the whole process, and ``send()`` on it would inject bytes into
+   someone else's connection.
+
+The wait callback is process-global to psycopg2, so it is installed
+explicitly from the API-server process (see ``install_wait_callback``),
+never as an import side effect: a plugin importing this module in a
+request-executor process must not turn green mode on there. The engine
+listener is inert without a thread-local deadline, so attaching it to every
+Postgres engine is harmless in every process.
+"""
+import logging
+import os
+import select
+import threading
+import time
+from typing import FrozenSet, Optional, Tuple
+import weakref
+
+from sqlalchemy import event
+
+logger = logging.getLogger(__name__)
+
+# psycopg2 is a server-only dependency; this module is imported by
+# ``db_utils.get_engine`` which also runs in client-only (sqlite) installs.
+# Import lazily-at-module-load and degrade: without psycopg2 the wait
+# callback is never installed and ``DBDeadlineExceeded`` is only ever used as
+# an isinstance target that cannot match.
+try:
+    import psycopg2  # pylint: disable=import-outside-toplevel
+    import psycopg2.extensions as _psycopg2_ext
+    _OperationalErrorBase: type = psycopg2.OperationalError
+    # psycopg2's exported steady connection states. While the connection
+    # handshake runs, ``conn.status`` holds an internal, unexported value
+    # (CONN_STATUS_SETUP before the first poll, then CONN_STATUS_CONNECTING);
+    # ``STATUS_SETUP`` itself is never observable after the first ``poll()``.
+    _STEADY_STATUSES: FrozenSet[int] = frozenset(
+        (_psycopg2_ext.STATUS_READY, _psycopg2_ext.STATUS_BEGIN,
+         _psycopg2_ext.STATUS_PREPARED))
+    # "No transaction open": psycopg2 sends its implicit BEGIN together with
+    # the first statement (status READY -> BEGIN) and is back to READY after
+    # COMMIT/ROLLBACK. Read by the SET LOCAL listener to find the first
+    # statement of each transaction.
+    _STATUS_READY: Optional[int] = _psycopg2_ext.STATUS_READY
+except ImportError:  # pragma: no cover - exercised only in sqlite-only installs
+    psycopg2 = None  # type: ignore
+    _psycopg2_ext = None  # type: ignore
+    _OperationalErrorBase = Exception
+    _STEADY_STATUSES = frozenset()
+    _STATUS_READY = None
+
+
+class DBDeadlineExceeded(_OperationalErrorBase):  # type: ignore
+    """The DB client gave up waiting on the socket.
+
+    Subclasses ``psycopg2.OperationalError`` so that, when raised from the
+    wait callback, psycopg2 closes the connection (``green_panic`` ->
+    ``PQfinish``) and SQLAlchemy wraps it as ``OperationalError`` with this as
+    ``.orig`` and ``connection_invalidated=True``. Raised during the connect
+    handshake it propagates from ``psycopg2.connect()`` unchanged.
+
+    ``reason`` names how the wait ended, for the metric label:
+    ``client_deadline`` (the thread's deadline passed; the socket was still
+    ours), ``client_deadline_fd_stolen`` / ``client_deadline_fd_closed`` (the
+    fd no longer identified our socket -- the incident's stolen-fd class;
+    raised whether or not a deadline is set), or ``connect_timeout`` (the
+    DSN's ``connect_timeout`` passed during the handshake).
+    """
+
+    def __init__(self, *args, reason: str = 'client_deadline') -> None:
+        super().__init__(*args)
+        self.reason = reason
+
+
+# Postgres SQLSTATEs the server-side bounds raise, mapped to metric-label
+# reasons. 57014 = statement_timeout (query cancelled), 55P03 = lock_timeout
+# (lock not available), 25P03 = idle_in_transaction_session_timeout (the
+# killed session's own next statement, when the client reads the FATAL; if
+# nobody was reading, that client sees a closed connection instead).
+TIMEOUT_PGCODE_REASONS = {
+    '57014': 'statement_timeout',
+    '55P03': 'lock_timeout',
+    '25P03': 'idle_in_transaction',
+}
+
+# Margin between the server-side bounds and the client deadline, so the
+# server's error (which carries a SQLSTATE) normally arrives first.
+_SERVER_MARGIN_MS = 500
+# lock_timeout is set this far under statement_timeout so a lock wait reports
+# the distinct 55P03 rather than 57014.
+_LOCK_UNDER_MS = 100
+# Floor for any server-side timeout: a value <= 0 would be "no timeout".
+_MIN_TIMEOUT_MS = 50
+# Longest a single poll slice sleeps while a deadline is set. Bounds how long
+# a thread can sleep on a fd that was closed and reused under it (the kernel
+# keeps a sleeping poll on the old socket) before the identity check runs.
+_MAX_SLICE_MS = 1000
+
+
+def _timeout_values_ms(total_ms: int) -> Tuple[int, int, int]:
+    """(statement_timeout, lock_timeout, idle_in_transaction) in ms.
+
+    lock < statement so a lock wait reports the distinct 55P03, and
+    idle_in_transaction >= statement so it never preempts a running statement
+    (it only bounds an *idle* -- i.e. orphaned -- transaction).
+    """
+    statement_ms = max(_MIN_TIMEOUT_MS, total_ms - _SERVER_MARGIN_MS)
+    lock_ms = max(_MIN_TIMEOUT_MS, statement_ms - _LOCK_UNDER_MS)
+    idle_ms = max(_MIN_TIMEOUT_MS, total_ms)
+    return statement_ms, lock_ms, idle_ms
+
+
+def _set_local_prefix(total_ms: int) -> str:
+    """The ``SET LOCAL ...; `` prefix for a transaction with ``total_ms`` left.
+
+    No ``%`` in the text, so psycopg2's parameter interpolation of the
+    statement it is prepended to is unaffected.
+    """
+    statement_ms, lock_ms, idle_ms = _timeout_values_ms(total_ms)
+    return (f'SET LOCAL statement_timeout = {statement_ms}; '
+            f'SET LOCAL lock_timeout = {lock_ms}; '
+            f'SET LOCAL idle_in_transaction_session_timeout = {idle_ms}; ')
+
+
+_local = threading.local()
+# Socket identity (st_dev, st_ino) of each connection's libpq socket, recorded
+# while the connection is established and compared before every later libpq
+# I/O to detect a stolen/closed fd. Keyed by the psycopg2 connection object
+# (weak, so it does not keep connections alive).
+_sock_ident: 'weakref.WeakKeyDictionary' = weakref.WeakKeyDictionary()
+# Engines the SET LOCAL listener is attached to (see ``install`` /
+# ``is_bounding``). Weak, so it never keeps an engine alive.
+_installed: 'weakref.WeakSet' = weakref.WeakSet()
+
+# --- thread-local deadline -------------------------------------------------
+
+
+def set_deadline(deadline_monotonic: float) -> None:
+    """Set the current thread's DB deadline (a ``time.monotonic()`` value)."""
+    _local.deadline = deadline_monotonic
+
+
+def clear_deadline() -> None:
+    _local.deadline = None
+
+
+def get_deadline() -> Optional[float]:
+    return getattr(_local, 'deadline', None)
+
+
+# --- exception classification (shared by callers and retry logic) ----------
+
+
+def deadline_reason(exc: BaseException) -> Optional[str]:
+    """The metric reason if ``exc`` is a deadline our bounds made, else None.
+
+    Handles both the wrapped case (SQLAlchemy ``DBAPIError`` with ``.orig`` a
+    ``DBDeadlineExceeded`` or a server timeout SQLSTATE) and the unwrapped
+    driver exception.
+    """
+    orig = getattr(exc, 'orig', exc)
+    if isinstance(orig, DBDeadlineExceeded):
+        return orig.reason
+    pgcode = getattr(orig, 'pgcode', None)
+    if pgcode is None:
+        return None
+    return TIMEOUT_PGCODE_REASONS.get(pgcode)
+
+
+def is_deadline_error(exc: BaseException) -> bool:
+    """Whether ``exc`` was produced by a deadline bound (client or server)."""
+    return deadline_reason(exc) is not None
+
+
+def is_transient_driver_error(exc: BaseException) -> bool:
+    """Whether ``exc`` is a psycopg2 operational/interface error.
+
+    A connection dropped or closed under the call (one of the fd-corruption
+    victims), a lost server, a pooler that went away: an operational failure
+    of the database layer, never the request's fault, so the caller answers
+    with a retryable status. "Transient" is the common case, not a guarantee:
+    psycopg2 reports a bad password (28P01) as an OperationalError too, and a
+    retry will not fix that -- the log line the caller writes carries the real
+    error. Gated on the psycopg2 classes on purpose -- ``sqlite3
+    .OperationalError`` also covers schema errors ("no such table"), which are
+    programming errors and propagate unchanged.
+    """
+    if psycopg2 is None:
+        return False
+    orig = getattr(exc, 'orig', exc)
+    return isinstance(orig,
+                      (psycopg2.OperationalError, psycopg2.InterfaceError))
+
+
+# --- server-side SET LOCAL listener ----------------------------------------
+
+
+def _is_async_engine(engine) -> bool:
+    # AsyncEngine proxies a sync_engine; the deadline machinery is psycopg2
+    # (sync) only, so async engines get no listener.
+    return hasattr(engine, 'sync_engine')
+
+
+def _bounded_statement(conn, cursor, statement: str, executemany: bool) -> str:
+    """``statement``, prefixed with SET LOCAL if it opens a bounded transaction.
+
+    The prefix goes on the first statement of a transaction executed while a
+    thread-local deadline is set. Everything else passes through unchanged.
+
+    "First statement of the transaction" is the driver's own transaction
+    state: psycopg2 sends its implicit BEGIN with the first statement (status
+    READY -> BEGIN) and is back to READY after COMMIT/ROLLBACK, so a statement
+    that finds the connection READY is the one that opens the transaction.
+    Reading that (rather than keeping a per-connection mark cleared by the
+    ``begin`` event) needs no state that can go stale on a pooled connection,
+    and does not depend on listener order: a statement another ``begin``
+    listener issues (e.g. an engine-wide idle-in-transaction bound) is simply
+    the first statement, gets the prefix, and the caller's own first statement
+    then does not -- exactly one prefix per transaction either way.
+    """
+    deadline = get_deadline()
+    if deadline is None:
+        return statement
+    dbapi_conn = conn.connection.dbapi_connection
+    if _STATUS_READY is None or getattr(dbapi_conn, 'status',
+                                        None) != _STATUS_READY:
+        # A transaction is already open (or this is not a psycopg2
+        # connection): the transaction's first statement carried the prefix.
+        return statement
+    # SET LOCAL outside a transaction block is a WARNING no-op, and an
+    # autocommit connection never has one (advisory-lock holders use
+    # autocommit and reach here). Skip rather than spam the server log.
+    if getattr(dbapi_conn, 'autocommit', False):
+        return statement
+    # executemany repeats the statement text per parameter set, so the prefix
+    # would run once per row; skip it. A server-side (named) cursor wraps the
+    # text in `DECLARE ... CURSOR FOR <statement>`, where a leading SET LOCAL
+    # is a syntax error. A transaction OPENED by either of them therefore gets
+    # no server-side bound (the client-side deadline still frees the thread);
+    # the auth path issues only single-row statements and never streams.
+    if executemany or getattr(cursor, 'name', None):
+        return statement
+    # idle_in_transaction_session_timeout only counts time the transaction
+    # sits idle between statements; the auth path is idle for microseconds
+    # (execute -> fetchone -> commit), so it only bites an *orphaned*
+    # transaction -- exactly the incident's blocker -- bounding it to the
+    # budget instead of forever.
+    total_ms = int((deadline - time.monotonic()) * 1000)
+    # One round trip: prepend to the statement text (simple-query
+    # multi-statement) instead of a separate cursor.execute, so the bounds
+    # are set inside SQLAlchemy's DBAPI error handling. psycopg2 sends its
+    # implicit BEGIN before this, so the SET LOCALs land inside the
+    # transaction they bound.
+    return _set_local_prefix(total_ms) + statement
+
+
+def install(engine) -> None:
+    """Attach the SET LOCAL listener to a Postgres psycopg2 (sync) engine.
+
+    No-op for async engines, non-Postgres dialects and other drivers (the
+    listener reads psycopg2's connection status). Safe to call in any process:
+    the listener does nothing unless a thread-local deadline is set, which only
+    the auth path does. Idempotent.
+    """
+    if _is_async_engine(engine):
+        return
+    if engine.dialect.name != 'postgresql':
+        return
+    if engine.dialect.driver != 'psycopg2':
+        return
+    if engine in _installed:
+        return
+
+    @event.listens_for(engine, 'before_cursor_execute', retval=True)
+    def _before_cursor_execute(  # pylint: disable=unused-variable
+            conn, cursor, statement, parameters, context, executemany):
+        del context
+        return (_bounded_statement(conn, cursor, statement,
+                                   executemany), parameters)
+
+    _installed.add(engine)
+
+
+def is_bounding(engine) -> bool:
+    """Whether a transaction this thread opens on ``engine`` now gets bounded.
+
+    True when the SET LOCAL listener is attached to ``engine`` AND the thread
+    has a deadline set -- i.e. the transaction's first statement will carry
+    the deadline-sized ``SET LOCAL`` trio. Callers that otherwise issue their
+    own fixed ``SET LOCAL`` statements use this to skip them (no duplicate
+    round trips), and only then: an engine without the listener keeps the
+    caller's own bounds even under a deadline.
+    """
+    return get_deadline() is not None and engine in _installed
+
+
+# --- client-side psycopg2 wait callback ------------------------------------
+
+
+def _ident(fd: int) -> Optional[Tuple[int, int]]:
+    try:
+        st = os.fstat(fd)
+        return (st.st_dev, st.st_ino)
+    except OSError:
+        return None
+
+
+def _fileno(conn) -> int:
+    try:
+        return conn.fileno()
+    except Exception:  # pylint: disable=broad-except
+        return -1
+
+
+def _record_ident(conn, fd: int) -> None:
+    ident = _ident(fd)
+    if ident is not None:
+        _sock_ident[conn] = ident
+
+
+def _fd_status(conn) -> str:
+    """Classify the connection's current fd against its recorded identity.
+
+    ``fd_closed`` -- the number is closed (``EBADF``); ``fd_stolen`` -- the
+    number is open but now identifies a different file (reused under us);
+    ``ok`` -- still our socket, or nothing recorded yet.
+    """
+    recorded = _sock_ident.get(conn)
+    if recorded is None:
+        return 'ok'
+    now = _ident(_fileno(conn))
+    if now is None:
+        return 'fd_closed'
+    if now != recorded:
+        return 'fd_stolen'
+    return 'ok'
+
+
+def _check_fd(conn) -> None:
+    """Raise before libpq touches a fd that is no longer this connection's.
+
+    The incident's class: the fd number was closed and reused under the
+    thread. Handing it to libpq would ``recv()``/``send()`` on someone else's
+    file -- a blocking socket freezes the process with the GIL held. This is
+    a mitigation, not a proof: it cannot close the microsecond race between
+    this check and psycopg2's own syscall, and it does not run during the
+    connection handshake (see ``_connecting``: libpq swaps sockets there, so
+    the identity is not stable) -- a fd stolen inside those few milliseconds
+    is caught at the next wait if the deadline expires, or produces a garbage
+    error from libpq reading the foreign (readable, hence non-blocking) fd.
+    The real fix is to stop closing the fd twice.
+
+    When this raises, psycopg2 answers with ``PQfinish`` on the connection,
+    which closes the fd NUMBER -- now the new owner's. That is one collateral
+    stray close per detected theft (the same class of event as the root
+    cause, at ~1 per detection), unavoidable from Python.
+    """
+    status = _fd_status(conn)
+    if status != 'ok':
+        raise DBDeadlineExceeded(
+            f'DB connection fd {_fileno(conn)} is no longer this '
+            f'connection\'s socket ({status})',
+            reason=f'client_deadline_{status}')
+
+
+def _connecting(conn) -> bool:
+    """Whether the connection handshake (``PQconnectPoll``) is still running.
+
+    Two things are different while it runs. libpq may close and reopen its
+    socket (address fallback, e.g. ``localhost`` -> ``::1`` refused ->
+    ``127.0.0.1``; multi-host DSNs), so the fd identity is not stable and the
+    fd gate must not run. And it is the phase ``connect_timeout`` bounds.
+
+    Known limitation of green mode in this phase: psycopg2 drives
+    ``PQconnectPoll`` with the GIL held, and libpq resolves every host of a
+    multi-host DSN *after the first* inside ``PQconnectPoll`` (the first host
+    is resolved in ``PQconnectStart``, which psycopg2 wraps in
+    ``Py_BEGIN_ALLOW_THREADS``). So a DSN with several *hostnames* whose
+    earlier host fails does a DNS lookup for the fallback host with the GIL
+    held -- during a resolver outage that stalls the whole process for the
+    resolver timeout, where sync psycopg2 stalled one thread. Single-host
+    DSNs, IP literals and ``hostaddr=`` are unaffected; prefer those for
+    multi-host DSNs on the API server.
+    """
+    return conn.status not in _STEADY_STATUSES
+
+
+def _connect_timeout(conn) -> Optional[float]:
+    """The connection's ``connect_timeout`` in seconds, or None if unset.
+
+    libpq applies ``connect_timeout`` only inside its own blocking connect
+    loop; the ``PQconnectPoll`` path green mode uses leaves it to the caller,
+    so the callback enforces it. The value is readable from the DSN during
+    the handshake.
+    """
+    try:
+        raw = conn.get_dsn_parameters().get('connect_timeout')
+    except Exception:  # pylint: disable=broad-except
+        return None
+    if not raw:
+        return None
+    try:
+        seconds = float(raw)
+    except (TypeError, ValueError):
+        return None
+    return seconds if seconds > 0 else None
+
+
+def _effective_deadline(
+        thread_at: Optional[float],
+        connect_at: Optional[float]) -> Tuple[Optional[float], Optional[str]]:
+    """The earliest of the thread deadline and the connect-phase deadline."""
+    if connect_at is None:
+        return (thread_at, 'client') if thread_at is not None else (None, None)
+    if thread_at is None or connect_at <= thread_at:
+        return connect_at, 'connect'
+    return thread_at, 'client'
+
+
+def _raise_deadline(conn, fd: int, reason: Optional[str],
+                    connecting: bool) -> None:
+    """Raise ``DBDeadlineExceeded`` for the wait that just ran out of time.
+
+    During the handshake the connection is closed here first. psycopg2 only
+    calls ``PQfinish`` for a connect that failed inside the wait callback when
+    the connection object is deallocated (``conn_connect`` marks it
+    ``closed = 2``, "still requires cleanup"), and the exception's traceback
+    holds this frame -- and with it ``conn`` -- so that deallocation waits for
+    the next cyclic GC pass. Sync psycopg2 closes a timed-out connect at once;
+    doing the same here keeps a burst of connect deadlines (a pooler that is
+    down or queueing) from parking half-open client sockets on the pooler
+    until the collector runs. ``close()`` takes the connection lock, which
+    nothing holds during the handshake, and the later deallocation finds
+    ``pgconn`` already gone. After the handshake psycopg2 itself closes the
+    connection on a callback error (``green_panic`` -> ``PQfinish``), so
+    nothing is done here.
+    """
+    if connecting:
+        conn.close()
+    if reason == 'connect':
+        # libpq's own wording for its connect_timeout. One deadline covers
+        # the whole handshake: a multi-host DSN fails at the first host that
+        # does not answer instead of moving on to the next (libpq's blocking
+        # connect applies the timeout per host).
+        raise DBDeadlineExceeded('timeout expired', reason='connect_timeout')
+    status = 'ok' if connecting else _fd_status(conn)
+    label = 'client_deadline' if status == 'ok' else f'client_deadline_{status}'
+    raise DBDeadlineExceeded(
+        f'DB deadline exceeded while waiting for the socket '
+        f'(fd={fd}, fd_check={status})',
+        reason=label)
+
+
+def wait_callback(conn) -> None:
+    """psycopg2 wait callback: poll(2)-based, deadline- and fd-aware.
+
+    With no thread-local deadline this waits exactly like libpq (poll(fd, -1)),
+    so a process with the callback installed behaves like sync psycopg2 for
+    unbounded callers -- except it still enforces ``connect_timeout`` and still
+    refuses to touch a fd that is no longer the connection's socket.
+
+    ``conn.poll()`` is only ever called when the socket reported readiness (or
+    an error), as libpq requires: calling ``PQconnectPoll`` on a socket that
+    is not ready confuses its state machine (it tries to send the startup
+    packet and fails with a misleading error). A poll slice that expires
+    without readiness only re-checks the deadline and the fd identity.
+    """
+    # select.poll(), never select.select(): select fails at fd >= 1024 and
+    # uvicorn workers that spawn kubectl children exceed that.
+    connect_at: Optional[float] = None
+    connecting = _connecting(conn)
+    if not connecting:
+        # Before the first libpq I/O of this wait (for a query, that is the
+        # flush of the statement just sent).
+        _check_fd(conn)
+    state = conn.poll()
+    while state != _psycopg2_ext.POLL_OK:
+        if state == _psycopg2_ext.POLL_READ:
+            flags = select.POLLIN
+        elif state == _psycopg2_ext.POLL_WRITE:
+            flags = select.POLLOUT
+        else:
+            raise psycopg2.OperationalError(f'bad poll state: {state!r}')
+        fd = conn.fileno()
+        still_connecting = _connecting(conn)
+        if connecting or still_connecting or conn not in _sock_ident:
+            # Track the socket libpq holds *now*: during the handshake it may
+            # have swapped sockets since the last wait, and the identity
+            # recorded on the last handshake wait (or on the first wait after
+            # it) is the socket libpq kept.
+            _record_ident(conn, fd)
+        connecting = still_connecting
+        if connecting and connect_at is None:
+            timeout = _connect_timeout(conn)
+            if timeout is not None:
+                connect_at = time.monotonic() + timeout
+        deadline_at, reason = _effective_deadline(
+            get_deadline(), connect_at if connecting else None)
+        poller = select.poll()
+        poller.register(fd, flags)
+        while True:
+            if deadline_at is None:
+                poller.poll()
+                ready = True
+            else:
+                remaining = deadline_at - time.monotonic()
+                if remaining <= 0:
+                    _raise_deadline(conn, fd, reason, connecting)
+                ready = bool(
+                    poller.poll(min(int(remaining * 1000) + 1, _MAX_SLICE_MS)))
+            if not connecting:
+                # Also after a slice that expired without readiness: the fd
+                # may have been closed/reused while we slept, and the kernel
+                # keeps a sleeping poll on the *old* socket.
+                _check_fd(conn)
+            if ready:
+                break
+        state = conn.poll()
+
+
+def install_wait_callback() -> bool:
+    """Install the process-global psycopg2 wait callback (green mode).
+
+    Call once from the API-server process (its startup), so it lands only in
+    processes that serve the app. Idempotent. Returns False (with a warning)
+    when psycopg2 cannot be imported: a sqlite-only deployment must keep
+    starting -- there is no psycopg2 wait to bound there.
+
+    Process-global: any child created with the ``fork`` start method inherits
+    it. The API server creates its worker processes with ``spawn``, which
+    imports the app afresh and never runs this.
+    """
+    if _psycopg2_ext is None:
+        logger.warning('psycopg2 is not importable; DB waits in this process '
+                       'are not bounded by the auth-path deadline (only '
+                       'relevant with a Postgres state database).')
+        return False
+    _psycopg2_ext.set_wait_callback(wait_callback)
+    return True
+
+
+def uninstall_wait_callback() -> None:
+    if _psycopg2_ext is not None:
+        _psycopg2_ext.set_wait_callback(None)
+
+
+def get_wait_callback():
+    """The currently installed wait callback, or None (for tests)."""
+    if _psycopg2_ext is None:
+        return None
+    return _psycopg2_ext.get_wait_callback()

--- a/sky/utils/db/retries.py
+++ b/sky/utils/db/retries.py
@@ -22,10 +22,29 @@ from typing import Awaitable, Callable, Tuple, Type, TypeVar
 import sqlalchemy.exc
 
 from sky.utils import common_utils
+from sky.utils.db import deadline as db_deadline
 
 logger = logging.getLogger(__name__)
 
 T = TypeVar('T')
+
+
+def _stop_for_deadline(e: BaseException, delay: float) -> bool:
+    """Whether the caller's thread-local deadline says a retry cannot help.
+
+    Only when a thread-local deadline is set (i.e. the caller is on the bounded
+    auth path). Then, either ``e`` *is* that deadline (a client- or server-side
+    bound fired; replaying would hold the thread past the deadline the bound
+    exists to enforce), or the backoff sleep alone would run past the deadline
+    (the retry could not even start in budget). Everywhere else (no deadline
+    set), this is False and retry behaviour is unchanged.
+    """
+    deadline = db_deadline.get_deadline()
+    if deadline is None:
+        return False
+    if db_deadline.is_deadline_error(e):
+        return True
+    return time.monotonic() + delay >= deadline
 
 
 def _build_retryable_exceptions() -> Tuple[Type[BaseException], ...]:
@@ -113,6 +132,10 @@ def with_db_retries(fn: Callable[[int], T],
                              f'{max_retries} attempts; {summarize(e)}')
                 raise
             delay = backoff.current_backoff()
+            if _stop_for_deadline(e, delay):
+                logger.debug(f'Not retrying under the caller\'s deadline: '
+                             f'{summarize(e)}')
+                raise
             logger.warning(
                 f'Transient DB error (attempt {attempt + 1}/{max_retries}), '
                 f'retrying in {delay:.1f}s: {summarize(e)}')
@@ -142,6 +165,10 @@ async def with_db_retries_async(coro_fn: Callable[[int], Awaitable[T]],
                              f'{max_retries} attempts; {summarize(e)}')
                 raise
             delay = backoff.current_backoff()
+            if _stop_for_deadline(e, delay):
+                logger.debug(f'Not retrying under the caller\'s deadline: '
+                             f'{summarize(e)}')
+                raise
             logger.warning(
                 f'Transient DB error (attempt {attempt + 1}/{max_retries}), '
                 f'retrying in {delay:.1f}s: {summarize(e)}')

--- a/tests/unit_tests/test_sky/server/requests/test_executor.py
+++ b/tests/unit_tests/test_sky/server/requests/test_executor.py
@@ -13,6 +13,7 @@ from unittest import mock
 import pytest
 
 from sky import exceptions
+from sky import global_user_state
 from sky import skypilot_config
 from sky.server import config as server_config
 from sky.server import constants as server_constants
@@ -25,6 +26,7 @@ from sky.server.requests import process
 from sky.server.requests import requests as requests_lib
 from sky.skylet import constants
 from sky.utils import context_utils
+from sky.utils.db import db_utils
 
 
 @pytest.fixture()
@@ -1521,6 +1523,42 @@ def test_override_env_applied_for_client_request(stub_override_request_env_deps,
             body, request_id='not-a-daemon-uuid', request_name='sky.launch'):
         assert os.environ['SKYPILOT_POD_MEMORY_BYTES_LIMIT'] == str(100 * 1024 *
                                                                     1024)
+
+
+@pytest.mark.parametrize('server_value', [None, '8'])
+def test_client_cannot_override_auth_db_timeout(stub_override_request_env_deps,
+                                                monkeypatch, server_value):
+    """A client-supplied SKYPILOT_AUTH_DB_TIMEOUT_SECONDS is dropped.
+
+    The users upsert inside the overlay derives its server-side SET LOCAL
+    timeouts from that variable at call time, so a client (an older one
+    still forwards every SKYPILOT_* variable) must not be able to loosen
+    or break them: the worker keeps the server's own setting, or none.
+    """
+    if server_value is None:
+        monkeypatch.delenv(constants.ENV_VAR_AUTH_DB_TIMEOUT_SECONDS,
+                           raising=False)
+    else:
+        monkeypatch.setenv(constants.ENV_VAR_AUTH_DB_TIMEOUT_SECONDS,
+                           server_value)
+    expected_deadline = db_utils.get_auth_db_timeout_seconds()
+    expected_timeouts = global_user_state._user_upsert_timeouts_ms()  # pylint: disable=protected-access
+
+    body = payloads.RequestBody(
+        env_vars={
+            constants.ENV_VAR_AUTH_DB_TIMEOUT_SECONDS: '1000000',
+            constants.USER_ID_ENV_VAR: 'client-user-id',
+            constants.USER_ENV_VAR: 'client-user',
+        })
+
+    with executor.override_request_env_and_config(
+            body, request_id='not-a-daemon-uuid', request_name='sky.launch'):
+        assert os.environ.get(
+            constants.ENV_VAR_AUTH_DB_TIMEOUT_SECONDS) == server_value
+        assert db_utils.get_auth_db_timeout_seconds() == expected_deadline
+        assert (global_user_state._user_upsert_timeouts_ms()  # pylint: disable=protected-access
+                == expected_timeouts)
+    assert constants.ENV_VAR_AUTH_DB_TIMEOUT_SECONDS not in body.env_vars
 
 
 def test_daemon_env_mutations_reverted_on_exit(stub_override_request_env_deps,

--- a/tests/unit_tests/test_sky/server/requests/test_payloads.py
+++ b/tests/unit_tests/test_sky/server/requests/test_payloads.py
@@ -16,6 +16,7 @@ def test_request_body_env_vars_includes_expected_keys(monkeypatch):
     monkeypatch.setenv(skypilot_config.ENV_VAR_PROJECT_CONFIG,
                        '/tmp/project.yaml')
     monkeypatch.setenv(constants.ENV_VAR_DB_CONNECTION_URI, 'db-uri')
+    monkeypatch.setenv(constants.ENV_VAR_AUTH_DB_TIMEOUT_SECONDS, '1000000')
 
     monkeypatch.setattr(payloads.common, 'is_api_server_local', lambda: True)
     local_env = payloads.request_body_env_vars()
@@ -23,6 +24,9 @@ def test_request_body_env_vars_includes_expected_keys(monkeypatch):
     assert local_env[
         skypilot_config.ENV_VAR_SKYPILOT_CONFIG] == '/tmp/config.yaml'
     assert constants.ENV_VAR_DB_CONNECTION_URI not in local_env
+    # Server-side setting: the server derives the timeouts on its own users
+    # upsert from it, so a client must never supply it.
+    assert constants.ENV_VAR_AUTH_DB_TIMEOUT_SECONDS not in local_env
     assert skypilot_config.ENV_VAR_GLOBAL_CONFIG not in local_env
     assert skypilot_config.ENV_VAR_PROJECT_CONFIG not in local_env
 
@@ -33,6 +37,7 @@ def test_request_body_env_vars_includes_expected_keys(monkeypatch):
     assert skypilot_config.ENV_VAR_GLOBAL_CONFIG not in remote_env
     assert skypilot_config.ENV_VAR_PROJECT_CONFIG not in remote_env
     assert constants.CLIENT_USER_HASH_ENV_VAR not in remote_env
+    assert constants.ENV_VAR_AUTH_DB_TIMEOUT_SECONDS not in remote_env
 
 
 def test_request_body_env_vars_client_user_hash_with_basic_auth(monkeypatch):

--- a/tests/unit_tests/test_sky/server/test_auth_db_deadline.py
+++ b/tests/unit_tests/test_sky/server/test_auth_db_deadline.py
@@ -48,6 +48,7 @@ from sky.server import server
 from sky.server.auth import db_lookup
 from sky.server.requests import threads
 from sky.skylet import constants
+from sky.utils import context_utils
 from sky.utils.db import deadline as db_deadline
 
 # Lookups sleep _SLOW_DB_SECONDS while the deadline is patched to
@@ -686,6 +687,33 @@ class TestDeadlineHandedToTheDbLayer:
         assert 4.0 < remaining <= 5 - db_lookup._CLIENT_DEADLINE_MARGIN_SECONDS
 
     @pytest.mark.asyncio
+    async def test_deadline_origin_is_the_submit_not_the_thread_start(
+            self, monkeypatch):
+        """Same origin as `wait_for`: time the call spends between submit
+        and thread start (a busy pool, a loop stall) comes off the DB
+        layer's budget too, so the two deadlines cannot disagree."""
+        monkeypatch.setattr(db_lookup, 'AUTH_DB_TIMEOUT_SECONDS', 5)
+        real = context_utils.to_thread_with_executor
+        delay = 0.3
+
+        async def _start_late(pool, fn, *args, **kwargs):
+            await asyncio.sleep(delay)
+            return await real(pool, fn, *args, **kwargs)
+
+        monkeypatch.setattr(context_utils, 'to_thread_with_executor',
+                            _start_late)
+        seen = {}
+
+        def _probe():
+            seen['remaining'] = db_deadline.get_deadline() - time.monotonic()
+
+        await db_lookup.call_with_deadline(_probe)
+        inner = 5 - db_lookup._CLIENT_DEADLINE_MARGIN_SECONDS
+        # A deadline computed at thread start would show ~inner remaining.
+        assert seen['remaining'] < inner - delay + 0.1, seen
+        assert seen['remaining'] > inner - delay - 1.0, seen
+
+    @pytest.mark.asyncio
     async def test_request_pool_variant_sets_it_too(self, monkeypatch):
         monkeypatch.setattr(db_lookup, 'AUTH_DB_TIMEOUT_SECONDS', 5)
         seen = {}
@@ -727,6 +755,42 @@ class TestDeadlineHandedToTheDbLayer:
 
         await db_lookup.call_with_deadline(_probe)
         assert seen['remaining'] > 0
+
+
+class TestLifespanWiring:
+    """The server lifespan installs the psycopg2 wait callback.
+
+    That call is the one place the client-side half is switched on (never on
+    import -- see `TestNoInstallOnImport` in the deadline tests). Everything
+    else the lifespan starts is stubbed: this is a test of one line, and must
+    not touch the requests DB or start daemons.
+    """
+
+    @pytest.mark.asyncio
+    async def test_lifespan_installs_the_wait_callback(self, monkeypatch):
+
+        async def _noop(*args, **kwargs):
+            del args, kwargs
+
+        monkeypatch.setattr(server.requests_lib,
+                            'delete_orphan_internal_daemons_async', _noop)
+        monkeypatch.setattr(server.daemons, 'INTERNAL_REQUEST_DAEMONS', [])
+        monkeypatch.setattr(server, 'schedule_on_boot_check_async', _noop)
+        monkeypatch.setattr(server, 'cleanup_upload_ids', _noop)
+        monkeypatch.setattr(server.version_check, 'check_versions_periodically',
+                            _noop)
+        monkeypatch.setattr(server.loop_stall, 'start_watchdog',
+                            lambda **kwargs: None)
+        monkeypatch.setattr(server.metrics_utils, 'METRICS_ENABLED', False)
+        db_deadline.uninstall_wait_callback()
+        try:
+            assert db_deadline.get_wait_callback() is None
+            async with server.lifespan(mock.Mock()):
+                await asyncio.sleep(0)  # let the stubbed startup tasks finish
+                assert (db_deadline.get_wait_callback() is
+                        db_deadline.wait_callback)
+        finally:
+            db_deadline.uninstall_wait_callback()
 
 
 def _metric(reason):

--- a/tests/unit_tests/test_sky/server/test_auth_db_deadline.py
+++ b/tests/unit_tests/test_sky/server/test_auth_db_deadline.py
@@ -27,6 +27,8 @@ These tests pin the containment behavior:
   error still propagates unchanged.
 """
 
+# pylint: disable=protected-access,redefined-outer-name,missing-class-docstring
+
 import asyncio
 import os
 import time
@@ -83,7 +85,8 @@ def mock_request():
 def call_next_sentinel():
     """call_next that records whether the request reached the router."""
 
-    async def call_next(_request):
+    async def call_next(request):
+        del request  # unused
         call_next.reached = True
         return fastapi.responses.JSONResponse({'message': 'success'})
 

--- a/tests/unit_tests/test_sky/server/test_auth_db_deadline.py
+++ b/tests/unit_tests/test_sky/server/test_auth_db_deadline.py
@@ -19,7 +19,12 @@ These tests pin the containment behavior:
   not retry;
 * the basic-auth path on ``/api/health`` stays best-effort: probes must
   survive a DB incident, so it proceeds unauthenticated instead of
-  failing.
+  failing;
+* a lookup the *database* cut off at one of the server-side timeouts the
+  auth path sets on its own transaction (``lock_timeout``,
+  ``statement_timeout``, ``idle_in_transaction_session_timeout``) gets the
+  same retryable 503 as the client-side deadline, while every other DB
+  error still propagates unchanged.
 """
 
 import asyncio
@@ -29,6 +34,7 @@ import unittest.mock as mock
 
 import fastapi
 import pytest
+import sqlalchemy.exc
 
 from sky import exceptions
 from sky import models
@@ -478,3 +484,169 @@ class TestEnsureRoleForAuthenticatedUser:
         # contention on the policy lock, a healthy database doing its job.
         assert b'assigning roles' in response.body
         perm.queue_role_repair.assert_called_once_with('u-broken')
+
+
+class _PgError(Exception):
+    """Stand-in for a psycopg2 error: carries the SQLSTATE as ``pgcode``.
+
+    Duck-typed on purpose -- `db_lookup` must not depend on psycopg2 (a
+    server-only extra), and a manually constructed psycopg2 error has no
+    pgcode anyway; only the C layer sets it from a real server reply.
+    """
+
+    def __init__(self, pgcode, message):
+        super().__init__(message)
+        self.pgcode = pgcode
+
+
+def _raises_db_error(pgcode, message='canceling statement due to timeout'):
+    """A synchronous stand-in for a DB call the database itself cut off."""
+
+    def _call(*args, **kwargs):
+        del args, kwargs
+        raise sqlalchemy.exc.OperationalError('INSERT INTO users ...', {},
+                                              _PgError(pgcode, message))
+
+    return _call
+
+
+# The three timeouts `global_user_state.add_or_update_user` sets on its own
+# Postgres transaction, and the SQLSTATE each produces.
+_SERVER_TIMEOUT_PGCODES = (
+    '55P03',  # lock_timeout: lock_not_available
+    '57014',  # statement_timeout: query_canceled
+    '57P05',  # idle_in_transaction_session_timeout (next statement)
+)
+
+
+class TestServerSideTimeoutMapping:
+    """A DB-side timeout on the auth path is the deadline path's 503."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize('pgcode', _SERVER_TIMEOUT_PGCODES)
+    async def test_server_timeout_pgcodes_become_timeout_errors(
+            self, monkeypatch, pgcode):
+        # The database gives up well before the client deadline here.
+        monkeypatch.setattr(db_lookup, 'AUTH_DB_TIMEOUT_SECONDS', 5)
+        with pytest.raises(asyncio.TimeoutError) as excinfo:
+            await db_lookup.call_with_deadline(_raises_db_error(pgcode))
+        assert isinstance(excinfo.value, db_lookup.AuthDBTimeoutError)
+        # The original DB error is kept as the cause for the log/debugging.
+        assert isinstance(excinfo.value.__cause__,
+                          sqlalchemy.exc.OperationalError)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize('pgcode', _SERVER_TIMEOUT_PGCODES)
+    async def test_request_pool_variant_maps_the_same_way(
+            self, monkeypatch, pgcode):
+        monkeypatch.setattr(db_lookup, 'AUTH_DB_TIMEOUT_SECONDS', 5)
+        with pytest.raises(asyncio.TimeoutError):
+            await db_lookup._call_on_request_pool(_raises_db_error(pgcode))
+
+    @pytest.mark.asyncio
+    async def test_raw_driver_error_with_pgcode_is_mapped_too(
+            self, monkeypatch):
+        """Raw connections raise the driver error unwrapped (no `.orig`)."""
+        monkeypatch.setattr(db_lookup, 'AUTH_DB_TIMEOUT_SECONDS', 5)
+
+        def _raw(*args, **kwargs):
+            del args, kwargs
+            raise _PgError('55P03', 'lock timeout')
+
+        with pytest.raises(asyncio.TimeoutError):
+            await db_lookup.call_with_deadline(_raw)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        'pgcode',
+        [
+            '23505',  # unique_violation: a real data error
+            '08006',  # connection_failure
+            '40P01',  # deadlock_detected
+            None,  # driver error with no SQLSTATE (e.g. socket EBADF)
+        ])
+    async def test_other_db_errors_still_propagate_unchanged(
+            self, monkeypatch, pgcode):
+        """The mapping is narrow: only the aligned server-side timeouts."""
+        monkeypatch.setattr(db_lookup, 'AUTH_DB_TIMEOUT_SECONDS', 5)
+        with pytest.raises(sqlalchemy.exc.OperationalError) as excinfo:
+            await db_lookup.call_with_deadline(_raises_db_error(pgcode))
+        assert not isinstance(excinfo.value, asyncio.TimeoutError)
+
+    @pytest.mark.asyncio
+    async def test_non_db_errors_still_propagate_unchanged(self, monkeypatch):
+        monkeypatch.setattr(db_lookup, 'AUTH_DB_TIMEOUT_SECONDS', 5)
+
+        def _boom(*args, **kwargs):
+            del args, kwargs
+            raise RuntimeError('not a database error')
+
+        with pytest.raises(RuntimeError):
+            await db_lookup.call_with_deadline(_boom)
+
+    @pytest.mark.asyncio
+    async def test_exhaustion_is_not_swallowed_by_the_mapping(
+            self, monkeypatch):
+        monkeypatch.setattr(db_lookup, 'AUTH_DB_TIMEOUT_SECONDS', 5)
+        exhausted = threads.OnDemandThreadExecutor(name='test-exhausted-map',
+                                                   max_workers=0)
+        with mock.patch.object(db_lookup.executor,
+                               'get_auth_thread_executor',
+                               return_value=exhausted):
+            with pytest.raises(exceptions.ConcurrentWorkerExhaustedError):
+                await db_lookup.call_with_deadline(lambda: 'never runs')
+
+    @pytest.mark.asyncio
+    async def test_auth_proxy_upsert_cut_off_by_lock_timeout_is_503(
+            self, monkeypatch, mock_request, call_next_sentinel):
+        """The incident shape: the users row is locked by another session
+        and this request's upsert waits. With `lock_timeout` set on the
+        transaction the database fails the wait (55P03) and the thread is
+        freed; the client must see the same retryable 503 as a deadline."""
+        monkeypatch.setattr(db_lookup, 'AUTH_DB_TIMEOUT_SECONDS', 5)
+        proxy_config = mock.Mock()
+        proxy_config.enabled = True
+        with mock.patch.object(server.server_config,
+                               'load_external_proxy_config',
+                               return_value=proxy_config):
+            middleware = server.AuthProxyMiddleware(app=mock.Mock())
+
+        with mock.patch.object(
+                server,
+                '_extract_user_from_header',
+                return_value=models.User(id='u-1', name='tester')), \
+                mock.patch(
+                    'sky.global_user_state.add_or_update_user',
+                    _raises_db_error(
+                        '55P03',
+                        'canceling statement due to lock timeout')):
+            response = await middleware.dispatch(mock_request,
+                                                 call_next_sentinel)
+
+        _assert_retryable_timeout_503(response)
+        assert not call_next_sentinel.reached
+
+    @pytest.mark.asyncio
+    async def test_bearer_token_lookup_cut_off_by_statement_timeout_is_503(
+            self, monkeypatch, mock_request, call_next_sentinel):
+        monkeypatch.setattr(db_lookup, 'AUTH_DB_TIMEOUT_SECONDS', 5)
+        mock_request.headers = {'authorization': 'Bearer sky_token'}
+        middleware = server.BearerTokenMiddleware(app=mock.Mock())
+
+        with mock.patch.dict(
+                os.environ,
+            {constants.ENV_VAR_ENABLE_SERVICE_ACCOUNTS: 'true'}), \
+                mock.patch('sky.users.token_service.token_service') as tks, \
+                mock.patch(
+                    'sky.global_user_state.get_service_account_token_by_hash',
+                    _raises_db_error('57014')):
+            tks.verify_token.return_value = {
+                'sub': 'sa-1',
+                'name': 'sa',
+                'token_id': 'tok-1'
+            }
+            response = await middleware.dispatch(mock_request,
+                                                 call_next_sentinel)
+
+        _assert_retryable_timeout_503(response)
+        assert not call_next_sentinel.reached

--- a/tests/unit_tests/test_sky/server/test_auth_db_deadline.py
+++ b/tests/unit_tests/test_sky/server/test_auth_db_deadline.py
@@ -518,7 +518,7 @@ def _raises_db_error(pgcode, message='canceling statement due to timeout'):
 _SERVER_TIMEOUT_PGCODES = (
     '55P03',  # lock_timeout: lock_not_available
     '57014',  # statement_timeout: query_canceled
-    '57P05',  # idle_in_transaction_session_timeout (next statement)
+    '25P03',  # idle_in_transaction_session_timeout (next statement)
 )
 
 

--- a/tests/unit_tests/test_sky/server/test_auth_db_deadline.py
+++ b/tests/unit_tests/test_sky/server/test_auth_db_deadline.py
@@ -30,20 +30,25 @@ These tests pin the containment behavior:
 # pylint: disable=protected-access,redefined-outer-name,missing-class-docstring
 
 import asyncio
+import concurrent.futures
 import os
+import sqlite3
 import time
 import unittest.mock as mock
 
 import fastapi
+import psycopg2
 import pytest
 import sqlalchemy.exc
 
 from sky import exceptions
 from sky import models
+from sky.metrics import utils as metrics_utils
 from sky.server import server
 from sky.server.auth import db_lookup
 from sky.server.requests import threads
 from sky.skylet import constants
+from sky.utils.db import deadline as db_deadline
 
 # Lookups sleep _SLOW_DB_SECONDS while the deadline is patched to
 # _DEADLINE_SECONDS, so every "slow DB" test trips the deadline quickly and
@@ -653,3 +658,241 @@ class TestServerSideTimeoutMapping:
 
         _assert_retryable_timeout_503(response)
         assert not call_next_sentinel.reached
+
+
+class TestDeadlineHandedToTheDbLayer:
+    """`_run_with_deadline` sets the thread-local deadline the DB layer honours.
+
+    Without it the SET LOCAL listener and the wait callback are inert and the
+    thread is only ever freed by the database -- the pin this change removes.
+    """
+
+    @pytest.mark.asyncio
+    async def test_thread_local_deadline_is_set_inside_the_call(
+            self, monkeypatch):
+        monkeypatch.setattr(db_lookup, 'AUTH_DB_TIMEOUT_SECONDS', 5)
+        seen = {}
+
+        def _probe():
+            seen['deadline'] = db_deadline.get_deadline()
+            seen['now'] = time.monotonic()
+            return 'ok'
+
+        assert await db_lookup.call_with_deadline(_probe) == 'ok'
+        assert seen[
+            'deadline'] is not None, 'no deadline handed to the DB layer'
+        remaining = seen['deadline'] - seen['now']
+        # The inner budget: the 5s deadline minus the client margin.
+        assert 4.0 < remaining <= 5 - db_lookup._CLIENT_DEADLINE_MARGIN_SECONDS
+
+    @pytest.mark.asyncio
+    async def test_request_pool_variant_sets_it_too(self, monkeypatch):
+        monkeypatch.setattr(db_lookup, 'AUTH_DB_TIMEOUT_SECONDS', 5)
+        seen = {}
+
+        def _probe():
+            seen['deadline'] = db_deadline.get_deadline()
+
+        await db_lookup._call_on_request_pool(_probe)
+        assert seen['deadline'] is not None
+
+    @pytest.mark.asyncio
+    async def test_deadline_is_cleared_after_the_call(self, monkeypatch):
+        # One worker thread, so the check runs on the thread the call used.
+        monkeypatch.setattr(db_lookup, 'AUTH_DB_TIMEOUT_SECONDS', 5)
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        try:
+
+            def _boom():
+                raise sqlalchemy.exc.OperationalError(
+                    'stmt', {},
+                    db_deadline.DBDeadlineExceeded('x',
+                                                   reason='client_deadline'))
+
+            await db_lookup._run_with_deadline(pool, lambda: 'ok')
+            with pytest.raises(db_lookup.AuthDBTimeoutError):
+                await db_lookup._run_with_deadline(pool, _boom)
+            assert pool.submit(db_deadline.get_deadline).result(5) is None
+        finally:
+            pool.shutdown(wait=True)
+
+    @pytest.mark.asyncio
+    async def test_a_tiny_budget_still_leaves_a_positive_deadline(
+            self, monkeypatch):
+        monkeypatch.setattr(db_lookup, 'AUTH_DB_TIMEOUT_SECONDS', 0.2)
+        seen = {}
+
+        def _probe():
+            seen['remaining'] = db_deadline.get_deadline() - time.monotonic()
+
+        await db_lookup.call_with_deadline(_probe)
+        assert seen['remaining'] > 0
+
+
+def _metric(reason):
+    return metrics_utils.SKY_APISERVER_AUTH_DB_DEADLINE_TOTAL.labels(
+        reason=reason)._value.get()
+
+
+class TestClientSideDeadlineMapping:
+    """What the DB layer raises reaches the middleware as the retryable 503.
+
+    The client-side bounds (the wait callback) raise `DBDeadlineExceeded`; a
+    connection that dropped under the call raises a plain psycopg2 error with
+    no SQLSTATE. Both are the client's bad luck, not a bad request, and must
+    not surface as a bare 500. Real faults still propagate unchanged.
+    """
+
+    @pytest.fixture(autouse=True)
+    def real_deadline(self, monkeypatch):
+        monkeypatch.setattr(db_lookup, 'AUTH_DB_TIMEOUT_SECONDS', 5)
+
+    @pytest.mark.asyncio
+    async def test_client_deadline_becomes_timeout_error(self):
+
+        def _raise():
+            orig = db_deadline.DBDeadlineExceeded(
+                'x', reason='client_deadline_fd_stolen')
+            raise sqlalchemy.exc.OperationalError('stmt', {}, orig)
+
+        before = _metric('client_deadline_fd_stolen')
+        with pytest.raises(db_lookup.AuthDBTimeoutError) as ei:
+            await db_lookup.call_with_deadline(_raise)
+        assert ei.value.reason == 'client_deadline_fd_stolen'
+        assert isinstance(ei.value, asyncio.TimeoutError)
+        assert isinstance(ei.value.__cause__, sqlalchemy.exc.OperationalError)
+        assert _metric('client_deadline_fd_stolen') == before + 1
+
+    @pytest.mark.asyncio
+    async def test_unwrapped_client_deadline_maps(self):
+
+        def _raise():
+            raise db_deadline.DBDeadlineExceeded('x', reason='connect_timeout')
+
+        with pytest.raises(db_lookup.AuthDBTimeoutError) as ei:
+            await db_lookup.call_with_deadline(_raise)
+        assert ei.value.reason == 'connect_timeout'
+
+    @pytest.mark.asyncio
+    async def test_server_timeout_counts_its_reason(self):
+        before = _metric('lock_timeout')
+        with pytest.raises(db_lookup.AuthDBTimeoutError) as ei:
+            await db_lookup.call_with_deadline(_raises_db_error('55P03'))
+        assert ei.value.reason == 'lock_timeout'
+        assert _metric('lock_timeout') == before + 1
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize('orig', [
+        psycopg2.OperationalError('server closed the connection unexpectedly'),
+        psycopg2.InterfaceError('connection already closed'),
+    ])
+    async def test_dropped_connection_becomes_retryable(self, orig):
+
+        def _raise():
+            raise sqlalchemy.exc.OperationalError('stmt', {}, orig)
+
+        before = _metric('db_error')
+        with pytest.raises(db_lookup.AuthDBTimeoutError) as ei:
+            await db_lookup.call_with_deadline(_raise)
+        assert ei.value.reason == 'db_error'
+        assert _metric('db_error') == before + 1
+
+    @pytest.mark.asyncio
+    async def test_dropped_connection_is_a_503_at_the_middleware(
+            self, mock_request, call_next_sentinel):
+        proxy_config = mock.Mock()
+        proxy_config.enabled = True
+        with mock.patch.object(server.server_config,
+                               'load_external_proxy_config',
+                               return_value=proxy_config):
+            middleware = server.AuthProxyMiddleware(app=mock.Mock())
+
+        def _dropped(*args, **kwargs):
+            del args, kwargs
+            raise sqlalchemy.exc.OperationalError(
+                'INSERT INTO users ...', {},
+                psycopg2.OperationalError('SSL SYSCALL error: EOF detected'))
+
+        with mock.patch.object(
+                server,
+                '_extract_user_from_header',
+                return_value=models.User(id='u-1', name='tester')), \
+                mock.patch('sky.global_user_state.add_or_update_user',
+                           _dropped):
+            response = await middleware.dispatch(mock_request,
+                                                 call_next_sentinel)
+        _assert_retryable_timeout_503(response)
+        assert not call_next_sentinel.reached
+
+    @pytest.mark.asyncio
+    async def test_sqlite_operational_error_still_propagates(self):
+        # sqlite3.OperationalError also covers schema errors ("no such
+        # table"); those are real faults, not transient, and stay a 500.
+
+        def _raise():
+            raise sqlalchemy.exc.OperationalError(
+                'stmt', {}, sqlite3.OperationalError('no such table: users'))
+
+        with pytest.raises(sqlalchemy.exc.OperationalError) as ei:
+            await db_lookup.call_with_deadline(_raise)
+        assert not isinstance(ei.value, asyncio.TimeoutError)
+
+    @pytest.mark.asyncio
+    async def test_programming_error_still_propagates(self):
+
+        def _raise():
+            raise sqlalchemy.exc.ProgrammingError(
+                'stmt', {}, psycopg2.ProgrammingError('syntax error'))
+
+        with pytest.raises(sqlalchemy.exc.ProgrammingError):
+            await db_lookup.call_with_deadline(_raise)
+
+    @pytest.mark.asyncio
+    async def test_caller_timeout_still_raises_and_is_counted(
+            self, monkeypatch):
+        # The thread does not give up (a Python-level block, not DB I/O):
+        # wait_for is the backstop, and its firing is the "pinned" alarm.
+        monkeypatch.setattr(db_lookup, 'AUTH_DB_TIMEOUT_SECONDS', 0.1)
+        before = _metric('caller_timeout')
+        with pytest.raises(asyncio.TimeoutError) as ei:
+            await db_lookup.call_with_deadline(lambda: time.sleep(0.6))
+        assert not isinstance(ei.value, db_lookup.AuthDBTimeoutError)
+        assert _metric('caller_timeout') == before + 1
+
+    @pytest.mark.asyncio
+    async def test_a_late_thread_outcome_is_logged(self, monkeypatch):
+        # wait_for released the caller; the thread finishes later. Its outcome
+        # lands on a cancelled future, so the only trace is this log line --
+        # what an operator correlates with a "stuck thread" report.
+        monkeypatch.setattr(db_lookup, 'AUTH_DB_TIMEOUT_SECONDS', 0.1)
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+
+        def _late_then_fail():
+            time.sleep(0.5)
+            raise sqlalchemy.exc.OperationalError(
+                'stmt', {},
+                db_deadline.DBDeadlineExceeded('x', reason='client_deadline'))
+
+        try:
+            with mock.patch.object(db_lookup.logger, 'info') as info:
+                with pytest.raises(asyncio.TimeoutError):
+                    await db_lookup._run_with_deadline(pool, _late_then_fail)
+                pool.shutdown(wait=True)  # let the thread finish
+            messages = [str(c.args[0]) for c in info.call_args_list]
+            # Other tests in this module leave late threads of their own
+            # behind (tiny budgets, sleeping stand-ins); pick out ours.
+            late = [m for m in messages if '_late_then_fail' in m]
+            assert late, messages
+            assert 'finished' in late[0] and 'after' in late[0]
+            assert 'client_deadline' in late[0]
+        finally:
+            pool.shutdown(wait=True)
+
+    @pytest.mark.asyncio
+    async def test_an_in_time_outcome_is_not_logged_as_late(self, monkeypatch):
+        monkeypatch.setattr(db_lookup, 'AUTH_DB_TIMEOUT_SECONDS', 5)
+        with mock.patch.object(db_lookup.logger, 'info') as info:
+            assert await db_lookup.call_with_deadline(lambda: 'ok') == 'ok'
+        assert not [
+            c for c in info.call_args_list if 'finished' in str(c.args[0])
+        ]

--- a/tests/unit_tests/test_sky/test_global_user_state_user_upsert_timeouts.py
+++ b/tests/unit_tests/test_sky/test_global_user_state_user_upsert_timeouts.py
@@ -1,0 +1,246 @@
+"""The users upsert bounds its own Postgres transaction with SET LOCAL timeouts.
+
+`add_or_update_user` runs on the request authentication path under a
+client-side deadline (`sky.server.auth.db_lookup.AUTH_DB_TIMEOUT_SECONDS`)
+that frees the caller but not the executor thread. On Postgres the function
+therefore also asks the database to give up: `SET LOCAL lock_timeout /
+statement_timeout / idle_in_transaction_session_timeout`, issued as the
+first statements of the transaction so they cover the upsert. `SET LOCAL` is
+transaction-scoped, so it resets at COMMIT and is safe through a
+transaction-mode connection pooler.
+
+These tests pin:
+
+* Postgres: the three SET LOCAL statements are the first statements issued,
+  on the same session (hence inside the same auto-begun transaction) as the
+  upsert, and the values stay at or below the auth deadline;
+* SQLite: no SET LOCAL at all (unsupported there); behavior unchanged.
+"""
+
+# pylint: disable=protected-access,redefined-outer-name,missing-class-docstring
+from unittest import mock
+
+import pytest
+import sqlalchemy
+from sqlalchemy import event
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.sql import elements
+
+from sky import global_user_state
+from sky import models
+from sky.server.auth import db_lookup
+from sky.skylet import constants
+from sky.utils.db import db_utils
+
+_EXPECTED_SET_LOCAL = (
+    f'SET LOCAL lock_timeout = '
+    f'\'{global_user_state._USER_UPSERT_LOCK_TIMEOUT_MS}ms\'',
+    f'SET LOCAL statement_timeout = '
+    f'\'{global_user_state._USER_UPSERT_STATEMENT_TIMEOUT_MS}ms\'',
+    f'SET LOCAL idle_in_transaction_session_timeout = '
+    f'\'{global_user_state._USER_UPSERT_IDLE_IN_TRANSACTION_TIMEOUT_MS}ms\'',
+)
+
+
+class _RecordingSession:
+    """Stand-in for `orm.Session` that records what is executed, in order.
+
+    A query issued through `session.query(...)` is recorded as the string
+    'QUERY' so its position relative to the SET LOCAL statements is visible.
+    """
+
+    def __init__(self):
+        self.statements = []
+        self.commit_after = None
+
+    def execute(self, statement):
+        self.statements.append(statement)
+        result = mock.Mock()
+        result.fetchone.return_value = mock.Mock(id='u-1',
+                                                 name='tester',
+                                                 password=None,
+                                                 created_at=1,
+                                                 type=None,
+                                                 preferred_workspace=None,
+                                                 was_inserted=True)
+        result.rowcount = 1
+        return result
+
+    def query(self, *args, **kwargs):
+        del args, kwargs
+        self.statements.append('QUERY')
+        chain = mock.Mock()
+        chain.filter.return_value.first.return_value = None
+        chain.filter_by.return_value.first.return_value = None
+        return chain
+
+    def commit(self):
+        self.commit_after = len(self.statements)
+
+
+@pytest.fixture
+def postgres_session():
+    """`add_or_update_user` against a fake Postgres engine + recording session.
+
+    The engine is a mock whose dialect says Postgres; the ORM session is the
+    recorder above, so the test sees exactly which statements the function
+    issues and in what order, without a live database.
+    """
+    engine = mock.Mock()
+    engine.dialect.name = db_utils.SQLAlchemyDialect.POSTGRESQL.value
+    session = _RecordingSession()
+    with mock.patch.object(global_user_state._db_manager, '_engine', engine), \
+            mock.patch('sky.global_user_state.orm.Session') as session_cls:
+        session_cls.return_value.__enter__.return_value = session
+        yield session
+
+
+def _set_local_texts(statements):
+    return [
+        str(s)
+        for s in statements
+        if isinstance(s, elements.TextClause) and str(s).startswith('SET LOCAL')
+    ]
+
+
+class TestPostgresUpsertIsBounded:
+
+    def test_set_local_timeouts_precede_the_upsert_in_one_session(
+            self, postgres_session):
+        global_user_state.add_or_update_user(
+            models.User(id='u-1', name='tester'))
+
+        statements = postgres_session.statements
+        # Exactly the three SET LOCALs, first, in this order.
+        assert _set_local_texts(statements[:3]) == list(_EXPECTED_SET_LOCAL)
+        # Then the upsert itself, then COMMIT -- all on the same session, so
+        # SQLAlchemy's autobegin puts the SET LOCALs and the INSERT in one
+        # transaction and COMMIT resets the timeouts.
+        assert len(statements) == 4
+        assert isinstance(statements[3], postgresql.Insert)
+        assert statements[3].table is global_user_state.user_table
+        assert postgres_session.commit_after == 4
+
+    def test_set_local_comes_before_the_duplicate_name_check_too(
+            self, postgres_session):
+        """With allow_duplicate_name=False the first statement is a SELECT;
+        the timeouts must still be issued before it, or the SELECT (which
+        can wait on the same row lock) runs unbounded."""
+        global_user_state.add_or_update_user(models.User(id='u-1',
+                                                         name='tester'),
+                                             allow_duplicate_name=False)
+
+        statements = postgres_session.statements
+        assert _set_local_texts(statements[:3]) == list(_EXPECTED_SET_LOCAL)
+        assert statements[3] == 'QUERY'
+        assert isinstance(statements[4], postgresql.Insert)
+
+    def test_set_local_is_issued_through_the_session_not_a_hook(
+            self, postgres_session):
+        """Issued via `session.execute(text(...))`, so a failure (e.g. the
+        pooler never assigns a server) surfaces through SQLAlchemy's normal
+        error handling, not from inside an engine event listener."""
+        global_user_state.add_or_update_user(
+            models.User(id='u-1', name='tester'))
+        for statement in postgres_session.statements[:3]:
+            assert isinstance(statement, elements.TextClause)
+
+    def test_no_bind_parameters_in_set_local(self, postgres_session):
+        """SET does not accept bind parameters; the values are literals."""
+        global_user_state.add_or_update_user(
+            models.User(id='u-1', name='tester'))
+        for statement in postgres_session.statements[:3]:
+            assert not statement.compile().params
+
+
+class TestTimeoutValues:
+    """The server-side bounds must be at or below the caller's deadline."""
+
+    def test_values_are_at_or_below_the_auth_deadline(self):
+        deadline_ms = db_lookup.AUTH_DB_TIMEOUT_SECONDS * 1000
+        assert global_user_state._USER_UPSERT_LOCK_TIMEOUT_MS <= deadline_ms
+        assert (global_user_state._USER_UPSERT_STATEMENT_TIMEOUT_MS <=
+                deadline_ms)
+        assert (global_user_state._USER_UPSERT_IDLE_IN_TRANSACTION_TIMEOUT_MS <=
+                deadline_ms)
+
+    def test_lock_timeout_wins_over_statement_timeout(self):
+        """Lower lock_timeout so a row-lock wait reports the distinct
+        'lock not available' error (55P03) rather than a generic cancel."""
+        assert (global_user_state._USER_UPSERT_LOCK_TIMEOUT_MS <
+                global_user_state._USER_UPSERT_STATEMENT_TIMEOUT_MS)
+
+    def test_idle_in_transaction_is_the_largest(self):
+        """It terminates the session, so it must only fire for a session that
+        has really gone quiet mid-transaction, after the statement bounds."""
+        assert (global_user_state._USER_UPSERT_IDLE_IN_TRANSACTION_TIMEOUT_MS >=
+                global_user_state._USER_UPSERT_STATEMENT_TIMEOUT_MS)
+
+
+def _fresh_sqlite_db(tmp_path, monkeypatch):
+    """Point the global state DB at a tmp sqlite file (real engine)."""
+    monkeypatch.setenv(constants.SKY_RUNTIME_DIR_ENV_VAR_KEY, str(tmp_path))
+    monkeypatch.setattr(
+        global_user_state,
+        '_db_manager',
+        db_utils.DatabaseManager(
+            'state',
+            global_user_state.create_table,
+            post_init_fn=lambda _: global_user_state._sqlite_supports_returning(
+            ),
+        ),
+    )
+    return global_user_state._db_manager.get_engine()
+
+
+class TestSqliteUpsertIsUnchanged:
+
+    def test_sqlite_issues_no_set_local(self, tmp_path, monkeypatch):
+        engine = _fresh_sqlite_db(tmp_path, monkeypatch)
+        assert engine.dialect.name == db_utils.SQLAlchemyDialect.SQLITE.value
+        executed = []
+
+        def _capture(conn, cursor, statement, parameters, context, executemany):
+            del conn, cursor, parameters, context, executemany
+            executed.append(statement)
+
+        event.listen(engine, 'before_cursor_execute', _capture)
+        try:
+            newly_added = global_user_state.add_or_update_user(
+                models.User(id='u-sqlite', name='tester'))
+            again = global_user_state.add_or_update_user(
+                models.User(id='u-sqlite', name='tester-renamed'))
+        finally:
+            event.remove(engine, 'before_cursor_execute', _capture)
+
+        assert newly_added is True
+        assert again is False
+        assert executed, 'the upsert must have reached the database'
+        assert not [s for s in executed if 'SET LOCAL' in s.upper()]
+        stored = global_user_state.get_user('u-sqlite')
+        assert stored is not None and stored.name == 'tester-renamed'
+
+    def test_sqlite_engine_is_not_asked_for_postgres_settings(
+            self, tmp_path, monkeypatch):
+        """Belt and braces: SET LOCAL is a syntax error on SQLite, so the
+        Postgres-only helper must never see a SQLite session."""
+        _fresh_sqlite_db(tmp_path, monkeypatch)
+        with mock.patch.object(global_user_state,
+                               '_bound_user_upsert_transaction') as bound:
+            global_user_state.add_or_update_user(
+                models.User(id='u-sqlite-2', name='tester'))
+        bound.assert_not_called()
+
+
+def test_set_local_statement_text_is_valid_sql():
+    """Compile the statements as Postgres SQL (no live DB): each is exactly
+    one `SET LOCAL <parameter> = '<n>ms'`."""
+    session = _RecordingSession()
+    global_user_state._bound_user_upsert_transaction(session)
+    compiled = [
+        str(s.compile(dialect=postgresql.dialect())) for s in session.statements
+    ]
+    assert compiled == list(_EXPECTED_SET_LOCAL)
+    for text in compiled:
+        assert ';' not in text
+        assert isinstance(sqlalchemy.text(text), elements.TextClause)

--- a/tests/unit_tests/test_sky/test_global_user_state_user_upsert_timeouts.py
+++ b/tests/unit_tests/test_sky/test_global_user_state_user_upsert_timeouts.py
@@ -23,6 +23,11 @@ These tests pin:
   configured deadline otherwise, always `lock < statement < idle <= deadline`,
   and read from the same source as `db_lookup.AUTH_DB_TIMEOUT_SECONDS`; a
   nonsensical setting is refused loudly instead of reaching the database;
+* under an auth-path deadline, with the deadline-aware engine listener of
+  `sky.utils.db.deadline` attached to the engine, the explicit statements are
+  skipped (the listener prepends deadline-sized ones to the transaction's
+  first statement instead); without the listener, or without a deadline,
+  they stay;
 * SQLite: no SET LOCAL at all (unsupported there); behavior unchanged.
 """
 
@@ -30,6 +35,7 @@ These tests pin:
 import os
 import subprocess
 import sys
+import time
 from unittest import mock
 
 import pytest
@@ -43,6 +49,7 @@ from sky import models
 from sky.server.auth import db_lookup
 from sky.skylet import constants
 from sky.utils.db import db_utils
+from sky.utils.db import deadline as db_deadline
 
 _DEADLINE_ENV = constants.ENV_VAR_AUTH_DB_TIMEOUT_SECONDS
 
@@ -323,6 +330,61 @@ class TestServerStartupReadsTheSetting:
         assert result.returncode != 0
         assert 'ValueError' in result.stderr
         assert _DEADLINE_ENV in result.stderr
+
+
+class TestUnderAnAuthDeadline:
+    """On the auth path the engine listener in `sky.utils.db.deadline` sizes
+    the same three timeouts from the remaining budget and prepends them to
+    the transaction's first statement (no extra round trips); the explicit
+    statements here are for callers without a deadline -- and for any engine
+    the listener is not attached to, deadline or not."""
+
+    @pytest.fixture
+    def listener_installed(self):
+        # The fixture's engine is a mock, so mark it the way `install` would
+        # (the listener itself is tested in test_deadline.py).
+        engine = global_user_state._db_manager._engine
+        db_deadline._installed.add(engine)
+        yield engine
+        db_deadline._installed.discard(engine)
+
+    def test_the_explicit_set_local_is_skipped(self, postgres_session,
+                                               listener_installed):
+        del listener_installed
+        db_deadline.set_deadline(time.monotonic() + 5)
+        try:
+            global_user_state.add_or_update_user(
+                models.User(id='u-1', name='tester'))
+        finally:
+            db_deadline.clear_deadline()
+        statements = postgres_session.statements
+        assert _set_local_texts(statements) == []
+        assert isinstance(statements[0], postgresql.Insert)
+
+    def test_without_a_deadline_the_explicit_bounds_apply(
+            self, postgres_session, listener_installed):
+        del listener_installed
+        assert db_deadline.get_deadline() is None
+        global_user_state.add_or_update_user(
+            models.User(id='u-1', name='tester'))
+        assert _set_local_texts(
+            postgres_session.statements[:3]) == _expected_set_local()
+
+    def test_an_engine_without_the_listener_keeps_the_explicit_bounds(
+            self, postgres_session):
+        """The skip trusts nothing it cannot see: a deadline alone does not
+        remove the explicit bounds unless this engine's listener will add its
+        own."""
+        assert global_user_state._db_manager._engine not in (
+            db_deadline._installed)
+        db_deadline.set_deadline(time.monotonic() + 5)
+        try:
+            global_user_state.add_or_update_user(
+                models.User(id='u-1', name='tester'))
+        finally:
+            db_deadline.clear_deadline()
+        assert _set_local_texts(
+            postgres_session.statements[:3]) == _expected_set_local()
 
 
 def _fresh_sqlite_db(tmp_path, monkeypatch):

--- a/tests/unit_tests/test_sky/test_global_user_state_user_upsert_timeouts.py
+++ b/tests/unit_tests/test_sky/test_global_user_state_user_upsert_timeouts.py
@@ -195,13 +195,28 @@ class TestAuthDbTimeoutSetting:
         monkeypatch.setenv(_DEADLINE_ENV, raw)
         assert db_utils.get_auth_db_timeout_seconds() == expected
 
-    @pytest.mark.parametrize('raw', ['abc', '', '0', '-1', 'nan', 'inf'])
+    @pytest.mark.parametrize('raw',
+                             ['abc', '', '0', '-1', 'nan', 'inf', '2147484'])
     def test_nonsensical_values_are_refused_loudly(self, monkeypatch, raw):
         """Not silently replaced by the default: a non-positive deadline
-        would fail every auth call, and `0` disables a Postgres timeout."""
+        would fail every auth call, `0` disables a Postgres timeout, and a
+        deadline above Postgres' 32-bit millisecond range would make the
+        SET LOCAL itself fail on every upsert."""
         monkeypatch.setenv(_DEADLINE_ENV, raw)
         with pytest.raises(ValueError, match=_DEADLINE_ENV):
             db_utils.get_auth_db_timeout_seconds()
+
+    def test_largest_accepted_deadline_fits_postgres_milliseconds(
+            self, monkeypatch):
+        """Boundary: the largest accepted value derives timeouts that are
+        still valid Postgres settings (<= 2147483647 ms); one more second
+        is refused (see above)."""
+        monkeypatch.setenv(_DEADLINE_ENV,
+                           str(db_utils.AUTH_DB_TIMEOUT_MAX_SECONDS))
+        assert (db_utils.get_auth_db_timeout_seconds() ==
+                db_utils.AUTH_DB_TIMEOUT_MAX_SECONDS)
+        for value_ms in global_user_state._user_upsert_timeouts_ms():
+            assert 0 < value_ms <= 2147483647
 
     def test_db_lookup_deadline_comes_from_the_same_source(self):
         """`db_lookup.AUTH_DB_TIMEOUT_SECONDS` is read at import through the

--- a/tests/unit_tests/test_sky/test_global_user_state_user_upsert_timeouts.py
+++ b/tests/unit_tests/test_sky/test_global_user_state_user_upsert_timeouts.py
@@ -9,15 +9,27 @@ first statements of the transaction so they cover the upsert. `SET LOCAL` is
 transaction-scoped, so it resets at COMMIT and is safe through a
 transaction-mode connection pooler.
 
+The three values are derived from the configured deadline
+(`SKYPILOT_AUTH_DB_TIMEOUT_SECONDS`, default 5 s), which both modules read
+through the one helper `db_utils.get_auth_db_timeout_seconds()`.
+
 These tests pin:
 
 * Postgres: the three SET LOCAL statements are the first statements issued,
   on the same session (hence inside the same auto-begun transaction) as the
-  upsert, and the values stay at or below the auth deadline;
+  upsert;
+* the values: exactly 3900 / 4000 / 5000 ms at the default deadline (the
+  values a deployment on the default already runs with), derived from the
+  configured deadline otherwise, always `lock < statement < idle <= deadline`,
+  and read from the same source as `db_lookup.AUTH_DB_TIMEOUT_SECONDS`; a
+  nonsensical setting is refused loudly instead of reaching the database;
 * SQLite: no SET LOCAL at all (unsupported there); behavior unchanged.
 """
 
 # pylint: disable=protected-access,redefined-outer-name,missing-class-docstring
+import os
+import subprocess
+import sys
 from unittest import mock
 
 import pytest
@@ -32,14 +44,18 @@ from sky.server.auth import db_lookup
 from sky.skylet import constants
 from sky.utils.db import db_utils
 
-_EXPECTED_SET_LOCAL = (
-    f'SET LOCAL lock_timeout = '
-    f'\'{global_user_state._USER_UPSERT_LOCK_TIMEOUT_MS}ms\'',
-    f'SET LOCAL statement_timeout = '
-    f'\'{global_user_state._USER_UPSERT_STATEMENT_TIMEOUT_MS}ms\'',
-    f'SET LOCAL idle_in_transaction_session_timeout = '
-    f'\'{global_user_state._USER_UPSERT_IDLE_IN_TRANSACTION_TIMEOUT_MS}ms\'',
-)
+_DEADLINE_ENV = constants.ENV_VAR_AUTH_DB_TIMEOUT_SECONDS
+
+
+def _expected_set_local():
+    """The three statements the upsert must issue, for the current env."""
+    lock_ms, statement_ms, idle_ms = global_user_state._user_upsert_timeouts_ms(
+    )
+    return [
+        f'SET LOCAL lock_timeout = \'{lock_ms}ms\'',
+        f'SET LOCAL statement_timeout = \'{statement_ms}ms\'',
+        f'SET LOCAL idle_in_transaction_session_timeout = \'{idle_ms}ms\'',
+    ]
 
 
 class _RecordingSession:
@@ -112,7 +128,7 @@ class TestPostgresUpsertIsBounded:
 
         statements = postgres_session.statements
         # Exactly the three SET LOCALs, first, in this order.
-        assert _set_local_texts(statements[:3]) == list(_EXPECTED_SET_LOCAL)
+        assert _set_local_texts(statements[:3]) == _expected_set_local()
         # Then the upsert itself, then COMMIT -- all on the same session, so
         # SQLAlchemy's autobegin puts the SET LOCALs and the INSERT in one
         # transaction and COMMIT resets the timeouts.
@@ -131,7 +147,7 @@ class TestPostgresUpsertIsBounded:
                                              allow_duplicate_name=False)
 
         statements = postgres_session.statements
-        assert _set_local_texts(statements[:3]) == list(_EXPECTED_SET_LOCAL)
+        assert _set_local_texts(statements[:3]) == _expected_set_local()
         assert statements[3] == 'QUERY'
         assert isinstance(statements[4], postgresql.Insert)
 
@@ -152,29 +168,146 @@ class TestPostgresUpsertIsBounded:
         for statement in postgres_session.statements[:3]:
             assert not statement.compile().params
 
+    def test_values_follow_the_configured_deadline(self, postgres_session,
+                                                   monkeypatch):
+        """The statements the database receives carry the derived values."""
+        monkeypatch.setenv(_DEADLINE_ENV, '8')
+        global_user_state.add_or_update_user(
+            models.User(id='u-1', name='tester'))
+        assert _set_local_texts(postgres_session.statements[:3]) == [
+            'SET LOCAL lock_timeout = \'6240ms\'',
+            'SET LOCAL statement_timeout = \'6400ms\'',
+            'SET LOCAL idle_in_transaction_session_timeout = \'8000ms\'',
+        ]
+
+
+class TestAuthDbTimeoutSetting:
+    """`get_auth_db_timeout_seconds` is the one source of the deadline."""
+
+    def test_default_is_five_seconds(self, monkeypatch):
+        monkeypatch.delenv(_DEADLINE_ENV, raising=False)
+        assert db_utils.get_auth_db_timeout_seconds() == 5.0
+        assert constants.DEFAULT_AUTH_DB_TIMEOUT_SECONDS == 5.0
+
+    @pytest.mark.parametrize('raw, expected', [('8', 8.0), ('2.5', 2.5),
+                                               ('0.05', 0.05)])
+    def test_reads_the_environment(self, monkeypatch, raw, expected):
+        monkeypatch.setenv(_DEADLINE_ENV, raw)
+        assert db_utils.get_auth_db_timeout_seconds() == expected
+
+    @pytest.mark.parametrize('raw', ['abc', '', '0', '-1', 'nan', 'inf'])
+    def test_nonsensical_values_are_refused_loudly(self, monkeypatch, raw):
+        """Not silently replaced by the default: a non-positive deadline
+        would fail every auth call, and `0` disables a Postgres timeout."""
+        monkeypatch.setenv(_DEADLINE_ENV, raw)
+        with pytest.raises(ValueError, match=_DEADLINE_ENV):
+            db_utils.get_auth_db_timeout_seconds()
+
+    def test_db_lookup_deadline_comes_from_the_same_source(self):
+        """`db_lookup.AUTH_DB_TIMEOUT_SECONDS` is read at import through the
+        same helper; in the (unchanged) environment of this process the two
+        agree, so the client-side deadline and the server-side bounds cannot
+        be configured apart."""
+        assert (db_lookup.AUTH_DB_TIMEOUT_SECONDS ==
+                db_utils.get_auth_db_timeout_seconds())
+
 
 class TestTimeoutValues:
-    """The server-side bounds must be at or below the caller's deadline."""
+    """The server-side bounds derive from, and stay under, the deadline."""
 
-    def test_values_are_at_or_below_the_auth_deadline(self):
-        deadline_ms = db_lookup.AUTH_DB_TIMEOUT_SECONDS * 1000
-        assert global_user_state._USER_UPSERT_LOCK_TIMEOUT_MS <= deadline_ms
-        assert (global_user_state._USER_UPSERT_STATEMENT_TIMEOUT_MS <=
-                deadline_ms)
-        assert (global_user_state._USER_UPSERT_IDLE_IN_TRANSACTION_TIMEOUT_MS <=
-                deadline_ms)
+    def test_default_deadline_gives_exactly_3900_4000_5000(self, monkeypatch):
+        """The values a deployment running on the default deadline already
+        has; deriving them must not change them."""
+        monkeypatch.delenv(_DEADLINE_ENV, raising=False)
+        assert global_user_state._user_upsert_timeouts_ms() == (3900, 4000,
+                                                                5000)
 
-    def test_lock_timeout_wins_over_statement_timeout(self):
-        """Lower lock_timeout so a row-lock wait reports the distinct
-        'lock not available' error (55P03) rather than a generic cancel."""
-        assert (global_user_state._USER_UPSERT_LOCK_TIMEOUT_MS <
-                global_user_state._USER_UPSERT_STATEMENT_TIMEOUT_MS)
+    def test_deadline_of_8s_gives_6240_6400_8000(self, monkeypatch):
+        monkeypatch.setenv(_DEADLINE_ENV, '8')
+        lock_ms, statement_ms, idle_ms = (
+            global_user_state._user_upsert_timeouts_ms())
+        assert (lock_ms, statement_ms, idle_ms) == (6240, 6400, 8000)
+        assert lock_ms < statement_ms < idle_ms
 
-    def test_idle_in_transaction_is_the_largest(self):
-        """It terminates the session, so it must only fire for a session that
-        has really gone quiet mid-transaction, after the statement bounds."""
-        assert (global_user_state._USER_UPSERT_IDLE_IN_TRANSACTION_TIMEOUT_MS >=
-                global_user_state._USER_UPSERT_STATEMENT_TIMEOUT_MS)
+    @pytest.mark.parametrize('raw', [None, '8', '2.5', '0.05', '12.345'])
+    def test_values_are_at_or_below_the_auth_deadline(self, monkeypatch, raw):
+        if raw is None:
+            monkeypatch.delenv(_DEADLINE_ENV, raising=False)
+        else:
+            monkeypatch.setenv(_DEADLINE_ENV, raw)
+        deadline_ms = db_utils.get_auth_db_timeout_seconds() * 1000
+        for value_ms in global_user_state._user_upsert_timeouts_ms():
+            assert isinstance(value_ms, int)
+            assert 0 < value_ms <= deadline_ms
+
+    @pytest.mark.parametrize('raw', [None, '8', '2.5', '0.05', '12.345'])
+    def test_lock_below_statement_below_idle(self, monkeypatch, raw):
+        """lock_timeout < statement_timeout so a row-lock wait reports the
+        distinct 'lock not available' error (55P03) rather than a generic
+        cancel; idle_in_transaction_session_timeout is the largest because it
+        terminates the session, so it must only fire for a session that has
+        really gone quiet mid-transaction, after the statement bounds."""
+        if raw is None:
+            monkeypatch.delenv(_DEADLINE_ENV, raising=False)
+        else:
+            monkeypatch.setenv(_DEADLINE_ENV, raw)
+        lock_ms, statement_ms, idle_ms = (
+            global_user_state._user_upsert_timeouts_ms())
+        assert lock_ms < statement_ms < idle_ms
+
+    def test_a_deadline_too_small_to_order_the_values_is_refused(
+            self, monkeypatch):
+        """10 ms would round to 8 / 8 / 10: lock and statement collide, and
+        a smaller deadline still could round a value to `0ms`, which Postgres
+        reads as *disabled*. Refuse rather than send that."""
+        monkeypatch.setenv(_DEADLINE_ENV, '0.01')
+        with pytest.raises(ValueError, match=_DEADLINE_ENV):
+            global_user_state._user_upsert_timeouts_ms()
+
+    @pytest.mark.parametrize('raw', ['abc', '0', '-1'])
+    def test_a_nonsensical_deadline_never_reaches_the_database(
+            self, postgres_session, monkeypatch, raw):
+        monkeypatch.setenv(_DEADLINE_ENV, raw)
+        with pytest.raises(ValueError, match=_DEADLINE_ENV):
+            global_user_state.add_or_update_user(
+                models.User(id='u-1', name='tester'))
+        assert not postgres_session.statements
+
+
+_IMPORT_DB_LOOKUP = ('from sky.server.auth import db_lookup; '
+                     'from sky import global_user_state; '
+                     'print(db_lookup.AUTH_DB_TIMEOUT_SECONDS, '
+                     'global_user_state._user_upsert_timeouts_ms())')
+
+
+def _import_db_lookup_in_a_fresh_process(env_value):
+    """`db_lookup` reads the deadline at import (server startup); run that
+    import in a child so this process's module state is untouched."""
+    env = dict(os.environ)
+    env.pop(_DEADLINE_ENV, None)
+    if env_value is not None:
+        env[_DEADLINE_ENV] = env_value
+    return subprocess.run([sys.executable, '-c', _IMPORT_DB_LOOKUP],
+                          env=env,
+                          capture_output=True,
+                          text=True,
+                          check=False)
+
+
+class TestServerStartupReadsTheSetting:
+
+    def test_override_is_seen_by_both_modules_at_import(self):
+        result = _import_db_lookup_in_a_fresh_process('8')
+        assert result.returncode == 0, result.stderr
+        # Last line only: the import may log to stdout before the print.
+        assert result.stdout.strip().splitlines()[-1] == ('8.0 (6240, 6400, '
+                                                          '8000)')
+
+    def test_a_nonsensical_value_fails_server_startup_with_its_name(self):
+        result = _import_db_lookup_in_a_fresh_process('0')
+        assert result.returncode != 0
+        assert 'ValueError' in result.stderr
+        assert _DEADLINE_ENV in result.stderr
 
 
 def _fresh_sqlite_db(tmp_path, monkeypatch):
@@ -240,7 +373,7 @@ def test_set_local_statement_text_is_valid_sql():
     compiled = [
         str(s.compile(dialect=postgresql.dialect())) for s in session.statements
     ]
-    assert compiled == list(_EXPECTED_SET_LOCAL)
+    assert compiled == _expected_set_local()
     for text in compiled:
         assert ';' not in text
         assert isinstance(sqlalchemy.text(text), elements.TextClause)

--- a/tests/unit_tests/test_sky/users/test_permission.py
+++ b/tests/unit_tests/test_sky/users/test_permission.py
@@ -16,6 +16,7 @@ from sky.users import permission
 from sky.users import rbac
 from sky.utils import common
 from sky.utils import locks
+from sky.utils.db import deadline as db_deadline
 
 
 @pytest.fixture
@@ -2266,6 +2267,12 @@ class TestRoleReplacement:
         assert ['user', 'team_private', '*'] not in remaining
 
 
+def _pg_error(pgcode):
+    err = Exception('cancelled')
+    err.pgcode = pgcode
+    return err
+
+
 @pytest.fixture
 def policy_db(tmp_path):
     """A real sqlite-backed enforcer, so blocklist semantics are the real ones.
@@ -2811,6 +2818,27 @@ class TestProbeThrottle:
                                '_load_policy_no_lock',
                                side_effect=RuntimeError('db down')):
             worker._probe_unknown_principal('ghost')
+        assert worker._probe_cooldown_until > time.time() - 1
+
+    @pytest.mark.parametrize('error', [
+        sqlalchemy.exc.OperationalError(
+            'stmt', {},
+            db_deadline.DBDeadlineExceeded('x', reason='client_deadline')),
+        sqlalchemy.exc.OperationalError('stmt', {}, _pg_error('55P03')),
+    ])
+    def test_a_reload_cut_off_by_the_auth_deadline_is_re_raised(
+            self, policy_db, error):
+        """A deadline is the middleware's retryable 503, not a 403 "no roles":
+        swallowing it would deny a principal who does have a role because the
+        database was slow for a moment."""
+        worker = policy_db()
+        worker.enforcer.load_policy()
+        with mock.patch.object(worker,
+                               '_load_policy_no_lock',
+                               side_effect=error):
+            with pytest.raises(sqlalchemy.exc.OperationalError):
+                worker._probe_unknown_principal('ghost')
+        # The cooldown is still set (finally), so a slow DB is not hammered.
         assert worker._probe_cooldown_until > time.time() - 1
 
 

--- a/tests/unit_tests/test_sky/utils/db/test_deadline.py
+++ b/tests/unit_tests/test_sky/utils/db/test_deadline.py
@@ -1,0 +1,1102 @@
+"""Unit tests for the auth-path DB deadline machinery.
+
+These cover the parts that need no Postgres server:
+
+* the wait callback is NOT installed as an import side effect (a plugin
+  importing the auth modules in an executor process must not turn green mode
+  on there);
+* the wait callback frees a thread whose fd never becomes readable, at the
+  deadline, and classifies a stolen / closed fd instead of handing it back to
+  libpq (the blocking-socket freeze the design's earlier version had);
+* the connect phase: ``connect_timeout`` is enforced (green mode otherwise
+  ignores it) and the earlier of it and the thread deadline wins, a connect
+  that gives up is closed at once (psycopg2 would otherwise leave that to
+  deallocation, i.e. to the cyclic GC), and libpq swapping its socket during
+  the handshake (address fallback, multi-host DSNs) is NOT reported as a
+  stolen fd -- driven both through a scripted connection stand-in and through
+  REAL psycopg2/libpq against local listeners that refuse, never answer, or
+  hang up;
+* the SET LOCAL listener: attached only to Postgres psycopg2 (sync) engines,
+  emits the prefix on the first statement of a bounded transaction and
+  nothing else -- keyed on the driver's own transaction state, so exactly
+  once per transaction whatever other engine listeners run first -- resets
+  per transaction, skips executemany / named cursors / autocommit;
+* exception classification used by the caller and the retry logic.
+
+The stolen/closed-fd and connect-phase tests with the stand-in drive the
+callback directly with real sockets/pipes; the stand-in models psycopg2's
+status transitions (an unexported CONNECTING value during the handshake) so
+the predicate the callback keys on is the one real psycopg2 presents. The
+listener tests run real SQLAlchemy machinery on a sqlite connection class
+that presents psycopg2's ``status`` / ``autocommit`` surface.
+"""
+# pylint: disable=protected-access,missing-class-docstring,redefined-outer-name
+import os
+import re
+import socket
+import sqlite3
+import threading
+import time
+from unittest import mock
+
+import psycopg2
+import pytest
+import sqlalchemy
+from sqlalchemy import orm
+
+from sky.utils.db import deadline
+
+
+@pytest.fixture(autouse=True)
+def _clean_callback_and_deadline():
+    """Never leak a wait callback or a thread-local deadline between tests."""
+    deadline.uninstall_wait_callback()
+    deadline.clear_deadline()
+    yield
+    deadline.uninstall_wait_callback()
+    deadline.clear_deadline()
+
+
+class _FakeConn:
+    """A psycopg2-connection stand-in for driving the wait callback.
+
+    ``poll()`` returns the next scripted state; ``fileno()`` returns a fd the
+    test controls; ``poll()`` never touches the fd, so what the tests observe
+    is the callback's own fd/timing behaviour.
+
+    Models the status transitions the callback keys on, the way real psycopg2
+    presents them: with ``connecting=True`` the status is ``STATUS_SETUP``
+    before the first ``poll()``, then psycopg2's internal CONNECTING value (20,
+    not exported) until the handshake completes with ``POLL_OK``, then
+    ``STATUS_READY``. An optional ``on_poll`` hook runs before each scripted
+    state is returned (used to emulate libpq swapping its socket).
+    """
+    _CONNECTING = 20
+    # A callback that keeps polling a fd it should have refused (a broken fd
+    # gate) must fail the test, not spin for the rest of the process.
+    _MAX_POLLS = 10000
+
+    def __init__(self, fd, states, connecting=False, dsn=None, on_poll=None):
+        self._fd = fd
+        self._states = list(states)
+        self.connecting = connecting
+        self.status = (psycopg2.extensions.STATUS_SETUP
+                       if connecting else psycopg2.extensions.STATUS_READY)
+        self._dsn = dsn or {}
+        self._on_poll = on_poll
+        self.polls = 0
+        self.close_calls = 0
+
+    def close(self):
+        self.close_calls += 1
+
+    def poll(self):
+        self.polls += 1
+        if self.polls > self._MAX_POLLS:
+            raise RuntimeError('fake connection polled too often')
+        if self.connecting:
+            self.status = self._CONNECTING
+        if self._on_poll is not None:
+            self._on_poll(self, self.polls)
+        state = (self._states.pop(0)
+                 if self._states else psycopg2.extensions.POLL_READ)
+        if state == psycopg2.extensions.POLL_OK and self.connecting:
+            self.connecting = False
+            self.status = psycopg2.extensions.STATUS_READY
+        return state
+
+    def fileno(self):
+        return self._fd
+
+    def get_dsn_parameters(self):
+        return dict(self._dsn)
+
+
+def _run_callback_in_thread(conn, deadline_seconds=None):
+    """Run wait_callback(conn) in a daemon thread; return (thread, result)."""
+    result = {}
+
+    def worker():
+        if deadline_seconds is not None:
+            deadline.set_deadline(time.monotonic() + deadline_seconds)
+        t0 = time.monotonic()
+        try:
+            deadline.wait_callback(conn)
+            result.update(kind='returned', dt=time.monotonic() - t0)
+        except BaseException as e:  # noqa: BLE001  pylint: disable=broad-except
+            result.update(kind='raised',
+                          dt=time.monotonic() - t0,
+                          exc=type(e).__name__,
+                          reason=getattr(e, 'reason', None),
+                          msg=str(e).splitlines()[0][:80])
+        finally:
+            deadline.clear_deadline()
+
+    t = threading.Thread(target=worker, daemon=True, name='cb-worker')
+    t.start()
+    return t, result
+
+
+def _close_all(*objs):
+    for o in objs:
+        try:
+            if isinstance(o, int):
+                os.close(o)
+            else:
+                o.close()
+        except OSError:
+            pass
+
+
+class TestNoInstallOnImport:
+    """Green mode must not be a global side effect of importing auth."""
+
+    def test_importing_db_lookup_leaves_no_wait_callback(self):
+        # Fresh import name-check: the module is already imported by other
+        # tests, so assert the invariant the install path must preserve.
+        import sky.server.auth.db_lookup  # noqa: F401  pylint: disable=import-outside-toplevel,unused-import
+        assert psycopg2.extensions.get_wait_callback() is None
+
+    def test_install_and_uninstall(self):
+        assert deadline.get_wait_callback() is None
+        assert deadline.install_wait_callback() is True
+        assert deadline.get_wait_callback() is deadline.wait_callback
+        deadline.uninstall_wait_callback()
+        assert deadline.get_wait_callback() is None
+
+    def test_install_degrades_without_psycopg2(self, monkeypatch):
+        # A sqlite-only deployment where psycopg2 does not import must keep
+        # starting: no exception from the server lifespan, just a warning.
+        monkeypatch.setattr(deadline, '_psycopg2_ext', None)
+        with mock.patch.object(deadline.logger, 'warning') as warning:
+            assert deadline.install_wait_callback() is False
+        warning.assert_called_once()
+        assert deadline.get_wait_callback() is None
+        deadline.uninstall_wait_callback()  # no-op, no exception
+
+
+class TestWaitCallbackDeadline:
+    """Client side: the thread gives up at the deadline, never pins."""
+
+    def test_never_readable_socket_returns_at_deadline(self):
+        # A socketpair end that never receives data: poll(2) blocks until the
+        # slice expires, the callback re-checks the deadline and raises.
+        a, b = socket.socketpair()
+        try:
+            conn = _FakeConn(a.fileno(), [psycopg2.extensions.POLL_READ] * 100)
+            t, result = _run_callback_in_thread(conn, deadline_seconds=0.5)
+            t.join(3)
+            assert not t.is_alive(), 'thread pinned past the deadline'
+            assert result['kind'] == 'raised'
+            assert result['exc'] == 'DBDeadlineExceeded'
+            assert result['reason'] == 'client_deadline'
+            assert 0.4 <= result['dt'] <= 1.6
+            # After the handshake psycopg2 closes the connection itself on a
+            # callback error (green_panic -> PQfinish); the callback must not.
+            assert conn.close_calls == 0
+        finally:
+            _close_all(a, b)
+
+    def test_no_deadline_waits_until_readable(self):
+        a, b = socket.socketpair()
+        try:
+            conn = _FakeConn(
+                a.fileno(),
+                [psycopg2.extensions.POLL_READ, psycopg2.extensions.POLL_OK])
+            t, result = _run_callback_in_thread(conn, deadline_seconds=None)
+            time.sleep(0.3)
+            assert t.is_alive(), 'callback returned before the socket was ready'
+            b.send(b'x')  # make the fd readable -> poll wakes -> POLL_OK
+            t.join(3)
+            assert not t.is_alive()
+            assert result['kind'] == 'returned'
+        finally:
+            _close_all(a, b)
+
+    def test_conn_poll_is_not_called_after_an_expired_slice(self):
+        # libpq requires PQconnectPoll/PQconsumeInput only when the socket is
+        # ready; a slice that expires without readiness must only re-check the
+        # deadline. With a 2.2s deadline and 1s slices that is >= 2 expiries.
+        a, b = socket.socketpair()
+        try:
+            conn = _FakeConn(a.fileno(), [psycopg2.extensions.POLL_READ] * 100)
+            t, result = _run_callback_in_thread(conn, deadline_seconds=2.2)
+            t.join(5)
+            assert not t.is_alive()
+            assert result['kind'] == 'raised'
+            assert conn.polls == 1, conn.polls
+        finally:
+            _close_all(a, b)
+
+
+class TestStolenFd:
+    """A stolen/closed fd is detected by identity, never handed to libpq.
+
+    The design's earlier version let ``conn.poll()`` -> ``recv()`` run on the
+    reused number; when it was a blocking socket the whole process froze. The
+    fstat gate raises before touching the foreign fd, for every reuse kind.
+    """
+
+    def _steal(self, reuse_kind, deadline_seconds=3.0, sleep_first=0.5):
+        a, b = socket.socketpair()
+        fd = a.fileno()
+        conn = _FakeConn(fd, [psycopg2.extensions.POLL_READ] * 1000)
+        # Record identity as the callback does while the connection is made.
+        deadline._sock_ident[conn] = deadline._ident(fd)
+        t, result = _run_callback_in_thread(conn,
+                                            deadline_seconds=deadline_seconds)
+        time.sleep(sleep_first)  # let it park in poll()
+        # detach() first: a socket object whose number was closed under it
+        # would close that number AGAIN when collected -- and hit whatever
+        # reused it (the exact double close this module is about).
+        assert a.detach() == fd
+        os.close(fd)
+        keep = []
+        if reuse_kind == 'pipe':
+            r, w = os.pipe()
+            keep = [r, w]
+            reused = r
+        elif reuse_kind == 'blocking-socket':
+            c, d = socket.socketpair()  # blocking by default
+            keep = [c, d]
+            reused = c.fileno()
+        elif reuse_kind == 'nonblocking-socket':
+            c, d = socket.socketpair()
+            c.setblocking(False)
+            keep = [c, d]
+            reused = c.fileno()
+        else:  # closed, not reused
+            reused = None
+        return t, result, conn, fd, reused, (a, b), keep
+
+    @pytest.mark.parametrize('reuse_kind',
+                             ['pipe', 'blocking-socket', 'nonblocking-socket'])
+    def test_stolen_fd_is_detected_and_does_not_freeze(self, reuse_kind):
+        t, result, conn, fd, reused, ab, keep = self._steal(reuse_kind)
+        try:
+            # The callback must return within the deadline for EVERY reuse kind,
+            # including a blocking socket (which would otherwise freeze the
+            # thread inside recv() with the GIL held) -- and must not have
+            # handed the foreign fd to libpq: no poll() after the theft.
+            t.join(4)
+            assert not t.is_alive(), (
+                f'thread frozen on a {reuse_kind} that took the fd number')
+            assert result['kind'] == 'raised'
+            assert result['exc'] == 'DBDeadlineExceeded'
+            if reused == fd:
+                assert result['reason'] == 'client_deadline_fd_stolen'
+            assert conn.polls == 1, 'conn.poll() ran on the stolen fd'
+        finally:
+            _close_all(*keep, *ab)
+
+    def test_closed_fd_returns_fast(self):
+        t, result, conn, _, _, ab, keep = self._steal('closed',
+                                                      deadline_seconds=5.0,
+                                                      sleep_first=0.4)
+        try:
+            t.join(3)
+            assert not t.is_alive()
+            assert result['kind'] == 'raised'
+            assert result['reason'] == 'client_deadline_fd_closed'
+            # Much faster than the 5s deadline: caught at the next slice.
+            assert result['dt'] < 3.0
+            assert conn.polls == 1
+        finally:
+            _close_all(*keep, *ab)
+
+    def test_stolen_fd_is_caught_before_the_first_libpq_io(self):
+        # Stolen BETWEEN two statements (the fd is not being waited on). The
+        # first conn.poll() of the next wait would flush the statement -> a
+        # send() into someone else's socket. The gate runs before it.
+        a, b = socket.socketpair()
+        fd = a.fileno()
+        conn = _FakeConn(fd, [psycopg2.extensions.POLL_READ] * 10)
+        deadline._sock_ident[conn] = deadline._ident(fd)
+        assert a.detach() == fd
+        os.close(fd)
+        c, d = socket.socketpair()  # takes the number back
+        try:
+            assert c.fileno() == fd, 'test setup: fd number not reused'
+            # A deadline only so that a broken gate fails (client_deadline
+            # after 1s) instead of blocking here; the correct code raises at
+            # once, before any poll.
+            deadline.set_deadline(time.monotonic() + 1.0)
+            with pytest.raises(deadline.DBDeadlineExceeded) as ei:
+                deadline.wait_callback(conn)
+            assert ei.value.reason == 'client_deadline_fd_stolen'
+            assert conn.polls == 0
+        finally:
+            deadline.clear_deadline()
+            _close_all(b, c, d)
+
+    def test_stolen_fd_without_a_deadline_pins_until_the_wait_ends(self):
+        """The incident's pin, with plain sockets: no deadline means libpq's
+        poll(-1), and the kernel keeps the sleeping poll on the OLD socket.
+        Data on it wakes the sleeper, which re-checks readiness by fd NUMBER
+        (now the new owner), finds nothing and sleeps again; data on the new
+        owner alone never wakes it. Only a bounded slice (a deadline) ends
+        that early. When the wait does end, the gate runs before libpq sees
+        the foreign fd."""
+        a, b = socket.socketpair()
+        fd = a.fileno()
+        conn = _FakeConn(fd, [psycopg2.extensions.POLL_READ] * 10)
+        deadline._sock_ident[conn] = deadline._ident(fd)
+        t, result = _run_callback_in_thread(conn, deadline_seconds=None)
+        time.sleep(0.3)
+        assert a.detach() == fd
+        os.close(fd)
+        c, d = socket.socketpair()
+        try:
+            assert c.fileno() == fd, 'test setup: fd number not reused'
+            b.send(b'x')  # the old socket is readable...
+            time.sleep(0.5)
+            assert t.is_alive(), 'expected the pin (re-check by fd number)'
+            d.send(b'y')  # ...and now so is the new owner's; wake once more
+            b.send(b'z')
+            t.join(3)
+            assert not t.is_alive()
+            assert result['kind'] == 'raised'
+            assert result['reason'] == 'client_deadline_fd_stolen'
+            assert conn.polls == 1, 'conn.poll() ran on the stolen fd'
+        finally:
+            _close_all(b, c, d)
+
+
+class TestConnectPhaseWithStandIn:
+    """The handshake: connect_timeout enforced (and the earlier of it and the
+    thread deadline wins), a failed connect closed at once, socket swaps
+    tolerated."""
+
+    def test_connect_timeout_bounds_a_never_answering_connect(self):
+        # A socketpair end that never becomes readable, presented as a
+        # connection in psycopg2's CONNECTING status (the value real psycopg2
+        # shows inside the callback; STATUS_SETUP is gone after the first
+        # poll) with connect_timeout=1. No thread deadline: the connect bound
+        # is what must fire.
+        a, b = socket.socketpair()
+        try:
+            conn = _FakeConn(a.fileno(), [psycopg2.extensions.POLL_READ] * 1000,
+                             connecting=True,
+                             dsn={'connect_timeout': '1'})
+            t, result = _run_callback_in_thread(conn, deadline_seconds=None)
+            t.join(4)
+            assert not t.is_alive(), 'connect hung past connect_timeout'
+            assert result['kind'] == 'raised'
+            # An OperationalError (so is_disconnect / retry logic treat it as a
+            # libpq connect timeout) carrying our reason.
+            assert result['exc'] == 'DBDeadlineExceeded'
+            assert result['reason'] == 'connect_timeout'
+            assert 'timeout expired' in result['msg']
+            assert 0.8 <= result['dt'] <= 2.5
+            assert conn.polls == 1
+        finally:
+            _close_all(a, b)
+
+    def test_no_connect_timeout_does_not_bound_connect(self):
+        a, b = socket.socketpair()
+        try:
+            conn = _FakeConn(a.fileno(), [psycopg2.extensions.POLL_READ] * 1000,
+                             connecting=True,
+                             dsn={})  # no connect_timeout
+            t, _ = _run_callback_in_thread(conn, deadline_seconds=None)
+            time.sleep(1.2)
+            assert t.is_alive(), 'connect bounded with no connect_timeout set'
+            b.send(b'x')
+            conn._states = [psycopg2.extensions.POLL_OK]
+            t.join(3)
+            assert not t.is_alive()
+        finally:
+            _close_all(a, b)
+
+    def test_thread_deadline_applies_during_connect(self):
+        a, b = socket.socketpair()
+        try:
+            conn = _FakeConn(a.fileno(), [psycopg2.extensions.POLL_READ] * 1000,
+                             connecting=True)
+            t, result = _run_callback_in_thread(conn, deadline_seconds=0.5)
+            t.join(3)
+            assert not t.is_alive()
+            assert result['kind'] == 'raised'
+            assert result['reason'] == 'client_deadline'
+        finally:
+            _close_all(a, b)
+
+    def test_connect_timeout_wins_over_a_longer_thread_deadline(self):
+        """Both bounds apply during the handshake and the earlier one fires:
+        a connect_timeout shorter than the remaining thread budget ends the
+        connect as libpq's own would (reason connect_timeout), not at the
+        thread deadline."""
+        a, b = socket.socketpair()
+        try:
+            conn = _FakeConn(a.fileno(), [psycopg2.extensions.POLL_READ] * 1000,
+                             connecting=True,
+                             dsn={'connect_timeout': '1'})
+            t, result = _run_callback_in_thread(conn, deadline_seconds=5.0)
+            t.join(4)
+            assert not t.is_alive(), 'connect ran past connect_timeout'
+            assert result['kind'] == 'raised'
+            assert result['reason'] == 'connect_timeout'
+            assert 0.8 <= result['dt'] <= 2.5, result
+        finally:
+            _close_all(a, b)
+
+    def test_thread_deadline_wins_over_a_longer_connect_timeout(self):
+        a, b = socket.socketpair()
+        try:
+            conn = _FakeConn(a.fileno(), [psycopg2.extensions.POLL_READ] * 1000,
+                             connecting=True,
+                             dsn={'connect_timeout': '5'})
+            t, result = _run_callback_in_thread(conn, deadline_seconds=0.5)
+            t.join(4)
+            assert not t.is_alive(), 'connect ran past the thread deadline'
+            assert result['kind'] == 'raised'
+            assert result['reason'] == 'client_deadline'
+            assert 0.3 <= result['dt'] <= 2.0, result
+        finally:
+            _close_all(a, b)
+
+    @pytest.mark.parametrize('connect_timeout, deadline_seconds, reason', [
+        ('1', None, 'connect_timeout'),
+        (None, 0.5, 'client_deadline'),
+    ])
+    def test_a_connect_deadline_closes_the_connection_at_once(
+            self, connect_timeout, deadline_seconds, reason):
+        """psycopg2 PQfinish'es a connect that failed inside the callback
+        only when the connection object is deallocated, which the exception's
+        traceback (holding the callback's frame, hence the connection) delays
+        to the next cyclic GC pass. The callback closes it itself, for either
+        bound, so the half-open socket is not held until then."""
+        dsn = {'connect_timeout': connect_timeout} if connect_timeout else {}
+        a, b = socket.socketpair()
+        try:
+            conn = _FakeConn(a.fileno(), [psycopg2.extensions.POLL_READ] * 1000,
+                             connecting=True,
+                             dsn=dsn)
+            t, result = _run_callback_in_thread(
+                conn, deadline_seconds=deadline_seconds)
+            t.join(4)
+            assert not t.is_alive()
+            assert result['kind'] == 'raised'
+            assert result['reason'] == reason
+            assert conn.close_calls == 1
+        finally:
+            _close_all(a, b)
+
+    def test_handshake_socket_swap_is_not_a_stolen_fd(self):
+        # libpq closes and reopens its socket inside PQconnectPoll (address
+        # fallback, multi-host DSNs); the new socket reuses the fd NUMBER, the
+        # inode changes. The gate must not fire during the handshake, and the
+        # identity kept afterwards must be the socket libpq ended up with.
+        a, b = socket.socketpair()
+        fd = a.fileno()
+        swapped = {}
+
+        def on_poll(conn, n):
+            del conn
+            if n == 2:
+                # The "fallback": drop the first socket, open the second on the
+                # same number, and make it readable for the READ step.
+                a.close()
+                c, d = socket.socketpair()
+                assert c.fileno() == fd, 'test setup: fd number not reused'
+                d.send(b'x')
+                swapped.update(c=c, d=d)
+
+        conn = _FakeConn(fd, [
+            psycopg2.extensions.POLL_WRITE, psycopg2.extensions.POLL_WRITE,
+            psycopg2.extensions.POLL_READ, psycopg2.extensions.POLL_OK
+        ],
+                         connecting=True,
+                         on_poll=on_poll)
+        try:
+            t, result = _run_callback_in_thread(conn, deadline_seconds=5.0)
+            t.join(4)
+            assert not t.is_alive()
+            assert result['kind'] == 'returned', result
+            assert conn.status == psycopg2.extensions.STATUS_READY
+            # The identity kept is the second socket's.
+            assert deadline._sock_ident[conn] == deadline._ident(
+                swapped['c'].fileno())
+            # ...so a theft AFTER the handshake is still caught.
+            swapped['c'].close()
+            e, f = socket.socketpair()
+            assert e.fileno() == fd
+            conn._states = [psycopg2.extensions.POLL_READ] * 10
+            deadline.set_deadline(time.monotonic() + 1.0)  # see above
+            with pytest.raises(deadline.DBDeadlineExceeded) as ei:
+                deadline.wait_callback(conn)
+            deadline.clear_deadline()
+            assert ei.value.reason == 'client_deadline_fd_stolen'
+            _close_all(e, f)
+        finally:
+            _close_all(b, swapped.get('d'))
+
+
+def _refused_socket() -> socket.socket:
+    """A bound, NOT listening TCP socket: a connect to its port is refused
+    (RST -> ECONNREFUSED) for as long as it stays open. Held open by the test
+    rather than bound-read-closed, so nothing else can take the port meanwhile.
+    """
+    s = socket.socket()
+    s.bind(('127.0.0.1', 0))
+    return s
+
+
+def _recv_until_eof(sock: socket.socket, timeout: float) -> bool:
+    """Drain ``sock``; True if the peer closed it (EOF) within ``timeout``."""
+    sock.settimeout(timeout)
+    try:
+        while True:
+            if not sock.recv(4096):
+                return True
+    except socket.timeout:
+        return False
+
+
+def _listener():
+    s = socket.socket()
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    s.bind(('127.0.0.1', 0))
+    s.listen(4)
+    return s
+
+
+def _dsn(ports, **extra):
+    hosts = ','.join('127.0.0.1' for _ in ports)
+    parts = [
+        f'host={hosts}', f'port={",".join(str(p) for p in ports)}', 'user=sky',
+        'dbname=sky', 'sslmode=disable', 'gssencmode=disable'
+    ]
+    parts += [f'{k}={v}' for k, v in extra.items()]
+    return ' '.join(parts)
+
+
+# A connect that the code under test fails to bound would block the test
+# process forever (a CI job timeout, not a red test). Every real-libpq connect
+# below runs in a worker thread and is given this long to finish.
+_CONNECT_TEST_TIMEOUT = 10.0
+
+
+def _connect_in_thread(dsn, deadline_seconds=None):
+    """psycopg2.connect(dsn) on a worker thread; (elapsed, exception or None).
+
+    Fails the test if the connect does not finish within
+    ``_CONNECT_TEST_TIMEOUT`` -- that IS the defect these tests exist for.
+    """
+    result = {}
+
+    def worker():
+        if deadline_seconds is not None:
+            deadline.set_deadline(time.monotonic() + deadline_seconds)
+        t0 = time.monotonic()
+        try:
+            psycopg2.connect(dsn).close()
+            result['exc'] = None
+        except Exception as e:  # pylint: disable=broad-except
+            result['exc'] = e
+        finally:
+            result['dt'] = time.monotonic() - t0
+            deadline.clear_deadline()
+
+    t = threading.Thread(target=worker, daemon=True, name='connect-worker')
+    t.start()
+    t.join(_CONNECT_TEST_TIMEOUT)
+    assert not t.is_alive(), (
+        f'psycopg2.connect did not return within {_CONNECT_TEST_TIMEOUT}s: '
+        f'the connect is not bounded')
+    return result['dt'], result['exc']
+
+
+class TestConnectPhaseWithRealLibpq:
+    """Real psycopg2/libpq, no database server: local listeners stand in.
+
+    A multi-host DSN whose first host refuses makes libpq swap sockets inside
+    the handshake (the fd number is reused). The second host either never
+    answers (the connect bound must fire, and it must NOT be reported as a
+    stolen fd) or hangs up (libpq's own error, i.e. the handshake proceeded on
+    the new socket).
+    """
+
+    def test_fallback_then_connect_timeout(self):
+        silent = _listener()  # accepts in the kernel, never answers
+        refused = _refused_socket()
+        try:
+            dsn = _dsn([refused.getsockname()[1],
+                        silent.getsockname()[1]],
+                       connect_timeout=1)
+            deadline.install_wait_callback()
+            dt, exc = _connect_in_thread(dsn)
+            assert isinstance(exc, psycopg2.OperationalError), exc
+            assert deadline.deadline_reason(exc) == 'connect_timeout', exc
+            assert 0.8 <= dt <= 2.5, dt
+            # Parity with sync psycopg2 (libpq's own connect_timeout).
+            deadline.uninstall_wait_callback()
+            dt, exc = _connect_in_thread(dsn)
+            assert isinstance(exc, psycopg2.OperationalError), exc
+            assert 0.8 <= dt <= 2.5, dt
+        finally:
+            silent.close()
+            refused.close()
+
+    def test_fallback_reaches_the_second_host(self):
+        hangup = _listener()
+        refused = _refused_socket()
+
+        def _accept_and_close():
+            try:
+                c, _ = hangup.accept()
+                c.close()
+            except OSError:
+                pass
+
+        th = threading.Thread(target=_accept_and_close, daemon=True)
+        th.start()
+        try:
+            dsn = _dsn([refused.getsockname()[1],
+                        hangup.getsockname()[1]],
+                       connect_timeout=8)
+            deadline.install_wait_callback()
+            dt, exc = _connect_in_thread(dsn)
+            # libpq's error from talking to the second host -- not ours...
+            assert isinstance(exc, psycopg2.OperationalError), exc
+            assert not isinstance(exc, deadline.DBDeadlineExceeded), exc
+            assert deadline.deadline_reason(exc) is None
+            # ...and promptly: a fallback that did not happen would only end
+            # at connect_timeout (8 s). Loose bound for loaded runners.
+            assert dt < 5.0, dt
+        finally:
+            hangup.close()
+            refused.close()
+            th.join(2)
+
+    def test_thread_deadline_bounds_a_silent_connect(self):
+        silent = _listener()
+        try:
+            dsn = _dsn([silent.getsockname()[1]])  # no connect_timeout
+            deadline.install_wait_callback()
+            dt, exc = _connect_in_thread(dsn, deadline_seconds=0.7)
+            # Propagates intact from psycopg2.connect (class, reason).
+            assert isinstance(exc, deadline.DBDeadlineExceeded), exc
+            assert exc.reason == 'client_deadline'
+            assert isinstance(exc, psycopg2.OperationalError)
+            assert 0.5 <= dt <= 2.0, dt
+        finally:
+            silent.close()
+
+    def test_connect_deadline_closes_the_socket_at_once(self):
+        """A connect that gives up in the callback is closed right there, as
+        sync psycopg2 closes a timed-out connect. psycopg2 otherwise
+        PQfinish'es a failed connect only when the connection object is
+        deallocated, and the exception's traceback keeps that object alive --
+        here for as long as the test holds `exc`, in a server until the next
+        cyclic GC pass. Observed from the peer: the accepted socket sees EOF
+        (after libpq's startup packet) while `exc` is still referenced."""
+        silent = _listener()
+        accepted: list = []
+
+        def _accept():
+            try:
+                c, _ = silent.accept()
+                accepted.append(c)
+            except OSError:
+                pass
+
+        th = threading.Thread(target=_accept, daemon=True)
+        th.start()
+        try:
+            deadline.install_wait_callback()
+            dt, exc = _connect_in_thread(_dsn([silent.getsockname()[1]]),
+                                         deadline_seconds=0.3)
+            assert isinstance(exc, deadline.DBDeadlineExceeded), exc
+            assert exc.reason == 'client_deadline'
+            assert 0.2 <= dt <= 2.0, dt
+            th.join(2)
+            assert accepted, 'libpq never reached the listener'
+            assert _recv_until_eof(accepted[0], timeout=2.0), (
+                'client socket still open after the connect deadline')
+            del exc
+        finally:
+            silent.close()
+            th.join(2)
+            for c in accepted:
+                c.close()
+
+
+_PREFIX_RE = re.compile(r'^(SET LOCAL [^;]+; )+')
+
+
+class _PsycopgLikeCursor(sqlite3.Cursor):
+    """Flips the connection to BEGIN on the first statement, like psycopg2."""
+
+    def execute(self, *args, **kwargs):
+        result = super().execute(*args, **kwargs)
+        self.connection.status = psycopg2.extensions.STATUS_BEGIN
+        return result
+
+    def executemany(self, *args, **kwargs):
+        result = super().executemany(*args, **kwargs)
+        self.connection.status = psycopg2.extensions.STATUS_BEGIN
+        return result
+
+
+class _PsycopgLikeConnection(sqlite3.Connection):
+    """A sqlite3 connection presenting psycopg2's transaction-state surface.
+
+    The listener reads two driver attributes: ``status`` (READY before the
+    first statement of a transaction, BEGIN until commit/rollback) and
+    ``autocommit`` (a bool on psycopg2; Python 3.12+ sqlite3 has its own
+    int-valued ``autocommit`` -- LEGACY_TRANSACTION_CONTROL is -1 -- shadowed
+    here). Everything else -- events, ``retval``, autobegin, pooling -- is
+    real SQLAlchemy machinery on a real DBAPI connection.
+    """
+    autocommit = False
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.status = psycopg2.extensions.STATUS_READY
+
+    def cursor(self, factory=None):
+        return super().cursor(factory or _PsycopgLikeCursor)
+
+    def commit(self):
+        super().commit()
+        self.status = psycopg2.extensions.STATUS_READY
+
+    def rollback(self):
+        super().rollback()
+        self.status = psycopg2.extensions.STATUS_READY
+
+
+class TestSetLocalListener:
+    """The engine listener: attach conditions, emitted text, reset."""
+
+    def _spy_engine(self,
+                    url='sqlite://',
+                    pretend_postgres=False,
+                    before_install=None):
+        """A sqlite engine, optionally presenting as Postgres + psycopg2.
+
+        With ``pretend_postgres`` the listener attaches (it keys on the
+        dialect name and driver) and the DBAPI connections are
+        ``_PsycopgLikeConnection``; a second listener registered after it
+        records what the driver would receive and strips the prefix again so
+        sqlite can run the statement. ``before_install(engine)`` registers
+        other listeners ahead of ours (listener-order tests).
+        """
+        if pretend_postgres:
+            engine = sqlalchemy.create_engine(
+                url,
+                creator=lambda: sqlite3.connect(':memory:',
+                                                factory=_PsycopgLikeConnection,
+                                                check_same_thread=False))
+            engine.dialect.name = 'postgresql'
+            engine.dialect.driver = 'psycopg2'
+        else:
+            engine = sqlalchemy.create_engine(url)
+        if before_install is not None:
+            before_install(engine)
+        deadline.install(engine)
+        emitted = []
+
+        @sqlalchemy.event.listens_for(engine,
+                                      'before_cursor_execute',
+                                      retval=True)
+        def _capture(conn, cursor, statement, parameters, context, executemany):  # pylint: disable=unused-variable
+            del conn, cursor, context, executemany
+            emitted.append(statement)
+            return _PREFIX_RE.sub('', statement), parameters
+
+        return engine, emitted
+
+    @staticmethod
+    def _prefixes(emitted):
+        return [s for s in emitted if s.startswith('SET LOCAL ')]
+
+    def test_sqlite_engine_gets_no_listener_and_no_set_local(self):
+        engine, emitted = self._spy_engine('sqlite://')
+        deadline.set_deadline(time.monotonic() + 5)
+        with engine.begin() as conn:
+            conn.execute(sqlalchemy.text('SELECT 1'))
+        assert not self._prefixes(emitted), emitted
+        assert not deadline.is_bounding(engine)
+
+    def test_other_postgres_driver_gets_no_listener(self):
+        # The listener reads psycopg2's connection status; on another driver
+        # it would silently never fire, so it is not attached at all.
+        engine = sqlalchemy.create_engine('sqlite://')
+        engine.dialect.name = 'postgresql'
+        engine.dialect.driver = 'psycopg'
+        deadline.install(engine)
+        deadline.set_deadline(time.monotonic() + 5)
+        assert not deadline.is_bounding(engine)
+
+    def test_install_is_idempotent(self):
+        engine, emitted = self._spy_engine(pretend_postgres=True)
+        deadline.install(engine)  # second call: no second listener
+        deadline.set_deadline(time.monotonic() + 4.5)
+        with engine.begin() as conn:
+            conn.execute(sqlalchemy.text('SELECT 1'))
+        assert len(emitted) == 1
+        assert len(_PREFIX_RE.match(emitted[0]).group(0).split('; ')) == 4
+
+    def test_no_deadline_emits_no_set_local(self):
+        engine, emitted = self._spy_engine(pretend_postgres=True)
+        with engine.begin() as conn:
+            conn.execute(sqlalchemy.text('SELECT 1'))
+        assert not self._prefixes(emitted), emitted
+        assert not deadline.is_bounding(engine)
+
+    def test_first_statement_of_a_bounded_transaction_gets_the_prefix(self):
+        engine, emitted = self._spy_engine(pretend_postgres=True)
+        deadline.set_deadline(time.monotonic() + 4.5)
+        with engine.begin() as conn:
+            conn.execute(sqlalchemy.text('SELECT 1'))
+            conn.execute(sqlalchemy.text('SELECT 2'))
+        assert len(emitted) == 2
+        first, second = emitted[0], emitted[1]
+        assert first.startswith('SET LOCAL statement_timeout = ')
+        assert 'SET LOCAL lock_timeout = ' in first
+        assert 'SET LOCAL idle_in_transaction_session_timeout = ' in first
+        assert first.endswith('; SELECT 1')
+        # Only the first statement of the transaction.
+        assert second == 'SELECT 2'
+
+    def test_a_new_transaction_is_prefixed_again(self):
+        # Same DBAPI connection (one Connection held open), three transactions
+        # in a row: bounded, unbounded, bounded. COMMIT puts the driver back to
+        # READY, so the third gets the prefix although the connection already
+        # carried it once -- no per-connection mark to go stale.
+        engine, emitted = self._spy_engine(pretend_postgres=True)
+        with engine.connect() as conn:
+            deadline.set_deadline(time.monotonic() + 4.5)
+            with conn.begin():
+                conn.execute(sqlalchemy.text('SELECT 1'))
+            deadline.clear_deadline()
+            with conn.begin():
+                conn.execute(sqlalchemy.text('SELECT 2'))
+            deadline.set_deadline(time.monotonic() + 4.5)
+            with conn.begin():
+                conn.execute(sqlalchemy.text('SELECT 3'))
+                conn.execute(sqlalchemy.text('SELECT 4'))
+        bare = [_PREFIX_RE.sub('', s) for s in emitted]
+        assert bare == ['SELECT 1', 'SELECT 2', 'SELECT 3', 'SELECT 4']
+        prefixed = [s.startswith('SET LOCAL') for s in emitted]
+        assert prefixed == [True, False, True, False]
+
+    def test_session_autobegin_is_prefixed(self):
+        engine, emitted = self._spy_engine(pretend_postgres=True)
+        deadline.set_deadline(time.monotonic() + 4.5)
+        with orm.Session(engine) as session:
+            session.execute(sqlalchemy.text('SELECT 1'))
+            session.execute(sqlalchemy.text('SELECT 2'))
+            session.commit()
+        prefixed = [s.startswith('SET LOCAL') for s in emitted]
+        assert prefixed == [True, False]
+
+    def test_executemany_is_not_prefixed(self):
+        engine, emitted = self._spy_engine(pretend_postgres=True)
+        with engine.begin() as conn:
+            conn.execute(sqlalchemy.text('CREATE TABLE t (x INTEGER)'))
+        emitted.clear()
+        deadline.set_deadline(time.monotonic() + 4.5)
+        with engine.begin() as conn:
+            # Opens the transaction; per-row text, so no prefix. The
+            # transaction is then open (BEGIN): the next statement is not its
+            # first and gets no prefix either -- a transaction OPENED by an
+            # executemany has no server-side bound (documented; the auth path
+            # never does this).
+            conn.execute(sqlalchemy.text('INSERT INTO t (x) VALUES (:x)'), [{
+                'x': 1
+            }, {
+                'x': 2
+            }])
+            conn.execute(sqlalchemy.text('SELECT count(*) FROM t'))
+        with engine.begin() as conn:
+            # A new transaction is bounded again.
+            conn.execute(sqlalchemy.text('SELECT count(*) FROM t'))
+        prefixed = [s.startswith('SET LOCAL') for s in emitted]
+        assert prefixed == [False, False, True], emitted
+
+    @pytest.mark.parametrize('other_listener_first', [True, False])
+    def test_exactly_one_prefix_with_a_begin_listener_in_either_order(
+            self, other_listener_first):
+        # Another engine listener runs a statement from the `begin` event
+        # (the shape of an engine-wide idle-in-transaction bound). Whatever
+        # the registration order, that statement is the transaction's first
+        # and carries the one prefix; the caller's own statements do not.
+        def other(engine):
+
+            @sqlalchemy.event.listens_for(engine, 'begin')
+            def _begin(conn):  # pylint: disable=unused-variable
+                conn.exec_driver_sql('SELECT 42').close()
+
+        if other_listener_first:
+            engine, emitted = self._spy_engine(pretend_postgres=True,
+                                               before_install=other)
+        else:
+            engine, emitted = self._spy_engine(pretend_postgres=True)
+            other(engine)
+        deadline.set_deadline(time.monotonic() + 4.5)
+        with engine.begin() as conn:
+            conn.execute(sqlalchemy.text('SELECT 1'))
+            conn.execute(sqlalchemy.text('SELECT 2'))
+        with engine.begin() as conn:  # and again for the next transaction
+            conn.execute(sqlalchemy.text('SELECT 3'))
+        bare = [_PREFIX_RE.sub('', s) for s in emitted]
+        assert bare == [
+            'SELECT 42', 'SELECT 1', 'SELECT 2', 'SELECT 42', 'SELECT 3'
+        ]
+        prefixed = [s.startswith('SET LOCAL') for s in emitted]
+        assert prefixed == [True, False, False, True, False], emitted
+
+    def test_is_bounding_needs_the_listener_and_a_deadline(self):
+        engine, _ = self._spy_engine(pretend_postgres=True)
+        assert not deadline.is_bounding(engine)
+        deadline.set_deadline(time.monotonic() + 4.5)
+        assert deadline.is_bounding(engine)
+        deadline.clear_deadline()
+        assert not deadline.is_bounding(engine)
+        # An engine without the listener is never "bounding", deadline or not.
+        deadline.set_deadline(time.monotonic() + 4.5)
+        assert not deadline.is_bounding(sqlalchemy.create_engine('sqlite://'))
+
+    def _stub_conn(self, autocommit=False, status='ready'):
+        conn = mock.Mock()
+        conn.info = {}
+        conn.connection.dbapi_connection.autocommit = autocommit
+        conn.connection.dbapi_connection.status = (
+            psycopg2.extensions.STATUS_READY
+            if status == 'ready' else psycopg2.extensions.STATUS_BEGIN)
+        return conn
+
+    def test_named_cursor_is_not_prefixed(self):
+        # A server-side cursor wraps the text in DECLARE ... FOR <statement>;
+        # a leading SET LOCAL there is a syntax error.
+        deadline.set_deadline(time.monotonic() + 4.5)
+        conn = self._stub_conn()
+        cursor = mock.Mock()
+        cursor.name = 'stream'
+        assert deadline._bounded_statement(conn, cursor, 'SELECT 1',
+                                           False) == 'SELECT 1'
+        cursor.name = None
+        assert deadline._bounded_statement(conn, cursor, 'SELECT 1',
+                                           False).endswith('; SELECT 1')
+
+    def test_autocommit_connection_is_not_prefixed(self):
+        deadline.set_deadline(time.monotonic() + 4.5)
+        conn = self._stub_conn(autocommit=True)
+        cursor = mock.Mock()
+        cursor.name = None
+        assert deadline._bounded_statement(conn, cursor, 'SELECT 1',
+                                           False) == 'SELECT 1'
+
+    def test_an_open_transaction_is_not_prefixed_again(self):
+        deadline.set_deadline(time.monotonic() + 4.5)
+        conn = self._stub_conn(status='begin')
+        cursor = mock.Mock()
+        cursor.name = None
+        assert deadline._bounded_statement(conn, cursor, 'SELECT 1',
+                                           False) == 'SELECT 1'
+
+    def test_a_connection_without_a_driver_status_is_left_alone(self):
+        deadline.set_deadline(time.monotonic() + 4.5)
+        conn = self._stub_conn()
+        del conn.connection.dbapi_connection.status
+        cursor = mock.Mock()
+        cursor.name = None
+        assert deadline._bounded_statement(conn, cursor, 'SELECT 1',
+                                           False) == 'SELECT 1'
+
+    def test_prefix_is_sized_from_the_remaining_budget(self):
+        deadline.set_deadline(time.monotonic() + 2.0)
+        conn = self._stub_conn()
+        cursor = mock.Mock()
+        cursor.name = None
+        text = deadline._bounded_statement(conn, cursor, 'SELECT 1', False)
+        statement_ms = int(
+            re.search(r'statement_timeout = (\d+)', text).group(1))
+        # 2000 remaining - 500 server margin, minus the microseconds elapsed.
+        assert 1400 <= statement_ms <= 1500, text
+
+    def test_prefix_values_are_ordered(self):
+        text = deadline._set_local_prefix(4500)
+
+        def _val(name):
+            return int(re.search(rf'{name} = (\d+)', text).group(1))
+
+        assert _val('lock_timeout') < _val('statement_timeout')
+        assert (_val('idle_in_transaction_session_timeout') >=
+                _val('statement_timeout'))
+        # statement fires the server margin before the client deadline.
+        assert _val('statement_timeout') == 4500 - deadline._SERVER_MARGIN_MS
+        assert '%' not in text
+
+    def test_prefix_values_floor_at_minimum(self):
+        text = deadline._set_local_prefix(10)  # tiny remaining budget
+
+        def _val(name):
+            return int(re.search(rf'{name} = (\d+)', text).group(1))
+
+        assert _val('statement_timeout') == deadline._MIN_TIMEOUT_MS
+        assert _val('lock_timeout') == deadline._MIN_TIMEOUT_MS
+
+
+class _PgError(Exception):
+    """A server error stand-in carrying a SQLSTATE (psycopg2's C error type
+    keeps `pgcode` read-only; deadline_reason only reads `orig.pgcode`)."""
+
+    def __init__(self, code):
+        super().__init__('cancelled')
+        self.pgcode = code
+
+
+class TestClassification:
+    """deadline_reason / is_deadline_error / is_transient_driver_error."""
+
+    def test_wrapped_client_deadline(self):
+        orig = deadline.DBDeadlineExceeded('x', reason='client_deadline')
+        wrapped = sqlalchemy.exc.OperationalError('stmt', {}, orig)
+        assert deadline.deadline_reason(wrapped) == 'client_deadline'
+        assert deadline.is_deadline_error(wrapped)
+
+    @pytest.mark.parametrize('reason', [
+        'client_deadline_fd_stolen', 'client_deadline_fd_closed',
+        'connect_timeout'
+    ])
+    def test_wrapped_client_reasons(self, reason):
+        orig = deadline.DBDeadlineExceeded('x', reason=reason)
+        wrapped = sqlalchemy.exc.OperationalError('stmt', {}, orig)
+        assert deadline.deadline_reason(wrapped) == reason
+
+    @pytest.mark.parametrize('pgcode,reason',
+                             [('57014', 'statement_timeout'),
+                              ('55P03', 'lock_timeout'),
+                              ('25P03', 'idle_in_transaction')])
+    def test_server_pgcodes(self, pgcode, reason):
+        wrapped = sqlalchemy.exc.OperationalError('stmt', {}, _PgError(pgcode))
+        assert deadline.deadline_reason(wrapped) == reason
+        assert deadline.is_deadline_error(wrapped)
+
+    def test_idle_session_timeout_is_not_ours(self):
+        # 57P05 is idle_session_timeout, which the bounds never set.
+        wrapped = sqlalchemy.exc.OperationalError('stmt', {}, _PgError('57P05'))
+        assert deadline.deadline_reason(wrapped) is None
+
+    def test_non_deadline_error(self):
+        orig = psycopg2.OperationalError('connection dropped')
+        wrapped = sqlalchemy.exc.OperationalError('stmt', {}, orig)
+        assert deadline.deadline_reason(wrapped) is None
+        assert not deadline.is_deadline_error(wrapped)
+
+    @pytest.mark.parametrize('orig,transient', [
+        (psycopg2.OperationalError('server closed the connection'), True),
+        (psycopg2.InterfaceError('connection already closed'), True),
+        (deadline.DBDeadlineExceeded('x'), True),
+        (sqlite3.OperationalError('no such table: users'), False),
+        (_PgError(None), False),
+        (Exception('x'), False),
+    ])
+    def test_transient_driver_error_is_psycopg2_only(self, orig, transient):
+        wrapped = sqlalchemy.exc.OperationalError('stmt', {}, orig)
+        assert deadline.is_transient_driver_error(wrapped) is transient
+        assert deadline.is_transient_driver_error(orig) is transient

--- a/tests/unit_tests/test_sky/utils/db/test_deadline.py
+++ b/tests/unit_tests/test_sky/utils/db/test_deadline.py
@@ -33,6 +33,7 @@ that presents psycopg2's ``status`` / ``autocommit`` surface.
 # pylint: disable=protected-access,missing-class-docstring,redefined-outer-name
 import os
 import re
+import select
 import socket
 import sqlite3
 import threading
@@ -44,6 +45,7 @@ import pytest
 import sqlalchemy
 from sqlalchemy import orm
 
+from sky.utils.db import db_utils
 from sky.utils.db import deadline
 
 
@@ -213,6 +215,46 @@ class TestWaitCallbackDeadline:
         finally:
             _close_all(a, b)
 
+    def test_no_deadline_is_one_unbounded_poll(self):
+        """Parity with sync psycopg2 for callers without a deadline: one
+        poll(fd, -1), no timed slices (a sliced wait would wake and re-check
+        the fd every second for every DB call in the web process)."""
+        real_poll = select.poll
+        calls = []
+
+        class _RecordingPoller:
+
+            def __init__(self):
+                self._poller = real_poll()
+                self.fd = None
+
+            def register(self, fd, flags):
+                self.fd = fd
+                self._poller.register(fd, flags)
+
+            def poll(self, *args):
+                calls.append((self.fd, args))
+                return self._poller.poll(*args)
+
+        a, b = socket.socketpair()
+        try:
+            conn = _FakeConn(
+                a.fileno(),
+                [psycopg2.extensions.POLL_READ, psycopg2.extensions.POLL_OK])
+            with mock.patch.object(select, 'poll', _RecordingPoller):
+                t, result = _run_callback_in_thread(conn, deadline_seconds=None)
+                time.sleep(0.3)
+                assert t.is_alive(), 'returned before the socket was ready'
+                b.send(b'x')
+                t.join(3)
+            assert not t.is_alive()
+            assert result['kind'] == 'returned'
+            ours = [args for fd, args in calls if fd == a.fileno()]
+            # Exactly one poll on our fd, called with NO timeout argument.
+            assert ours == [()], ours
+        finally:
+            _close_all(a, b)
+
     def test_conn_poll_is_not_called_after_an_expired_slice(self):
         # libpq requires PQconnectPoll/PQconsumeInput only when the socket is
         # ready; a slice that expires without readiness must only re-check the
@@ -328,6 +370,69 @@ class TestStolenFd:
         finally:
             deadline.clear_deadline()
             _close_all(b, c, d)
+
+    def test_first_wait_records_the_identity_of_an_existing_connection(self):
+        """A connection made before the callback was installed (a pool
+        connection from before the lifespan) has no recorded identity. Its
+        first wait must record one, or the fd gate stays inert for that
+        connection for its whole pooled life."""
+        a, b = socket.socketpair()
+        fd = a.fileno()
+        conn = _FakeConn(
+            fd, [psycopg2.extensions.POLL_READ, psycopg2.extensions.POLL_OK])
+        assert conn not in deadline._sock_ident
+        b.send(b'x')  # readable at once: the first wait returns
+        deadline.wait_callback(conn)
+        assert conn.polls == 2
+        assert deadline._sock_ident.get(conn) == deadline._ident(fd)
+        # Now steal the number; the next wait must refuse it before libpq I/O.
+        assert a.detach() == fd
+        os.close(fd)
+        c, d = socket.socketpair()
+        try:
+            assert c.fileno() == fd, 'test setup: fd number not reused'
+            d.send(b'y')  # the foreign fd is readable: a broken gate returns
+            conn._states = [
+                psycopg2.extensions.POLL_READ, psycopg2.extensions.POLL_OK
+            ]
+            deadline.set_deadline(time.monotonic() + 1.0)
+            with pytest.raises(deadline.DBDeadlineExceeded) as ei:
+                deadline.wait_callback(conn)
+            assert ei.value.reason == 'client_deadline_fd_stolen'
+            assert conn.polls == 2, 'conn.poll() ran on the stolen fd'
+        finally:
+            deadline.clear_deadline()
+            _close_all(b, c, d)
+
+    def test_a_theft_in_the_deadline_slice_keeps_the_theft_label(self):
+        """The deadline expires in the same slice the fd was stolen in: the
+        error must still say fd_stolen (the per-worker double-close detector
+        label), not the generic client_deadline."""
+        a, b = socket.socketpair()
+        fd = a.fileno()
+        keep = []
+
+        def _steal_during_poll(conn, n):
+            del conn
+            if n == 1:
+                assert a.detach() == fd
+                os.close(fd)
+                c, d = socket.socketpair()
+                keep.extend([c, d])
+                assert c.fileno() == fd, 'test setup: fd number not reused'
+
+        conn = _FakeConn(fd, [psycopg2.extensions.POLL_READ] * 10,
+                         on_poll=_steal_during_poll)
+        deadline._sock_ident[conn] = deadline._ident(fd)
+        try:
+            deadline.set_deadline(time.monotonic() - 1.0)  # already expired
+            with pytest.raises(deadline.DBDeadlineExceeded) as ei:
+                deadline.wait_callback(conn)
+            assert ei.value.reason == 'client_deadline_fd_stolen'
+            assert conn.polls == 1
+        finally:
+            deadline.clear_deadline()
+            _close_all(b, *keep)
 
     def test_stolen_fd_without_a_deadline_pins_until_the_wait_ends(self):
         """The incident's pin, with plain sockets: no deadline means libpq's
@@ -829,6 +934,32 @@ class TestSetLocalListener:
         deadline.install(engine)
         deadline.set_deadline(time.monotonic() + 5)
         assert not deadline.is_bounding(engine)
+
+    def test_get_engine_attaches_the_listener_to_every_sync_engine(
+            self, monkeypatch):
+        """The wiring in `db_utils.get_engine`: every sync Postgres engine it
+        builds (pooled, direct, no_pool) carries the listener; the asyncpg
+        engine does not. No database is needed: `create_engine` is lazy."""
+        monkeypatch.setenv('IS_SKYPILOT_SERVER', '1')
+        monkeypatch.setenv('SKYPILOT_DB_CONNECTION_URI',
+                           'postgresql://u:p@127.0.0.1:1/dbx')
+        monkeypatch.setenv('SKYPILOT_DB_POOL_CONNECTION_URI',
+                           'postgresql://u:p@127.0.0.1:2/dbx?sslmode=disable')
+        monkeypatch.delenv('SKYPILOT_DB_POOL_HOSTPORT', raising=False)
+        monkeypatch.setattr(db_utils, '_postgres_engine_cache', {})
+        pooled = db_utils.get_engine('state')
+        direct = db_utils.get_engine('state', direct=True)
+        no_pool = db_utils.get_engine('state', no_pool=True)
+        async_engine = db_utils.get_engine('state', async_engine=True)
+        assert len({id(pooled), id(direct), id(no_pool)}) == 3
+        for engine in (pooled, direct, no_pool):
+            assert engine.dialect.driver == 'psycopg2', engine.url
+            deadline.set_deadline(time.monotonic() + 5)
+            assert deadline.is_bounding(engine), engine.url
+            deadline.clear_deadline()
+            assert not deadline.is_bounding(engine)
+        deadline.set_deadline(time.monotonic() + 5)
+        assert not deadline.is_bounding(async_engine)
 
     def test_install_is_idempotent(self):
         engine, emitted = self._spy_engine(pretend_postgres=True)

--- a/tests/unit_tests/test_sky/utils/test_db_retries.py
+++ b/tests/unit_tests/test_sky/utils/test_db_retries.py
@@ -1,12 +1,14 @@
 """Unit tests for sky.utils.db.retries."""
 # pylint: disable=missing-class-docstring,protected-access,unnecessary-lambda
 import socket
+import time
 from unittest import mock
 
 import psycopg2
 import pytest
 import sqlalchemy.exc
 
+from sky.utils.db import deadline as db_deadline
 from sky.utils.db import retries
 
 
@@ -188,3 +190,82 @@ async def _coro_returning(value):
 
 async def _coro_raising(exc):
     raise exc
+
+
+def _deadline_error(reason='client_deadline'):
+    return sqlalchemy.exc.OperationalError(
+        'stmt', {}, db_deadline.DBDeadlineExceeded('x', reason=reason))
+
+
+class _PgError(Exception):
+
+    def __init__(self, pgcode):
+        super().__init__('cancelled')
+        self.pgcode = pgcode
+
+
+class TestRetriesUnderAnAuthDeadline:
+    """With a thread-local deadline set (the bounded auth path), retrying
+    cannot help: a deadline error IS the bound firing, and a backoff sleep
+    that outlives the deadline holds the thread the bound exists to free.
+    Without a deadline, nothing changes."""
+
+    @pytest.fixture(autouse=True)
+    def _clear(self):
+        db_deadline.clear_deadline()
+        yield
+        db_deadline.clear_deadline()
+
+    def test_a_client_deadline_error_is_not_retried(self):
+        db_deadline.set_deadline(time.monotonic() + 60)
+        fn = mock.Mock(side_effect=_deadline_error())
+        with mock.patch.object(retries.time, 'sleep') as sleep:
+            with pytest.raises(sqlalchemy.exc.OperationalError):
+                retries.with_db_retries(fn)
+        fn.assert_called_once()
+        sleep.assert_not_called()
+
+    @pytest.mark.parametrize('pgcode', ['55P03', '57014', '25P03'])
+    def test_a_server_timeout_is_not_retried(self, pgcode):
+        db_deadline.set_deadline(time.monotonic() + 60)
+        fn = mock.Mock(side_effect=sqlalchemy.exc.OperationalError(
+            'stmt', {}, _PgError(pgcode)))
+        with mock.patch.object(retries.time, 'sleep') as sleep:
+            with pytest.raises(sqlalchemy.exc.OperationalError):
+                retries.with_db_retries(fn)
+        fn.assert_called_once()
+        sleep.assert_not_called()
+
+    def test_a_backoff_past_the_deadline_stops_retrying(self):
+        # A non-deadline transient error (e.g. EBADF on a stolen fd) with
+        # 0.3s of budget left: the first backoff (~1s) would outlive it.
+        db_deadline.set_deadline(time.monotonic() + 0.3)
+        fn = mock.Mock(side_effect=_make_op_error('EBADF'))
+        with mock.patch.object(retries.time, 'sleep') as sleep:
+            with pytest.raises(sqlalchemy.exc.OperationalError):
+                retries.with_db_retries(fn)
+        fn.assert_called_once()
+        sleep.assert_not_called()
+
+    def test_a_transient_error_within_budget_is_still_retried(self):
+        db_deadline.set_deadline(time.monotonic() + 60)
+        fn = mock.Mock(side_effect=[_make_op_error('EBADF'), 'ok'])
+        with mock.patch.object(retries.time, 'sleep'):
+            assert retries.with_db_retries(fn) == 'ok'
+        assert fn.call_count == 2
+
+    def test_without_a_deadline_a_deadline_error_is_retried_as_before(self):
+        fn = mock.Mock(side_effect=[_deadline_error(), 'ok'])
+        with mock.patch.object(retries.time, 'sleep'):
+            assert retries.with_db_retries(fn) == 'ok'
+        assert fn.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_async_variant_stops_too(self):
+        db_deadline.set_deadline(time.monotonic() + 60)
+        fn = mock.AsyncMock(side_effect=_deadline_error())
+        with mock.patch.object(retries.asyncio, 'sleep') as sleep:
+            with pytest.raises(sqlalchemy.exc.OperationalError):
+                await retries.with_db_retries_async(fn)
+        fn.assert_called_once()
+        sleep.assert_not_called()


### PR DESCRIPTION
Stacked on #10684 (server-side `SET LOCAL` bounds on the users upsert, sized from the configured auth deadline). This PR generalizes the server-side bound to every auth-path transaction and adds the client-side half. The deadline stays the existing `SKYPILOT_AUTH_DB_TIMEOUT_SECONDS` (default `constants.DEFAULT_AUTH_DB_TIMEOUT_SECONDS`, 5 s), read through `db_utils.get_auth_db_timeout_seconds()` from #10684 -- one source for the `wait_for` deadline, the thread-local deadline handed to the DB layer, and both server-side sizings below. No new knob.

Related: #10681 (the descriptor double-close whose fallout this change bounds; the fix for the double close itself is #10689 and is independent of this PR). Stacked on #10684; if that merges first this PR retargets to `master` (the merge is clean).

## Problem

The auth middlewares run their DB lookups on a small thread executor under `asyncio.wait_for`. That deadline frees the *caller* (the request gets a retryable 503) but never the *thread*: a thread parked in libpq's `poll()` — waiting on a row lock, a slow statement, an unreachable or frozen server, or a socket whose fd number was closed and reused under it — keeps running until the DB layer lets go. In a production deployment, one such thread holding a `users` row lock in an idle transaction made every later same-row upsert pin another auth thread, until all 32 threads on every worker were pinned and every authenticated request failed with the worker-exhausted 503 (#10681).

#10684 bounds the users upsert transaction on the server side with explicit `SET LOCAL` statements sized as percentages of the configured deadline. This PR:

1. **Server side, generic.** An engine listener (`sky/utils/db/deadline.py`) prepends `SET LOCAL statement_timeout / lock_timeout / idle_in_transaction_session_timeout` to the first statement of every Postgres transaction opened while the auth-path deadline is active, sized from the remaining budget (at the default 5 s: lock 3.9 s < statement 4.0 s < idle-in-transaction 4.5 s ≈ client 4.5 s < `wait_for` 5.0 s). One round trip (prepended to the statement text, inside SQLAlchemy's error handling). "First statement of the transaction" is read from psycopg2's own connection status (READY before its implicit BEGIN), so the listener keeps no per-connection state and does not depend on the order of engine listeners: a statement another `begin` listener issues first (e.g. an engine-wide idle-in-transaction bound, #10687) is simply the first statement and carries the one prefix. Covers all auth transactions (users upsert, bearer-token lookups, RBAC policy reload), not only the upsert. The explicit statements from #10684 stay for callers without a deadline (request executor, user endpoints) and for any engine the listener is not attached to; they are skipped only when this engine's listener will bound the transaction itself (`deadline.is_bounding(engine)`).
   **Two sizings coexist on purpose.** Without a deadline, the upsert's explicit statements use #10684's percentages of the configured deadline (78 / 80 / 100 %: 3900 / 4000 / 5000 ms at the default 5 s). Under the auth-path deadline, the listener sizes from the *remaining* budget with absolute margins (statement = remaining − 500 ms, lock = statement − 100 ms, idle-in-transaction = remaining; about 3997 / 3897 / 4497 ms at the default, with 4.5 s of the 5 s handed to the DB layer). Both keep lock < statement <= deadline; neither is a bug when you see the other. For a deadline shorter than the 0.5 s margin the inner budget is floored at 50 ms and the listener's values collapse to their 50 ms floor (lock == statement, so a lock wait then reports 57014 rather than 55P03); #10684 already refuses a deadline that is not a positive finite number or too small to order its percentages.
2. **Client side.** A psycopg2 wait callback (green mode), installed only in the API-server web process at startup (never on import, so request-executor processes stay sync; a no-op with a warning if psycopg2 is not importable). It polls the libpq socket in bounded slices and gives up at the thread's deadline — the only thing that frees the thread when the server cannot help (frozen/unreachable server, a socket whose fd was closed and reused under the thread). It also enforces `connect_timeout` (libpq applies it only in its blocking connect path; the earlier of `connect_timeout` and the thread deadline wins during the handshake) and refuses to hand libpq a fd that no longer identifies the connection's own socket (a foreign blocking socket would freeze the process; `send()` on it would inject bytes into someone else's connection). A connect that gives up at either bound is closed in the callback itself: psycopg2 otherwise leaves a failed connect's `PQfinish` to deallocation, and the exception's traceback delays that to the next cyclic-GC pass, so a burst of connect deadlines (a pooler down or queueing) would park half-open client sockets on the pooler until the collector ran (measured: 20 connect deadlines left 20 client sockets open until `gc.collect()`; with the explicit close, 0 -- same as sync psycopg2).
3. **Error mapping.** `AuthDBTimeoutError(asyncio.TimeoutError)` from #10684 gains a `reason`; client-side deadlines and psycopg2 operational/interface errors (a connection dropped under the call — operational, not necessarily transient) map to the same retryable 503 instead of a bare 500. Programming/integrity errors, and sqlite operational errors, propagate unchanged. Note for the health-check path: it already proceeds unauthenticated on an auth `asyncio.TimeoutError` so the probe survives a DB incident; a dropped DB connection (`db_error`) now takes that same path (same intent, and its warning line says the lookup was unavailable).
4. **Retries / RBAC.** `with_db_retries` stops retrying under an active deadline when the error is the deadline or the backoff would outlive it; the RBAC unknown-principal probe re-raises a deadline instead of answering "no roles" (a non-retryable 403).
5. **Metric.** `sky_apiserver_auth_db_deadline_total{reason}` with a fixed label set (`lock_timeout`, `statement_timeout`, `idle_in_transaction`, `client_deadline`, `client_deadline_fd_stolen`, `client_deadline_fd_closed`, `connect_timeout`, `db_error`, `caller_timeout`). `caller_timeout` should stay ~0 after this change; a sustained rate is the "thread still pinned" alarm. `client_deadline_fd_*` is a per-worker detector for fd double-closes.
6. **Late outcomes are logged.** If `wait_for` released the caller and the thread finishes later, one INFO line says what finally freed it (the result otherwise lands on a cancelled future).

## Notes for reviewers

- `SET LOCAL` reaches the server through a transaction-mode pooler and is scoped to the one transaction (verified: no leak to later transactions on the same server connection, and none to other pooled clients).
- Interplay with #10687 (engine-wide idle-in-transaction bound at `begin`): verified in both `install` orders and both pool classes — exactly one prefix per transaction, on #10687's statement, and this PR's tighter values stay in effect (that PR's guard only lowers). No coordination needed in `get_engine`.
- The prefix changes the text of every bounded auth statement, so `pg_stat_statements` queryids for those statements change on upgrade.
- `connect_timeout` in green mode is one deadline over the whole handshake: a multi-host DSN fails at the first host that does not answer instead of moving on to the next (libpq's blocking connect applies it per host). Address fallback / multi-host DSNs (e.g. `localhost` resolving to `::1` first) connect normally.
- Known limitation of green mode: libpq resolves every host of a multi-host DSN *after the first* inside `PQconnectPoll`, which psycopg2 drives with the GIL held. A DSN with several *hostnames* whose earlier host fails therefore does the fallback DNS lookup with the GIL held — during a resolver outage that stalls the process for the resolver timeout, where sync psycopg2 stalled one thread. Single-host DSNs, IP literals and `hostaddr=` are unaffected; prefer those for multi-host DSNs on the API server.
- Scope of the fd check: it runs before every libpq I/O once the handshake is done. It does not run during the handshake itself (libpq swaps sockets there), and without a deadline a stolen fd still pins the wait until the foreign fd becomes readable (non-auth callers in the web process) — it is then caught before libpq touches the fd.
- When the callback gives up on a socket whose fd number was reused, psycopg2 answers with `PQfinish`, which closes that number — now the new owner's fd: one collateral stray close per detected theft, the same class of event as the double close itself and not avoidable from Python. The chain it can start is short and clean: when that number is another libpq socket, its owner detects `fd_closed` at its next wait, before any libpq I/O, and the chain stops at the first number that is unallocated when detected (measured: A stolen -> B closed under it -> C reuses the number and works). The fix for the double close is separate (#10681).
- A deadline that fires after a `COMMIT` was sent but before its reply arrives is reported as a deadline error although the transaction may have committed (the usual ambiguity of a lost reply). The auth path's writes are idempotent upserts, so the retry the 503 asks for is harmless.
- Overhead: no single-thread latency penalty (one poll wake per round trip); ~+0.1–0.2 ms CPU per DB op; throughput loss only when ≥8 threads do nothing but DB I/O.
- Base: #10684 at its current head (env-derived sizing; the deadline variable stripped from client request payloads and from the per-request env overlay, so the server's own setting is the only one either layer ever reads).
- Transactions opened by an `executemany` or a server-side (named) cursor get no server-side bound (the prefix would run per row / be a syntax error inside `DECLARE`); the client-side deadline still frees the thread. The auth path issues single-row statements only.

## Tested

- Unit tests (no DB): `tests/unit_tests/test_sky/utils/db/test_deadline.py` (new, 61 test items: wait callback with real sockets and a psycopg2 stand-in modelling its status transitions, including the connect-phase ordering of `connect_timeout` vs the thread deadline and the immediate close of a failed connect; REAL libpq connect against local listeners that refuse (a bound, non-listening socket held for the test) / never answer / hang up, each run on a bounded worker thread so an unbounded connect is a red test rather than a hung job, plus the peer seeing EOF right after a connect deadline; SET LOCAL listener through real SQLAlchemy events on a sqlite connection class presenting psycopg2's status/autocommit surface, including a `begin`-listener statement in either registration order, and the wiring itself: the real `get_engine` attaches the listener to every sync Postgres engine it builds (pooled, direct, no_pool) and not to the asyncpg one; classification). The wait-callback tests also pin the parity property for callers without a deadline (exactly one unbounded `poll`, no timed slices), the recording of a fd identity on the first wait of a connection that predates the callback, and the `fd_stolen` label when the deadline expires in the same slice as a theft. New tests on top of #10684's in `tests/unit_tests/test_sky/server/test_auth_db_deadline.py` (+16, including the wiring: the lifespan installs the wait callback, and the thread deadline's origin is the submit rather than the thread start), `tests/unit_tests/test_sky/utils/test_db_retries.py` (+6), `tests/unit_tests/test_sky/users/test_permission.py` (+1, parametrized) and `tests/unit_tests/test_sky/test_global_user_state_user_upsert_timeouts.py` (+3: the explicit statements are skipped only under a deadline AND with the listener attached). The five files run 325 tests (`pytest -n 4`), 0 failures.
- Integration (docker Postgres 16 + PgBouncer 1.20.1 in transaction mode, NullPool, real `add_or_update_user` through the real auth executor and real schema): a held `users` row lock no longer pins auth threads — 40 concurrent upserts behind an orphan: today 32 threads pinned forever; with this change every waiter is freed by its own `lock_timeout` at ~4 s and the pool drains to 0; an orphaned transaction opened under the deadline is killed by its own `idle_in_transaction_session_timeout` at 4.5 s and later upserts proceed; a never-answering peer returns at the deadline (2.0 s); a fd stolen by a blocking socket while a query waits returns within one slice with no process freeze; multi-host/`localhost` DSNs connect in green mode with and without a deadline; a black-holed host with `connect_timeout=2` fails at 2.0 s (same as sync); 50 bounded upserts succeed with no `SET LOCAL` leak to later unbounded transactions; with #10687's `begin` listener installed in either order, exactly one prefix per transaction and this PR's values in effect.
- `bash format.sh --files` on the 13 changed files: yapf/isort/mypy clean; pylint 10.00 on the changed `sky/` files (the only messages are the pre-existing protected-access / redefined-outer-name convention of `test_permission.py`).

## Review status

This branch went through two rounds of adversarial review by reviewers who did not write the code, each re-running the unit and integration suites themselves. Neither round returned an unqualified accept, so the PR opens as a draft with that on record:

- Round 1 (on the previous head, before the rebase onto #10684's current head): **revise (mechanical)** — the branch had to be rebased onto the moved base and a surviving mutant (connect deadline vs thread deadline ordering) needed a test. Both done in the first commit here.
- Round 2 (on the first commit here, `1d7635b85`): **revise (test-only; code accepted as-is)** — the `get_engine` -> `install` wiring had no test (a mutant deleting the line passed the suite), plus four coverage notes. All five landed as the second commit (`fa9020747`: tests only, one comment). That second commit has not been re-reviewed.
- Earlier design critiques (two rounds, on the design and the branch) found and fixed: a fd-identity false positive during libpq's connect handshake (multi-host / `localhost` DSNs), `connect_timeout` not actually enforced in green mode, `SET LOCAL` issued outside SQLAlchemy's error handling, the wait callback being installed on import (it would have reached non-server processes), and the DNS-under-the-GIL limitation documented above.

Before this leaves draft: one more review pass over the second commit, and validation on a deployment that runs the double-close (a per-worker `client_deadline_fd_*` count above zero with no thread pinned is the expected signal).

-Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)
