### PR TITLE
[Slurm] Add a scope-resolved getter for slurm.quota sub-fields

### DIFF
--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -1301,6 +1301,41 @@ def get_effective_slurm_account(
                                               partition=partition)
 
 
+def get_effective_slurm_quota_value(
+        key: str,
+        cluster: Optional[str] = None,
+        partition: Optional[str] = None,
+        workspace: Optional[str] = None,
+        override_configs: Optional[Dict[str, Any]] = None) -> Optional[str]:
+    """Returns a ``slurm.quota.<key>`` value, scope-resolved.
+
+    The ``slurm.quota`` block is deliberately permissive
+    (``additionalProperties: True``) so that consumers can carry
+    scheduler-specific sub-fields beyond the ``queue`` and ``account`` that
+    :func:`get_effective_queue_name` and :func:`get_effective_slurm_account`
+    read. This is the generic counterpart to those two: it resolves any such
+    sub-field over the same scopes -- workspace > global, and within each,
+    partition > cluster > cloud -- so a consumer does not have to reimplement
+    the walk and risk resolving its own field differently from ``queue``.
+
+    Args:
+        key: The sub-field under ``slurm.quota`` to read.
+        cluster: Slurm cluster, selecting the ``cluster_configs`` level.
+        partition: Partition, selecting the ``partition_configs`` level.
+        workspace: Workspace to read first; defaults to the active one.
+        override_configs: Task-level ``config`` overrides.
+
+    Returns:
+        The resolved value, or None if the field is unset at every scope.
+    """
+    return _get_effective_scoped_config_value(cloud='slurm',
+                                              property_keys=[('quota', key)],
+                                              region=cluster,
+                                              workspace=workspace,
+                                              override_configs=override_configs,
+                                              partition=partition)
+
+
 def get_effective_namespace(
         cloud: str,
         region: Optional[str] = None,

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -1306,7 +1306,7 @@ def get_effective_slurm_quota_value(
         cluster: Optional[str] = None,
         partition: Optional[str] = None,
         workspace: Optional[str] = None,
-        override_configs: Optional[Dict[str, Any]] = None) -> Optional[str]:
+        override_configs: Optional[Dict[str, Any]] = None) -> Any:
     """Returns a ``slurm.quota.<key>`` value, scope-resolved.
 
     The ``slurm.quota`` block is deliberately permissive
@@ -1318,6 +1318,15 @@ def get_effective_slurm_quota_value(
     partition > cluster > cloud -- so a consumer does not have to reimplement
     the walk and risk resolving its own field differently from ``queue``.
 
+    Returns ``Any`` rather than ``Optional[str]``, unlike the two named
+    getters: their fields are declared ``{'type': 'string'}`` and so are
+    validated as strings before they get here, while ``additionalProperties``
+    constrains nothing, so a sub-field can hold a number, a bool, a list or a
+    mapping. Narrowing the annotation would let a caller run string
+    operations on a value the schema never promised was a string. Validating
+    the type is the caller's job, the same split the ``slurm.quota`` schema
+    comment already describes.
+
     Args:
         key: The sub-field under ``slurm.quota`` to read.
         cluster: Slurm cluster, selecting the ``cluster_configs`` level.
@@ -1326,7 +1335,8 @@ def get_effective_slurm_quota_value(
         override_configs: Task-level ``config`` overrides.
 
     Returns:
-        The resolved value, or None if the field is unset at every scope.
+        The resolved value as configured, or None if the field is unset at
+        every scope.
     """
     return _get_effective_scoped_config_value(cloud='slurm',
                                               property_keys=[('quota', key)],

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2461,6 +2461,35 @@ def test_get_effective_slurm_quota_value(monkeypatch, tmp_path) -> None:
         'not_a_field', cluster='clusterA', partition='gpu') is None
 
 
+def test_get_effective_slurm_quota_value_preserves_type(monkeypatch,
+                                                        tmp_path) -> None:
+    """Non-string sub-fields come back as configured, not coerced.
+
+    `slurm.quota` is `additionalProperties: True`, so a sub-field can hold
+    any JSON type. Coercing to str would mask a mis-typed config and
+    returning None would silently drop it, so the value passes through and
+    the caller validates -- which is why the getter is annotated `Any`.
+    """
+    with open(tmp_path / 'slurm_quota_types.yaml', 'w', encoding='utf-8') as f:
+        f.write("""\
+        slurm:
+            quota:
+                a_number: 42
+                a_bool: true
+                a_list: [one, two]
+                a_mapping: {nested: value}
+        """)
+    monkeypatch.setattr(skypilot_config, '_GLOBAL_CONFIG_PATH',
+                        tmp_path / 'slurm_quota_types.yaml')
+    skypilot_config.reload_config()
+
+    get = skypilot_config.get_effective_slurm_quota_value
+    assert get('a_number', cluster='clusterA') == 42
+    assert get('a_bool', cluster='clusterA') is True
+    assert get('a_list', cluster='clusterA') == ['one', 'two']
+    assert get('a_mapping', cluster='clusterA') == {'nested': 'value'}
+
+
 def test_get_effective_slurm_account(monkeypatch, tmp_path) -> None:
     """`quota.account` walks the same scopes as the Slurm `quota.queue`."""
     with open(tmp_path / 'slurm_account.yaml', 'w', encoding='utf-8') as f:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2401,6 +2401,66 @@ def test_get_effective_queue_name_slurm_ignores_sbatch_options(
         cluster='clusterA', workspace='default') is None
 
 
+def test_get_effective_slurm_quota_value(monkeypatch, tmp_path) -> None:
+    """An arbitrary `quota.<key>` walks the same scopes as `quota.queue`."""
+    with open(tmp_path / 'slurm_quota_value.yaml', 'w', encoding='utf-8') as f:
+        f.write("""\
+        slurm:
+            quota:
+                borrow_queue: global-cloud-borrow
+            cluster_configs:
+                clusterA:
+                    partition_configs:
+                        gpu:
+                            quota:
+                                borrow_queue: global-clusterA-gpu-borrow
+        workspaces:
+            workspaceA:
+                slurm:
+                    quota:
+                        borrow_queue: ws-cloud-borrow
+            workspaceB: {}
+        """)
+    monkeypatch.setattr(skypilot_config, '_GLOBAL_CONFIG_PATH',
+                        tmp_path / 'slurm_quota_value.yaml')
+    skypilot_config.reload_config()
+
+    assert skypilot_config.get_effective_slurm_quota_value(
+        'borrow_queue',
+        cluster='clusterA',
+        partition='gpu',
+        workspace='workspaceA') == 'ws-cloud-borrow'
+    assert skypilot_config.get_effective_slurm_quota_value(
+        'borrow_queue',
+        cluster='clusterA',
+        partition='gpu',
+        workspace='workspaceB') == 'global-clusterA-gpu-borrow'
+    assert skypilot_config.get_effective_slurm_quota_value(
+        'borrow_queue',
+        cluster='clusterA',
+        partition='cpu',
+        workspace='workspaceB') == 'global-cloud-borrow'
+    assert skypilot_config.get_effective_slurm_quota_value(
+        'borrow_queue',
+        cluster='clusterA',
+        partition='cpu',
+        workspace='workspaceB',
+        override_configs={'slurm': {
+            'quota': {
+                'borrow_queue': 'task-borrow'
+            }
+        }}) == 'task-borrow'
+    # A cluster with no entry of its own still inherits the cloud scope.
+    assert skypilot_config.get_effective_slurm_quota_value(
+        'borrow_queue',
+        cluster='clusterB',
+        partition='gpu',
+        workspace='workspaceB') == 'global-cloud-borrow'
+    # A sub-field nobody set reads as absent rather than raising.
+    assert skypilot_config.get_effective_slurm_quota_value(
+        'not_a_field', cluster='clusterA', partition='gpu') is None
+
+
 def test_get_effective_slurm_account(monkeypatch, tmp_path) -> None:
     """`quota.account` walks the same scopes as the Slurm `quota.queue`."""
     with open(tmp_path / 'slurm_account.yaml', 'w', encoding='utf-8') as f:


### PR DESCRIPTION
`slurm.quota` is declared with `additionalProperties: True` so consumers can carry scheduler-specific sub-fields beyond `queue` and `account`:

```python
_SLURM_QUOTA_SCHEMA = {
    'additionalProperties': True,
    ...
}
```

But resolving such a sub-field over the config scope chain is only possible for the two fields that have a named getter — `get_effective_queue_name` and `get_effective_slurm_account`. Anything else has to reimplement the walk (workspace > global, and within each, partition > cluster > cloud).

That is worth avoiding: a hand-rolled walk tends to resolve *almost* the same way, so a partition-level value gets silently ignored or a workspace override is not applied, and the field ends up disagreeing with `quota.queue` — which is confusing precisely because the two values are meant to travel together on the same job.

This adds `get_effective_slurm_quota_value(key, ...)`, the generic counterpart to those two:

```python
borrow_queue = skypilot_config.get_effective_slurm_quota_value(
    'borrow_queue', cluster=cluster, partition=partition,
    override_configs=resources.cluster_config_overrides)
```

No behavior change. It is a thin wrapper over the existing `_get_effective_scoped_config_value` with `property_keys=[('quota', key)]`, and the two named getters are untouched.

For context on why an extra sub-field is useful at all: since Slurm 24.11 `sbatch --qos` accepts a comma-separated list, and slurmctld re-evaluates the requested QOS every scheduling cycle, admitting the job under the first whose limits currently allow it. Expressing "this queue, or that one if the first is at its cap" therefore needs a second QOS name alongside `quota.queue`, resolved over the same scopes.

## Tested

- `pytest tests/test_config.py -k effective` — 12 passed, including the new `test_get_effective_slurm_quota_value`, which covers workspace > global, partition > cluster > cloud, a task-level `config` override, inheritance by a cluster with no `cluster_configs` entry of its own, and an unset sub-field resolving to `None` rather than raising.
- `bash format.sh --files sky/skypilot_config.py tests/test_config.py` — yapf/isort/pylint clean; the one mypy error reported is pre-existing in `sky/client/sdk.py` and reproduces identically with this change stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10700" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->