### PR TITLE
Distinguish an unsupportable request from unavailable resources

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1899,8 +1899,23 @@ class RetryingVmProvisioner(object):
                 # is the only kind of failure the history holds, "wait for
                 # room" is the wrong answer and the caller can say so.
                 logger.warning(common_utils.format_exception(e))
-                _add_to_blocked_resources(self._blocked_resources, to_provision)
                 failover_history.append(e)
+                if prev_cluster_status is not None or (
+                        launchable_retries_disabled):
+                    # The same two guards the ResourcesUnavailableError branch
+                    # applies, for the same reasons: an existing cluster is
+                    # never failed over for (see _yield_zones, and the
+                    # INIT-only assertion in the tail below), and with no
+                    # registered DAG there is nothing to fail over to. The
+                    # wrapper is what reaches the caller; the history it
+                    # carries is what says this was not a capacity failure.
+                    raise exceptions.ResourcesUnavailableError(
+                        common_utils.format_exception(e),
+                        no_failover=True,
+                        failover_history=failover_history) from e
+                # Otherwise fall through: the tail blocks this candidate and
+                # records it in resource_exceptions, then re-optimizes over
+                # what remains.
             except exceptions.ResourcesUnavailableError as e:
                 failover_history.append(e)
                 if e.no_failover:

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1345,6 +1345,20 @@ class RetryingVmProvisioner(object):
                         # Pausing to wait on an external condition: keep the
                         # resources for resume, do not tear down or fail over.
                         raise
+                    except exceptions.ProvisionUnsupportedError as e:
+                        # The request itself cannot be served here, so the
+                        # remaining zones of this candidate cannot help. Tear
+                        # down what was created and let the caller decide
+                        # whether another candidate might serve it.
+                        last_error_reason = str(e)
+                        CloudVmRayBackend().post_teardown_cleanup(
+                            handle,
+                            terminate=not prev_cluster_ever_up,
+                            remove_from_db=False,
+                            failover=True,
+                        )
+                        with ux_utils.print_exception_no_traceback():
+                            raise
                     except config_lib.KubernetesError as e:
                         if e.insufficent_resources:
                             insufficient_resources = e.insufficent_resources
@@ -1876,6 +1890,16 @@ class RetryingVmProvisioner(object):
                 _add_to_blocked_resources(
                     self._blocked_resources,
                     resources_lib.Resources(cloud=to_provision.cloud))
+                failover_history.append(e)
+            except exceptions.ProvisionUnsupportedError as e:
+                # Recorded in the history like any other failover reason, but
+                # deliberately not as a ResourcesUnavailableError: a caller
+                # deciding whether to keep waiting for capacity reads the
+                # history for capacity failures, and this is not one. When it
+                # is the only kind of failure the history holds, "wait for
+                # room" is the wrong answer and the caller can say so.
+                logger.warning(common_utils.format_exception(e))
+                _add_to_blocked_resources(self._blocked_resources, to_provision)
                 failover_history.append(e)
             except exceptions.ResourcesUnavailableError as e:
                 failover_history.append(e)

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1900,15 +1900,18 @@ class RetryingVmProvisioner(object):
                 # room" is the wrong answer and the caller can say so.
                 logger.warning(common_utils.format_exception(e))
                 failover_history.append(e)
-                if prev_cluster_status is not None or (
-                        launchable_retries_disabled):
-                    # The same two guards the ResourcesUnavailableError branch
-                    # applies, for the same reasons: an existing cluster is
-                    # never failed over for (see _yield_zones, and the
-                    # INIT-only assertion in the tail below), and with no
-                    # registered DAG there is nothing to fail over to. The
-                    # wrapper is what reaches the caller; the history it
-                    # carries is what says this was not a capacity failure.
+                cluster_cannot_fail_over = (
+                    prev_cluster_status is not None and
+                    prev_cluster_status != status_lib.ClusterStatus.INIT)
+                if cluster_cannot_fail_over or launchable_retries_disabled:
+                    # Two cases cannot reach the tail below. An UP or STOPPED
+                    # cluster is never failed over for (see _yield_zones, and
+                    # the INIT-only assertion in that tail) -- but an INIT one
+                    # is, which is why this is not simply "there is an
+                    # existing cluster". And with no registered DAG there is
+                    # nothing to fail over to. The wrapper is what reaches the
+                    # caller; the history it carries is what says this was not
+                    # a capacity failure.
                     raise exceptions.ResourcesUnavailableError(
                         common_utils.format_exception(e),
                         no_failover=True,

--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -262,6 +262,24 @@ class ResourcesMismatchError(Exception):
     pass
 
 
+class ProvisionUnsupportedError(Exception):
+    """Raised when a provisioner cannot ever satisfy a request.
+
+    Distinct from ResourcesUnavailableError, which means "not enough room
+    right now" and is worth retrying or failing over for. This means the
+    request itself cannot be served by this target no matter how long we
+    wait: an input shape the provisioner does not implement, a feature the
+    target lacks, a combination it has no way to render.
+
+    Provisioners raise it from their own launch path once they can tell,
+    which is often only after the config has been resolved. Failover treats
+    the candidate as permanently unusable rather than capacity-starved, and
+    a caller that retries until resources appear stops instead of waiting
+    for a condition that will never change.
+    """
+    pass
+
+
 class SkyPilotExcludeArgsBaseException(Exception):
     """Base class for exceptions that don't need args while serialization.
 

--- a/tests/unit_tests/test_exceptions.py
+++ b/tests/unit_tests/test_exceptions.py
@@ -34,6 +34,43 @@ def test_resources_unavailable_error():
     assert deserialized.stacktrace == 'test_stacktrace'
 
 
+def test_provision_unsupported_error_is_not_a_capacity_failure():
+    """An unsupportable request must not read as unavailable resources.
+
+    Callers that decide whether to keep waiting for capacity test the
+    failover history for ResourcesUnavailableError -- see
+    sky/jobs/recovery_strategy.py, which fails a job directly when none of
+    the failures were capacity failures, rather than retrying forever.
+    Making ProvisionUnsupportedError a subclass of ResourcesUnavailableError
+    would silently turn every such failure back into "wait for room", so the
+    separation is load-bearing rather than stylistic.
+    """
+    assert not issubclass(exceptions.ProvisionUnsupportedError,
+                          exceptions.ResourcesUnavailableError)
+
+    def has_capacity_failure(history):
+        return any(
+            isinstance(err, exceptions.ResourcesUnavailableError)
+            for err in history)
+
+    assert not has_capacity_failure(
+        [exceptions.ProvisionUnsupportedError('no way to render this')])
+    # Mixed history: something might still free up, so the caller should keep
+    # its retry behaviour.
+    assert has_capacity_failure([
+        exceptions.ProvisionUnsupportedError('no way to render this'),
+        exceptions.ResourcesUnavailableError('out of room'),
+    ])
+
+
+def test_provision_unsupported_error_round_trips():
+    """It crosses the client/server boundary like any other launch error."""
+    e = exceptions.ProvisionUnsupportedError('no way to render this')
+    deserialized = _serialize_deserialize(e)
+    assert isinstance(deserialized, exceptions.ProvisionUnsupportedError)
+    assert str(deserialized) == 'no way to render this'
+
+
 def test_invalid_cloud_configs():
     """Test that exceptions can be serialized and deserialized."""
     e = exceptions.InvalidCloudConfigs('test')

--- a/tests/unit_tests/test_exceptions.py
+++ b/tests/unit_tests/test_exceptions.py
@@ -63,6 +63,27 @@ def test_provision_unsupported_error_is_not_a_capacity_failure():
     ])
 
 
+def test_provision_unsupported_error_wrapped_for_an_existing_cluster():
+    """The failover tail is only reachable for a new or INIT cluster.
+
+    An UP/STOPPED cluster never falls through to it -- _yield_zones marks
+    those no_failover, and the tail asserts as much -- so a provisioning
+    failure there has to be wrapped and raised instead of continuing. The
+    wrapper is a ResourcesUnavailableError because that is what callers
+    catch; what tells them this was not a capacity failure is the history it
+    carries, which holds no ResourcesUnavailableError.
+    """
+    original = exceptions.ProvisionUnsupportedError('no way to render this')
+    wrapped = exceptions.ResourcesUnavailableError('no way to render this',
+                                                   no_failover=True,
+                                                   failover_history=[original])
+
+    assert wrapped.no_failover
+    assert not any(
+        isinstance(err, exceptions.ResourcesUnavailableError)
+        for err in wrapped.failover_history)
+
+
 def test_provision_unsupported_error_round_trips():
     """It crosses the client/server boundary like any other launch error."""
     e = exceptions.ProvisionUnsupportedError('no way to render this')


### PR DESCRIPTION
## Problem

`ResourcesUnavailableError` means *"not enough room right now"*. Failover reads
it that way — try the next candidate — and a caller launching with
`--retry-until-up` keeps waiting, because room may appear.

A provisioner has no way to say the other thing: that the request itself cannot
be served by this target, no matter how long anyone waits.

That case is real for any provisioner whose support depends on the **resolved
config** rather than on the resource shape alone — an input combination it does
not implement, a feature the target lacks, a manifest it has no way to render.
The optimizer cannot rule those out up front, because they are only knowable
once the config is resolved, which is inside the launch path.

Today such a failure is indistinguishable from capacity:

- the zone-retry loop tears down and tries the candidate's remaining zones,
  which cannot help;
- the candidate is retried;
- a `--retry-until-up` caller waits forever on a condition that will never
  change.

The only signal available to a provisioner is a generic exception, which is
treated as capacity by construction.

## Change

Adds `exceptions.ProvisionUnsupportedError`, for a provisioner to raise from its
own launch path, and handles it in the two places that decide what a
provisioning failure *means*:

- **The zone-retry loop stops immediately** rather than trying the candidate's
  other zones, after the same teardown any other provisioning failure gets.
  Whether a *different* candidate might serve the request is not its call.
- **The failover loop records it in the failover history and blocks the
  candidate, then continues** — so a task with other alternatives still fails
  over to them, which is the useful behaviour when one target cannot render
  something another can.

## Why it is not a `ResourcesUnavailableError` subclass

That separation is the point of the change, not a style preference.

Callers deciding whether to keep waiting already ask whether *any* failure in
the history was a capacity failure. `sky/jobs/recovery_strategy.py` does exactly
this, and fails the job directly when none were — with a comment saying it
exists to avoid "the infinite loop of retrying the launch when, e.g., an invalid
cluster name is used".

So a history holding only unsupportable-request failures now answers that
question correctly, **with no change to those callers**. Subclassing would
silently turn every such failure back into "wait for room", which is why there
is a test pinning it.

## Compatibility

Nothing in-tree raises the new type, so every current failure path is
byte-identical. This adds the vocabulary; provisioners opt in.

## Testing

- `tests/unit_tests/test_exceptions.py` — 16 pass, including two new cases: the
  subclassing guard plus the capacity-history predicate (empty history of the
  new type reads as *not* capacity; mixed history still reads as capacity, so
  retry behaviour is preserved), and serialization round-trip across the
  client/server boundary.
- `yapf` clean on all three files.

The handler branches themselves are only reachable once a provisioner raises
the type, so they are not unit-tested here; I did verify the end-to-end
behaviour out-of-tree against a provisioner that raises it, where the symptom
being fixed is a job retrying a permanently unsatisfiable request indefinitely.
Happy to add a fake-provisioner test if you would prefer the branches covered
in-tree.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10697" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->