### PR TITLE
[Metrics] Track blob lookup sizes and cache hits

### DIFF
--- a/sky/client/common.py
+++ b/sky/client/common.py
@@ -476,6 +476,7 @@ def upload_mounts_to_api_server(
                         params={
                             'user_hash': common_utils.get_user_hash(),
                             'blob_id': blob_id,
+                            'size_bytes': os.path.getsize(temp_zip_file.name),
                         })
                     if resp.status_code != 200:
                         raise RuntimeError(f'Failed to check blob existence: '

--- a/sky/metrics/utils.py
+++ b/sky/metrics/utils.py
@@ -173,6 +173,13 @@ SKY_APISERVER_REQUESTS_TOTAL = prom.Counter(
     ['path', 'method', 'status'],
 )
 
+SKY_APISERVER_BLOB_CHECK_SIZE_BYTES = prom.Histogram(
+    'sky_apiserver_blob_check_size_bytes',
+    'Client-reported compressed blob bytes per existence check.',
+    ['result'],
+    buckets=[2**exponent for exponent in range(10, 37, 2)],
+)
+
 # Total number of API server requests per user.
 # This is a separate metric to avoid high cardinality in the primary metric.
 SKY_APISERVER_REQUESTS_BY_USER_TOTAL = prom.Counter(

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -1962,7 +1962,9 @@ async def check_blob_exists(
     user_hash: str,
     blob_id: str,
     size_bytes: Optional[int] = fastapi.Query(
-        None, ge=0,
+        None,
+        ge=0,
+        le=2**63 - 1,
         description='Client-reported compressed ZIP size in bytes.'),
 ) -> Dict[str, bool]:
     """Check if a file mount blob already exists."""

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -1957,8 +1957,14 @@ async def upload_zip_file(request: fastapi.Request, user_hash: str,
 
 
 @app.get('/upload_v2/blob')
-async def check_blob_exists(request: fastapi.Request, user_hash: str,
-                            blob_id: str) -> Dict[str, bool]:
+async def check_blob_exists(
+    request: fastapi.Request,
+    user_hash: str,
+    blob_id: str,
+    size_bytes: Optional[int] = fastapi.Query(
+        None, ge=0,
+        description='Client-reported compressed ZIP size in bytes.'),
+) -> Dict[str, bool]:
     """Check if a file mount blob already exists."""
     if not re.match(r'^[0-9a-f]{64}$', blob_id):
         raise fastapi.HTTPException(status_code=400,
@@ -1967,6 +1973,9 @@ async def check_blob_exists(request: fastapi.Request, user_hash: str,
     if request.state.auth_user is not None:
         user_id = request.state.auth_user.id
     exists = await bs.get_blob_storage().blob_exists(user_id, blob_id)
+    if metrics_utils.METRICS_ENABLED and size_bytes is not None:
+        metrics_utils.SKY_APISERVER_BLOB_CHECK_SIZE_BYTES.labels(
+            result='hit' if exists else 'miss').observe(size_bytes)
     return {'exists': exists}
 
 

--- a/tests/unit_tests/test_sky/server/test_blob_upload_metrics.py
+++ b/tests/unit_tests/test_sky/server/test_blob_upload_metrics.py
@@ -117,7 +117,9 @@ def test_client_upload_records_size_on_miss_and_hit(blob_upload_app, tmp_path,
     assert not list(tmp_path.glob('*.zip'))
 
 
-@pytest.mark.parametrize('size', [None, '-1', 'nan', '1.5'])
+@pytest.mark.parametrize(
+    'size', [None, '-1', 'nan', '1.5',
+             str(2**63), str(10**309)])
 def test_missing_or_invalid_size_not_observed(blob_upload_app, size):
     app, _, registry = blob_upload_app
     before = _sample(registry, 'count', 'miss')

--- a/tests/unit_tests/test_sky/server/test_blob_upload_metrics.py
+++ b/tests/unit_tests/test_sky/server/test_blob_upload_metrics.py
@@ -1,0 +1,163 @@
+"""Blob lookup metrics through the client upload and server routes."""
+import functools
+
+import fastapi
+from fastapi import testclient
+import prometheus_client as prom
+import pytest
+
+from sky import dag as dag_lib
+from sky import task as task_lib
+from sky.client import common as client_common
+from sky.metrics import utils as metrics_utils
+from sky.server import common as server_common
+from sky.server import constants as server_constants
+from sky.server import server
+from sky.server.blob import local_blob_storage
+
+_METRIC = 'sky_apiserver_blob_check_size_bytes'
+
+
+@pytest.fixture(name='blob_upload_app')
+def _blob_upload_app(tmp_path, monkeypatch):
+    app = fastapi.FastAPI()
+    app.router.routes.extend(route for route in server.app.routes
+                             if route.path in ('/upload_v2/blob', '/upload_v2'))
+    requests = []
+
+    @app.middleware('http')
+    async def auth_and_record(request, call_next):
+        request.state.auth_user = None
+        requests.append((request.method, dict(request.query_params)))
+        return await call_next(request)
+
+    monkeypatch.setattr(server_common, 'API_SERVER_CLIENT_DIR',
+                        tmp_path / 'clients')
+    storage = local_blob_storage.LocalFilesystemBlobStorage()
+    monkeypatch.setattr(server.bs, 'get_blob_storage', lambda: storage)
+    monkeypatch.setattr(metrics_utils, 'METRICS_ENABLED', True)
+    registry = prom.CollectorRegistry()
+    registry.register(metrics_utils.SKY_APISERVER_BLOB_CHECK_SIZE_BYTES)
+    return app, requests, registry
+
+
+def _sample(registry, suffix, result, **labels):
+    return registry.get_sample_value(f'{_METRIC}_{suffix}', {
+        'result': result,
+        **labels,
+    }) or 0
+
+
+@pytest.mark.parametrize('chunk_bytes', [95_000_000, 256])
+def test_client_upload_records_size_on_miss_and_hit(blob_upload_app, tmp_path,
+                                                    monkeypatch, chunk_bytes):
+    app, requests, registry = blob_upload_app
+    client = testclient.TestClient(app)
+    monkeypatch.setattr(server_common, 'is_api_server_local', lambda: False)
+    monkeypatch.setattr(server_common, 'get_server_url',
+                        lambda: 'http://testserver')
+    monkeypatch.setattr(server_common, 'get_api_cookie_jar', lambda: None)
+    monkeypatch.setattr(server_common, 'make_authenticated_request',
+                        client.request)
+    monkeypatch.setattr(client_common.httpx, 'Client',
+                        lambda **kwargs: testclient.TestClient(app))
+    monkeypatch.setattr(client_common.versions, 'get_remote_api_version',
+                        lambda: server_constants.API_VERSION)
+    monkeypatch.setattr(client_common.common_utils, 'get_user_hash',
+                        lambda: 'test-user')
+    monkeypatch.setattr(client_common.service_account_auth,
+                        'get_service_account_headers', lambda: {})
+    monkeypatch.setattr(client_common, 'FILE_UPLOAD_LOGS_DIR',
+                        str(tmp_path / 'logs'))
+    monkeypatch.setattr(client_common, '_FILE_UPLOAD_LOCK_DIR',
+                        str(tmp_path / 'locks'))
+    monkeypatch.setattr(client_common, '_UPLOAD_CHUNK_BYTES', chunk_bytes)
+    monkeypatch.setattr(
+        client_common.tempfile, 'NamedTemporaryFile',
+        functools.partial(client_common.tempfile.NamedTemporaryFile,
+                          dir=tmp_path))
+
+    workdir = tmp_path / 'workdir'
+    workdir.mkdir()
+    (workdir / 'code.py').write_text('print("hello")\n' * 1000)
+    mount = tmp_path / 'data.txt'
+    mount.write_text('data\n' * 1000)
+    dag = dag_lib.Dag()
+    dag.add(
+        task_lib.Task(workdir=str(workdir),
+                      file_mounts={'/data.txt': str(mount)}))
+    before = {(result, suffix): _sample(registry, suffix, result)
+              for result in ('hit', 'miss') for suffix in ('count', 'sum')}
+
+    _, blob_id = client_common.upload_mounts_to_api_server(dag)
+    checks = [params for method, params in requests if method == 'GET']
+    assert len(checks) == 1
+    size = int(checks[0]['size_bytes'])
+    assert 0 < size < (workdir /
+                       'code.py').stat().st_size + mount.stat().st_size
+    uploads = [params for method, params in requests if method == 'POST']
+    assert len(uploads) == (size + chunk_bytes - 1) // chunk_bytes
+    assert _sample(registry, 'count', 'miss') == before['miss', 'count'] + 1
+    assert _sample(registry, 'sum', 'miss') == before['miss', 'sum'] + size
+    assert _sample(registry, 'count', 'hit') == before['hit', 'count']
+    blob_dir = server.bs.get_blob_storage().get_target_dir('test-user', blob_id)
+    assert (blob_dir /
+            str(mount).lstrip('/')).read_bytes() == mount.read_bytes()
+
+    requests.clear()
+    _, reused_blob_id = client_common.upload_mounts_to_api_server(dag)
+    assert reused_blob_id == blob_id
+    assert len(requests) == 1
+    method, params = requests[0]
+    assert method == 'GET'
+    assert int(params['size_bytes']) == size
+    assert _sample(registry, 'count', 'hit') == before['hit', 'count'] + 1
+    assert _sample(registry, 'sum', 'hit') == before['hit', 'sum'] + size
+    assert _sample(registry, 'count', 'miss') == before['miss', 'count'] + 1
+    assert not list(tmp_path.glob('*.zip'))
+
+
+@pytest.mark.parametrize('size', [None, '-1', 'nan', '1.5'])
+def test_missing_or_invalid_size_not_observed(blob_upload_app, size):
+    app, _, registry = blob_upload_app
+    before = _sample(registry, 'count', 'miss')
+    params = {'user_hash': 'test-user', 'blob_id': 'a' * 64}
+    if size is not None:
+        params['size_bytes'] = size
+    response = testclient.TestClient(app).get('/upload_v2/blob', params=params)
+    assert response.status_code == (200 if size is None else 422)
+    assert _sample(registry, 'count', 'miss') == before
+
+
+@pytest.mark.parametrize('size', [0, 1024, 64 * 2**30])
+def test_size_histogram_buckets(blob_upload_app, size):
+    app, _, registry = blob_upload_app
+    before_count = _sample(registry, 'count', 'miss')
+    before_sum = _sample(registry, 'sum', 'miss')
+    before_bucket = _sample(registry, 'bucket', 'miss', le='1024.0')
+    response = testclient.TestClient(app).get('/upload_v2/blob',
+                                              params={
+                                                  'user_hash': 'test-user',
+                                                  'blob_id': 'a' * 64,
+                                                  'size_bytes': size,
+                                              })
+    assert response.status_code == 200
+    assert response.json() == {'exists': False}
+    assert _sample(registry, 'count', 'miss') == before_count + 1
+    assert _sample(registry, 'sum', 'miss') == before_sum + size
+    assert _sample(registry, 'bucket', 'miss',
+                   le='1024.0') == before_bucket + (size <= 1024)
+
+
+def test_disabled_metrics_not_observed(blob_upload_app, monkeypatch):
+    app, _, registry = blob_upload_app
+    monkeypatch.setattr(metrics_utils, 'METRICS_ENABLED', False)
+    before = _sample(registry, 'count', 'miss')
+    response = testclient.TestClient(app).get('/upload_v2/blob',
+                                              params={
+                                                  'user_hash': 'test-user',
+                                                  'blob_id': 'a' * 64,
+                                                  'size_bytes': 1024,
+                                              })
+    assert response.status_code == 200
+    assert _sample(registry, 'count', 'miss') == before


### PR DESCRIPTION
Workdir and file-mount upload deduplication has no metric distinguishing blob cache hits from misses: both existence-check outcomes return HTTP 200, and upload request counts include chunks and retries.

Add `sky_apiserver_blob_check_size_bytes{result="hit|miss"}`, observed once per successful existence check that includes a size. The client sends the compressed ZIP size using a local stat before the lookup. Buckets span 1 KiB to 64 GiB; `_count` provides lookup hit rate, `_bucket` provides size distributions, and the hit `_sum` estimates compressed bytes avoided.

The size is optional and nonnegative. Checks without a size remain supported and are excluded from the histogram. These are client-reported bytes per lookup, not completed-upload bytes or unique stored blobs. Recording respects the existing server metrics toggle.

Tested:

- 16 focused tests passed: real ZIP creation, single- and multi-chunk uploads through in-process API routes with local blob storage, repeat-upload cache hits, histogram counts/sums/buckets, missing/invalid sizes, and disabled metrics. HTTP transport and authentication are replaced by the test harness; no deployed-server or HA test was run.
- Pinned YAPF/isort checks and pylint on changed files; full mypy check: 599 source files.

Manual validation plan (not run): enable API-server metrics, submit the same workdir and local file mounts twice with the updated client, then inspect the histogram. Expect one miss followed by one hit with equal byte sums; the second submission should send no upload chunks.
