### PR TITLE
[Core] Let the async network check see the proxy environment

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2184,27 +2184,40 @@ def check_network_connection():
 async def async_check_network_connection():
     """Check if the network connection is available.
 
-    Tolerates 3 retries as it is observed that connections can fail.
     Uses aiohttp for async HTTP requests.
+
+    `trust_env=True` so this reads the proxy environment, which is what its
+    synchronous twin above does implicitly: `requests.Session` trusts the
+    environment by default, aiohttp does not. Without it, a deployment whose
+    outbound HTTPS goes through a proxy fails this check forever while the
+    sync version passes, and every caller that gates on it stalls -- the
+    managed job controller checks it before each job-status poll, so a job
+    whose task has already succeeded stays RUNNING indefinitely, logging
+    "Network is not available" once per attempt.
     """
-    # Create a session with retry logic
     timeout = ClientTimeout(total=15)
     connector = TCPConnector(limit=1)  # Limit to 1 connection at a time
 
     async with aiohttp.ClientSession(timeout=timeout,
-                                     connector=connector) as session:
-        for i, ip in enumerate(_TEST_IP_LIST):
+                                     connector=connector,
+                                     trust_env=True) as session:
+        last_error: Optional[Exception] = None
+        for ip in _TEST_IP_LIST:
             try:
                 async with session.head(ip) as response:
                     if response.status < 400:  # Any 2xx or 3xx status is good
                         return
             except (aiohttp.ClientError, asyncio.TimeoutError) as e:
-                if i == len(_TEST_IP_LIST) - 1:
-                    raise exceptions.NetworkError(
-                        'Could not refresh the cluster. '
-                        'Network seems down.') from e
-                # If not the last IP, continue to try the next one
+                last_error = e
                 continue
+        # Raised whether the last address failed to answer or answered with an
+        # error status. Returning success on a >= 400 from the last address --
+        # which the previous `i == len - 1` form did, since a bad status is not
+        # an exception -- told the caller the network was fine when it had just
+        # been refused, and gating a job-status poll on that is the false alarm
+        # this check exists to prevent.
+        raise exceptions.NetworkError('Could not refresh the cluster. '
+                                      'Network seems down.') from last_error
 
 
 # Kubeconfig assembly may rewrite a context's cluster/user `name` fields to

--- a/tests/unit_tests/test_async_network_probe.py
+++ b/tests/unit_tests/test_async_network_probe.py
@@ -1,0 +1,95 @@
+"""The async network probe must read the proxy environment, like its twin.
+
+`requests.Session` trusts the environment by default and aiohttp does not, so
+the two implementations of this check disagreed wherever outbound HTTPS goes
+through a proxy: the sync one passed and the async one failed forever. The
+managed job controller gates every job-status poll on the async one, so a job
+whose task had already succeeded stayed RUNNING indefinitely.
+"""
+import asyncio
+from unittest import mock
+
+import aiohttp
+import pytest
+
+from sky import exceptions
+from sky.backends import backend_utils
+
+
+class _Response:
+
+    def __init__(self, status):
+        self.status = status
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+
+class _Session:
+    """Records how it was constructed and what it was asked for."""
+
+    def __init__(self, *args, **kwargs):
+        self.kwargs = kwargs
+        _Session.last = self
+        self.requested = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    def head(self, url):
+        self.requested.append(url)
+        return _Session.responder(url)
+
+
+def _run(monkeypatch, responder):
+    _Session.responder = staticmethod(responder)
+    monkeypatch.setattr(aiohttp, 'ClientSession', _Session)
+    return asyncio.run(backend_utils.async_check_network_connection())
+
+
+def test_the_session_trusts_the_proxy_environment(monkeypatch):
+    """The fix. Without `trust_env`, aiohttp ignores `https_proxy` and
+    connects directly -- measured as a 31s timeout on a host whose direct
+    egress is blocked, against 0.64s through the proxy."""
+    _run(monkeypatch, lambda url: _Response(302))
+    assert _Session.last.kwargs.get('trust_env') is True
+
+
+def test_a_reachable_address_short_circuits(monkeypatch):
+    _run(monkeypatch, lambda url: _Response(200))
+    assert len(_Session.last.requested) == 1
+
+
+def test_the_second_address_is_tried_when_the_first_fails(monkeypatch):
+
+    def responder(url):
+        if url == backend_utils._TEST_IP_LIST[0]:
+            raise aiohttp.ClientError('refused')
+        return _Response(302)
+
+    _run(monkeypatch, responder)
+    assert _Session.last.requested == list(backend_utils._TEST_IP_LIST)
+
+
+def test_every_address_failing_raises(monkeypatch):
+
+    def responder(url):
+        raise aiohttp.ClientError('refused')
+
+    with pytest.raises(exceptions.NetworkError):
+        _run(monkeypatch, responder)
+
+
+def test_an_error_status_from_the_last_address_is_not_success(monkeypatch):
+    """A bad status is not an exception, so the previous form -- which only
+    raised when the *last* address threw -- returned success after being
+    refused by it. Gating a job-status poll on that is the false alarm this
+    check exists to prevent."""
+    with pytest.raises(exceptions.NetworkError):
+        _run(monkeypatch, lambda url: _Response(403))


### PR DESCRIPTION
## Summary

`check_network_connection` and `async_check_network_connection` are the same check twice, and they disagreed about proxies. `requests.Session` trusts the environment by default; aiohttp does not unless asked. So wherever outbound HTTPS goes through a proxy, the sync one passes and the async one connects straight to `https://8.8.8.8` and fails.

Measured on such a host (`https_proxy=http://127.0.0.1:7890`, direct egress blocked):

| call | result |
|---|---|
| `async_check_network_connection()` — before | `NetworkError` in **31s** (15s timeout × 2 addresses) |
| `aiohttp.ClientSession(trust_env=False)` | `ConnectionTimeoutError` in 31s |
| `aiohttp.ClientSession(trust_env=True)` | **302 in 0.64s** |
| `check_network_connection()` (sync twin) | OK 5/5 in 0.66s |
| `async_check_network_connection()` — after | **OK in 0.70s** |

**Every caller of the async form stalls.** The managed job controller checks it before each job-status poll (`sky/jobs/controller.py`), so a job whose task had *already succeeded* never left `RUNNING`:

```
Job status: JobStatus.SUCCEEDED
Started monitoring.
Network is not available. Retrying again in 5 seconds.   (forever)
```

That reads as a stuck job rather than a check that cannot pass, and it burns 31s per attempt while doing it. Anyone running an API server behind a proxy sees managed jobs never complete.

**A second defect in the same loop.** It only raised when the *last* address threw. A bad status is not an exception, so being refused by the last address with 4xx/5xx fell out of the loop and returned success — telling the caller the network was fine when it had just been refused. Gating a job-status poll on that is exactly the false alarm this check exists to prevent. It now raises whether the last address failed to answer or answered with an error status.

**Deliberately not changed.** The two implementations still differ in retry shape: the sync one retries three times with a doubling 0.5s timeout, the async one tries each address once under a 15s total. Aligning them changes timing for every caller, so it belongs in its own change.

## Test plan

```
pytest tests/unit_tests/test_async_network_probe.py tests/unit_tests/test_backend_utils.py   # 23 passed
```

Five new tests, with a fake `ClientSession` so no network is touched: the session is constructed with `trust_env=True`; a reachable first address short-circuits; the second address is tried when the first fails; every address failing raises; and an error status from the last address raises rather than passing.

Revert-checked individually — removing `trust_env=True` fails the first test, and restoring the old "only raise if the last address threw" shape fails the last one.

Verified live on the affected host: `async_check_network_connection()` went from `NetworkError` in 31s to returning in 0.70s, and a managed job that had been stuck in `RUNNING` after its task succeeded now completes.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10696" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->