### PR TITLE
[Jobs] Check the status of the submitted job instead of the latest job on the cluster

### DIFF
--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -720,13 +720,14 @@ class JobController:
             launch_time = time.time() - launch_start
             logger.info(f'Cluster launch completed in {launch_time:.2f}s')
             assert remote_job_submitted_at is not None, remote_job_submitted_at
-        # The id of the job submitted on the cluster (None if unknown, in
-        # which case the latest job on the cluster is used).
-        submit_cluster_name, job_id_on_pool_cluster = (
-            await managed_job_state.get_pool_submit_info_async(self._job_id))
         if self._pool:
             # Update the cluster name when using pool.
-            cluster_name = submit_cluster_name
+            cluster_name, job_id_on_pool_cluster = (
+                await
+                managed_job_state.get_pool_submit_info_async(self._job_id))
+        elif job_id_on_pool_cluster is None:
+            job_id_on_pool_cluster = await self._resolve_job_id_on_cluster(
+                self._strategy_executor)
         if cluster_name is None:
             # Check if we have been cancelled here, in the case where a user
             # quickly cancels the job we want to gracefully handle it here,
@@ -933,6 +934,29 @@ class JobController:
                 failure_reason=str(e),
                 callback_func=callback_func)
             return False
+
+    async def _resolve_job_id_on_cluster(
+            self,
+            executor: 'recovery_strategy.StrategyExecutor') -> Optional[int]:
+        """Return the id of the job submitted on a non-pool task's cluster.
+
+        The executor remembers the id from its own launch, which is correct
+        per task (JobGroup tasks launch concurrently, each on its own
+        cluster). When this process did not launch the task (resume after a
+        controller restart), fall back to the persisted id, but only for a
+        single-task job: the persisted job_info field is shared by all tasks
+        of a managed job, so for a JobGroup it may belong to another task.
+        None means unknown, in which case the latest job on the cluster is
+        used, as before.
+        """
+        if executor.job_id_on_pool_cluster is not None:
+            return executor.job_id_on_pool_cluster
+        if len(self._dag.tasks) != 1:
+            return None
+        _, job_id_on_cluster = (await
+                                managed_job_state.get_pool_submit_info_async(
+                                    self._job_id))
+        return job_id_on_cluster
 
     async def _monitor_one_task(
         self,
@@ -1584,14 +1608,16 @@ class JobController:
 
             recovered_time = await executor.recover()
 
-            # Refresh the id of the job submitted on the (new) cluster after
-            # recovery, and the cluster name for pools.
-            pool_cluster_name, job_id_on_pool_cluster = (
-                await
-                managed_job_state.get_pool_submit_info_async(self._job_id))
+            # Update cluster_name for pools after recovery; refresh the id
+            # of the job the executor submitted on the (new) cluster.
             if self._pool is not None:
+                pool_cluster_name, job_id_on_pool_cluster = (
+                    await
+                    managed_job_state.get_pool_submit_info_async(self._job_id))
                 assert pool_cluster_name is not None
                 cluster_name = pool_cluster_name
+            else:
+                job_id_on_pool_cluster = executor.job_id_on_pool_cluster
 
             if keep_starting:
                 # The task stayed STARTING (kept-starting resume). Reaching
@@ -1876,7 +1902,7 @@ class JobController:
             task_id=task_id,
             task=task,
             cluster_name=cluster_name,
-            job_id_on_pool_cluster=None,
+            job_id_on_pool_cluster=executor.job_id_on_pool_cluster,
             cleanup_cluster_on_success=False,  # JobGroup cleans up all at end
             force_transit_to_recovering=force_transit_to_recovering,
             on_recovery=on_recovery,
@@ -1888,7 +1914,7 @@ class JobController:
             task=task,
             cluster_name=cluster_name,
             executor=executor,
-            job_id_on_pool_cluster=None,
+            job_id_on_pool_cluster=executor.job_id_on_pool_cluster,
             cleanup_cluster_on_success=False,  # JobGroup cleans up all at end
             force_transit_to_recovering=force_transit_to_recovering,
             on_recovery=on_recovery,
@@ -2657,7 +2683,10 @@ class JobController:
             handle = await asyncio.to_thread(
                 global_user_state.get_handle_from_cluster_name, cluster_name)
             job_id_on_pool_cluster = None
-            if self._pool is not None:
+            # Pool jobs are single-task; for non-pool jobs the persisted id
+            # is only this task's for a single-task job (see
+            # _resolve_job_id_on_cluster).
+            if self._pool is not None or len(self._dag.tasks) == 1:
                 _, job_id_on_pool_cluster = (
                     await
                     managed_job_state.get_pool_submit_info_async(self._job_id))
@@ -3176,7 +3205,15 @@ class ControllerManager:
                                                   job_id_on_pool_cluster)
             return
 
-        # Non-pool path: download logs for each active task.
+        # Non-pool path: download logs for each active task. The persisted
+        # on-cluster job id identifies the submitted job only when a single
+        # task is active: the job_info field is shared by all tasks of a
+        # managed job, so for a JobGroup (concurrent tasks) it may belong to
+        # another task, and the latest job on each cluster is used instead.
+        job_id_on_cluster: Optional[int] = None
+        if len(task_ids) == 1:
+            _, job_id_on_cluster = (
+                await managed_job_state.get_pool_submit_info_async(job_id))
         for task_id in task_ids:
             try:
                 task = dag.tasks[task_id]
@@ -3185,7 +3222,8 @@ class ControllerManager:
                     managed_job_utils.generate_managed_job_cluster_name(
                         task.name, job_id))
                 await self._download_log_from_cluster(controller, job_id,
-                                                      task_id, cluster_name)
+                                                      task_id, cluster_name,
+                                                      job_id_on_cluster)
             except Exception as e:  # pylint: disable=broad-except
                 logger.warning(
                     f'Failed to download logs for job {job_id}, '

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -720,12 +720,15 @@ class JobController:
             launch_time = time.time() - launch_start
             logger.info(f'Cluster launch completed in {launch_time:.2f}s')
             assert remote_job_submitted_at is not None, remote_job_submitted_at
+        # The id of the job submitted on the cluster (None if unknown, in
+        # which case the latest job on the cluster is used).
+        job_id_on_pool_cluster: Optional[int] = None
         if self._pool:
             # Update the cluster name when using pool.
             cluster_name, job_id_on_pool_cluster = (
                 await
                 managed_job_state.get_pool_submit_info_async(self._job_id))
-        elif job_id_on_pool_cluster is None:
+        else:
             job_id_on_pool_cluster = await self._resolve_job_id_on_cluster(
                 self._strategy_executor)
         if cluster_name is None:

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -720,12 +720,13 @@ class JobController:
             launch_time = time.time() - launch_start
             logger.info(f'Cluster launch completed in {launch_time:.2f}s')
             assert remote_job_submitted_at is not None, remote_job_submitted_at
-        job_id_on_pool_cluster: Optional[int] = None
+        # The id of the job submitted on the cluster (None if unknown, in
+        # which case the latest job on the cluster is used).
+        submit_cluster_name, job_id_on_pool_cluster = (
+            await managed_job_state.get_pool_submit_info_async(self._job_id))
         if self._pool:
             # Update the cluster name when using pool.
-            cluster_name, job_id_on_pool_cluster = (
-                await
-                managed_job_state.get_pool_submit_info_async(self._job_id))
+            cluster_name = submit_cluster_name
         if cluster_name is None:
             # Check if we have been cancelled here, in the case where a user
             # quickly cancels the job we want to gracefully handle it here,
@@ -1583,11 +1584,12 @@ class JobController:
 
             recovered_time = await executor.recover()
 
-            # Update cluster_name for pools after recovery
+            # Refresh the id of the job submitted on the (new) cluster after
+            # recovery, and the cluster name for pools.
+            pool_cluster_name, job_id_on_pool_cluster = (
+                await
+                managed_job_state.get_pool_submit_info_async(self._job_id))
             if self._pool is not None:
-                pool_cluster_name, job_id_on_pool_cluster = (
-                    await
-                    managed_job_state.get_pool_submit_info_async(self._job_id))
                 assert pool_cluster_name is not None
                 cluster_name = pool_cluster_name
 

--- a/sky/jobs/recovery_strategy.py
+++ b/sky/jobs/recovery_strategy.py
@@ -151,6 +151,20 @@ def _consume_task_exception(task: 'asyncio.Future') -> None:
                      f'{common_utils.format_exception(exc)}')
 
 
+def _job_id_from_launch_result(launch_result: Any) -> Optional[int]:
+    """Return the on-cluster job id from a ``sky.launch`` request result.
+
+    ``sky.launch`` returns ``(job_id, handle)``. The job id is None when no
+    job was submitted; anything unexpected is treated the same way, so the
+    caller falls back to the latest job on the cluster.
+    """
+    if isinstance(launch_result, tuple) and len(launch_result) == 2:
+        job_id = launch_result[0]
+        if isinstance(job_id, int) and not isinstance(job_id, bool):
+            return job_id
+    return None
+
+
 class _LaunchRequestParked(Exception):
     """The underlying launch request was parked to wait for a condition.
 
@@ -682,7 +696,7 @@ class StrategyExecutor:
                                                      _stream_and_get)
 
     async def _await_launch_request(self, request_id: str,
-                                    stream_task: 'asyncio.Future') -> None:
+                                    stream_task: 'asyncio.Future') -> Any:
         """Wait for the inner launch request, detecting if it parks.
 
         While waiting on the request's log stream (started by
@@ -699,6 +713,10 @@ class StrategyExecutor:
         while the request is WAITING, so the same stream picks up where it
         left off, with no reconnect and no replayed log lines.
 
+        Returns:
+            The result of the launch request, i.e. the ``(job_id, handle)``
+            tuple returned by ``sky.launch``.
+
         Raises:
             _LaunchRequestParked: The request was parked as WAITING.
             Exception: Any exception raised by the launch request itself.
@@ -708,8 +726,7 @@ class StrategyExecutor:
                 {stream_task}, timeout=_LAUNCH_REQUEST_STATUS_POLL_SECONDS)
             if done:
                 # Surface the exception of the request, if any.
-                stream_task.result()
-                return
+                return stream_task.result()
             try:
                 request_payload = await self._get_request_payload(request_id)
             except Exception as e:  # pylint: disable=broad-except
@@ -1045,8 +1062,9 @@ class StrategyExecutor:
                                                 ).create_future())
                                             stream_task.set_result(result)
                                 assert stream_task is not None
-                                await self._await_launch_request(
-                                    request_id, stream_task)
+                                launch_result = (await
+                                                 self._await_launch_request(
+                                                     request_id, stream_task))
                             except asyncio.CancelledError:
                                 if request_id:
                                     await self._cancel_launch_request(request_id
@@ -1058,6 +1076,16 @@ class StrategyExecutor:
                                     stream_task.add_done_callback(
                                         _consume_task_exception)
                                 raise
+                            # Remember which job sky.launch submitted on the
+                            # cluster, so that status checks and log
+                            # downloads target that job rather than whatever
+                            # job is the latest on the cluster (e.g. a later
+                            # `sky exec` on the same cluster, see #10682).
+                            # None (unknown) falls back to the latest job.
+                            self.job_id_on_pool_cluster = (
+                                _job_id_from_launch_result(launch_result))
+                            await state.set_job_id_on_pool_cluster_async(
+                                self.job_id, self.job_id_on_pool_cluster)
                             logger.info('Managed job cluster launched.')
                         else:
                             # Get task resources from DAG for resource-aware

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -2553,9 +2553,15 @@ def update_job_full_resources(job_id: int,
         session.commit()
 
 
-async def set_job_id_on_pool_cluster_async(job_id: int,
-                                           job_id_on_pool_cluster: int) -> None:
-    """Set the job id on the pool cluster for a job."""
+async def set_job_id_on_pool_cluster_async(
+        job_id: int, job_id_on_pool_cluster: Optional[int]) -> None:
+    """Set the id of the job submitted on the cluster for a managed job.
+
+    Despite the name, this is recorded for every managed job, not only for
+    pool jobs: the controller uses it to check the status of and fetch the
+    logs for the job it submitted, instead of the latest job on the cluster.
+    None means unknown, in which case the latest job on the cluster is used.
+    """
     engine = await _db_manager.get_async_engine()
     async with sql_async.AsyncSession(engine) as session:
         await session.execute(

--- a/tests/unit_tests/test_sky/jobs/test_controller.py
+++ b/tests/unit_tests/test_sky/jobs/test_controller.py
@@ -15,6 +15,7 @@ import sys
 import threading
 from typing import Dict, List, Optional, Tuple
 from unittest.mock import AsyncMock
+from unittest.mock import call
 from unittest.mock import MagicMock
 from unittest.mock import patch
 import warnings
@@ -861,6 +862,9 @@ class TestDownloadLogsForCancelledJob:
         with patch('sky.jobs.controller.managed_job_utils'
                    '.generate_managed_job_cluster_name',
                    return_value='sky-managed-1-test-job') as mock_gen_name, \
+             patch('sky.jobs.controller.managed_job_state'
+                   '.get_pool_submit_info_async',
+                   return_value=(None, 7)) as mock_submit_info, \
              patch('sky.jobs.controller.backend_utils.get_clusters',
                    return_value=[{'handle': mock_handle}]) as mock_get_cl:
 
@@ -878,8 +882,51 @@ class TestDownloadLogsForCancelledJob:
                 refresh=common.StatusRefreshMode.NONE,
                 all_users=True,
                 _include_is_managed=True)
+            # The submitted job's id is used, not the latest job on the
+            # cluster (a later `sky exec` must not replace the logs).
+            mock_submit_info.assert_awaited_once_with(job_id)
             controller.download_log_and_stream.assert_called_once_with(
-                task_id, mock_handle, None)
+                task_id, mock_handle, 7)
+
+    @pytest.mark.asyncio
+    async def test_non_pool_job_group_downloads_latest_job_per_cluster(self):
+        """JobGroup tasks share one persisted job id field, so their logs
+        fall back to the latest job on each task's cluster."""
+        manager = self._make_manager()
+        controller = MagicMock()
+        job_id = 1
+
+        mock_dag = MagicMock()
+        mock_dag.tasks = []
+        for name in ('worker-a', 'worker-b'):
+            mock_task = MagicMock()
+            mock_task.name = name
+            mock_dag.tasks.append(mock_task)
+
+        mock_handle = MagicMock()
+
+        with patch('sky.jobs.controller.managed_job_utils'
+                   '.generate_managed_job_cluster_name',
+                   side_effect=lambda name, _: f'sky-managed-1-{name}'), \
+             patch('sky.jobs.controller.managed_job_state'
+                   '.get_pool_submit_info_async',
+                   return_value=(None, 7)) as mock_submit_info, \
+             patch('sky.jobs.controller.backend_utils.get_clusters',
+                   return_value=[{'handle': mock_handle}]):
+
+            await ControllerManager._download_logs_for_cancelled_job(
+                manager,
+                controller,
+                job_id,
+                task_ids=[0, 1],
+                dag=mock_dag,
+                pool=None)
+
+            mock_submit_info.assert_not_awaited()
+            assert controller.download_log_and_stream.call_args_list == [
+                call(0, mock_handle, None),
+                call(1, mock_handle, None),
+            ]
 
     @pytest.mark.asyncio
     async def test_pool_job_cluster_found(self):

--- a/tests/unit_tests/test_sky/jobs/test_recovery_strategy.py
+++ b/tests/unit_tests/test_sky/jobs/test_recovery_strategy.py
@@ -66,7 +66,8 @@ async def test_await_launch_request_returns_on_stream_completion(monkeypatch):
     api_status = mock.MagicMock()
     monkeypatch.setattr(recovery_strategy.sdk, 'api_status', api_status)
 
-    assert await executor._await_launch_request('req-1', stream_task) is None
+    assert (await executor._await_launch_request('req-1',
+                                                 stream_task) == 'result')
     api_status.assert_not_called()
 
 
@@ -122,7 +123,8 @@ async def test_await_launch_request_tolerates_poll_failures(monkeypatch):
                         '_LAUNCH_REQUEST_STATUS_POLL_SECONDS', 0.01)
 
     # Should not raise despite the status poll failing.
-    assert await executor._await_launch_request('req-1', stream_task) is None
+    assert (await executor._await_launch_request('req-1',
+                                                 stream_task) == 'result')
     assert api_status.call_count >= 1
 
 
@@ -140,7 +142,8 @@ async def test_await_launch_request_tolerates_unknown_request(monkeypatch):
     monkeypatch.setattr(recovery_strategy,
                         '_LAUNCH_REQUEST_STATUS_POLL_SECONDS', 0.01)
 
-    assert await executor._await_launch_request('req-1', stream_task) is None
+    assert (await executor._await_launch_request('req-1',
+                                                 stream_task) == 'result')
 
 
 @pytest.mark.asyncio
@@ -406,6 +409,50 @@ async def test_launch_cancel_while_parked_cancels_request(monkeypatch):
     with pytest.raises(asyncio.CancelledError):
         await task
     executor._cancel_launch_request.assert_awaited_once_with('req-123')
+
+
+@pytest.mark.asyncio
+async def test_launch_records_job_id_submitted_on_cluster(monkeypatch):
+    """A non-pool launch remembers the job id sky.launch submitted, so the
+    controller checks that job instead of the latest job on the cluster."""
+    executor = _make_launch_executor()
+    _patch_launch_environment(monkeypatch)
+    set_job_id = mock.AsyncMock()
+    monkeypatch.setattr(recovery_strategy.state,
+                        'set_job_id_on_pool_cluster_async', set_job_id)
+    executor._await_launch_request = mock.AsyncMock(
+        return_value=(7, mock.MagicMock()))
+
+    result = await executor._launch(max_retry=1, raise_on_failure=True)
+
+    assert result == 123.45
+    assert executor.job_id_on_pool_cluster == 7
+    set_job_id.assert_awaited_once_with(executor.job_id, 7)
+
+
+@pytest.mark.asyncio
+async def test_launch_without_job_id_falls_back_to_latest_job(monkeypatch):
+    """An unknown job id is recorded as None (latest job on the cluster)."""
+    executor = _make_launch_executor()
+    executor.job_id_on_pool_cluster = 3  # stale, from a previous cluster
+    _patch_launch_environment(monkeypatch)
+    set_job_id = mock.AsyncMock()
+    monkeypatch.setattr(recovery_strategy.state,
+                        'set_job_id_on_pool_cluster_async', set_job_id)
+    executor._await_launch_request = mock.AsyncMock(return_value=None)
+
+    await executor._launch(max_retry=1, raise_on_failure=True)
+
+    assert executor.job_id_on_pool_cluster is None
+    set_job_id.assert_awaited_once_with(executor.job_id, None)
+
+
+def test_job_id_from_launch_result():
+    assert recovery_strategy._job_id_from_launch_result((5, object())) == 5
+    assert recovery_strategy._job_id_from_launch_result(
+        (None, object())) is None
+    assert recovery_strategy._job_id_from_launch_result(None) is None
+    assert recovery_strategy._job_id_from_launch_result('result') is None
 
 
 def test_start_stream_task_uses_context_preserving_executor(monkeypatch):


### PR DESCRIPTION
Fixes #10682

For managed jobs that do not run on a pool, `managed_job_utils.get_job_status` was called with `job_id=None`, so `GetJobStatus` on the skylet fell back to `job_lib.get_latest_job_id()`: the controller checked whatever job happened to be the latest on the cluster. Running `sky exec` on the managed job's cluster therefore made the controller report the exec job's status; a successful exec marked the still-running managed job as `SUCCEEDED` and tore the cluster down. The same fallback affected the submit/end timestamps and the log download after the job finished.

Pool jobs already avoid this: `StrategyExecutor._launch` records the id returned by `sdk.exec` in `job_id_on_pool_cluster` and the controller passes it to every status/log call. This PR does the same for non-pool jobs:

- `_await_launch_request` now returns the launch request's result (the `(job_id, handle)` tuple of `sky.launch`) instead of discarding it, and the non-pool branch of `_launch` stores the job id on the executor and in `job_info.job_id_on_pool_cluster` (`set_job_id_on_pool_cluster_async`, which now accepts `None`) for the initial launch and every recovery launch. If the id cannot be determined, `None` is stored, which keeps the previous latest-job behavior.
- The controller reads the id back from the DB for pool and non-pool jobs alike, both after the initial launch and after a recovery (previously only for pools), so `get_job_status`, `get_job_timestamp`, `try_to_get_job_end_time`, `download_log_and_stream` and the live-link lookup all target the submitted job.

The column keeps its name to avoid a schema migration; the docstring on the setter notes that it is now recorded for every managed job. As a side effect, `sky jobs queue -v` and the dashboard's `job_id_on_pool_cluster` field now show the on-cluster job id for non-pool jobs too instead of `-`.

Tested (run the relevant ones):

- [x] Code formatting: `yapf`, `isort`, `pylint` (10.00/10 on the changed files)
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

New unit tests in `tests/unit_tests/test_sky/jobs/test_recovery_strategy.py`: a non-pool `_launch` records the job id returned by the launch request (`executor.job_id_on_pool_cluster == 7`, `set_job_id_on_pool_cluster_async(job_id, 7)` awaited), an unknown result resets a stale id to `None`, and `_job_id_from_launch_result` handles the possible shapes. The existing `_await_launch_request` tests were updated for the new return value. `pytest tests/unit_tests/test_sky/jobs/test_recovery_strategy.py tests/unit_tests/test_sky/jobs/test_controller.py` passes.

I could not run the smoke tests (no cloud credentials here); a reviewer with access may want to run `test_managed_jobs*` to exercise the real `sky exec`-on-managed-cluster scenario.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10699" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->