### PR TITLE
[Server] Count auth-path DB timeouts

### DIFF
--- a/sky/metrics/utils.py
+++ b/sky/metrics/utils.py
@@ -341,25 +341,34 @@ SKY_APISERVER_THREADS_EXHAUSTED_TOTAL = prom.Counter(
     ['name'],
 )
 
-# Auth-path DB calls that ended in a timeout instead of a result. This is the
+# Auth-path work that ended in a timeout instead of a result. This is the
 # earliest signal that authentication is degrading: in a production incident
 # the first one landed 13 minutes before the first client-visible 503, and it
 # was log-only, so nothing could alert on it.
 #
-# `cause` says which timeout ended the call, and the two kinds mean opposite
-# things:
-#   `deadline` -- the client-side `asyncio.wait_for` deadline elapsed. The
-#       caller is freed but the THREAD IS NOT: `wait_for` cannot cancel a
-#       thread parked in a blocking libpq call, so each of these holds an auth
-#       executor slot until the call returns on its own. This is the signal
-#       that runs ahead of pool exhaustion.
+# `pool` is the executor the work ran on, spelled as
+# `sky_apiserver_threads_exhausted_total{name}` spells it so the two can be
+# read together. It matters because the deadline frees the caller and never
+# the thread (`wait_for` cannot cancel a thread parked on a blocking call),
+# so every `cause="deadline"` costs a slot in THAT pool until the call
+# returns on its own:
+#   `auth_thread_executor` (32) -- short DB lookups. Losing slots here locks
+#       every authenticated request out, so this is the pre-exhaustion signal.
+#   `request_thread_executor` (128) -- role seeding, which reloads config and
+#       runs policy operations. Its blocker is often a policy lock rather
+#       than the database, and it is deliberately on the larger pool for
+#       exactly that reason, so do not read it as auth-pool pressure.
+#
+# `cause` says which timeout ended the call:
+#   `deadline` -- the client-side `asyncio.wait_for` deadline elapsed; the
+#       thread is still held (see above).
 #   anything else -- the database ended the call at one of the server-side
 #       timeouts the auth path sets on its own transaction (`lock_timeout`,
 #       `statement_timeout`, `idle_in_transaction_session_timeout`). The
 #       thread comes back; a `lock_timeout` says another session holds the
 #       row lock.
 #
-# `site` is the name of the DB function that was called: a closed set, since
+# `site` is the name of the function that was called: a closed set, since
 # every call site passes a module-level function or a bound method.
 #
 # Two things are deliberately NOT counted here. Executor exhaustion, which
@@ -369,10 +378,10 @@ SKY_APISERVER_THREADS_EXHAUSTED_TOTAL = prom.Counter(
 # unauthenticated, so it yields no client-visible error at all -- those
 # requests reach no request-level metric, and this counter is the only place
 # they appear.
-SKY_APISERVER_AUTH_DB_TIMEOUTS_TOTAL = prom.Counter(
-    'sky_apiserver_auth_db_timeouts_total',
-    'Auth-path DB calls that timed out, by call site and which timeout',
-    ['site', 'cause'],
+SKY_APISERVER_AUTH_TIMEOUTS_TOTAL = prom.Counter(
+    'sky_apiserver_auth_timeouts_total',
+    'Auth-path work that timed out, by call site, cause and executor pool',
+    ['site', 'cause', 'pool'],
 )
 
 # Time a request spends waiting in the task queue (from creation to dequeue).

--- a/sky/metrics/utils.py
+++ b/sky/metrics/utils.py
@@ -341,6 +341,40 @@ SKY_APISERVER_THREADS_EXHAUSTED_TOTAL = prom.Counter(
     ['name'],
 )
 
+# Auth-path DB calls that ended in a timeout instead of a result. This is the
+# earliest signal that authentication is degrading: in a production incident
+# the first one landed 13 minutes before the first client-visible 503, and it
+# was log-only, so nothing could alert on it.
+#
+# `cause` says which timeout ended the call, and the two kinds mean opposite
+# things:
+#   `deadline` -- the client-side `asyncio.wait_for` deadline elapsed. The
+#       caller is freed but the THREAD IS NOT: `wait_for` cannot cancel a
+#       thread parked in a blocking libpq call, so each of these holds an auth
+#       executor slot until the call returns on its own. This is the signal
+#       that runs ahead of pool exhaustion.
+#   anything else -- the database ended the call at one of the server-side
+#       timeouts the auth path sets on its own transaction (`lock_timeout`,
+#       `statement_timeout`, `idle_in_transaction_session_timeout`). The
+#       thread comes back; a `lock_timeout` says another session holds the
+#       row lock.
+#
+# `site` is the name of the DB function that was called: a closed set, since
+# every call site passes a module-level function or a bound method.
+#
+# Two things are deliberately NOT counted here. Executor exhaustion, which
+# already has `sky_apiserver_threads_exhausted_total`; and whatever response
+# the caller went on to produce. Most callers answer a retryable 503, but the
+# `/api/health` basic-auth path swallows the timeout and proceeds
+# unauthenticated, so it yields no client-visible error at all -- those
+# requests reach no request-level metric, and this counter is the only place
+# they appear.
+SKY_APISERVER_AUTH_DB_TIMEOUTS_TOTAL = prom.Counter(
+    'sky_apiserver_auth_db_timeouts_total',
+    'Auth-path DB calls that timed out, by call site and which timeout',
+    ['site', 'cause'],
+)
+
 # Time a request spends waiting in the task queue (from creation to dequeue).
 SKY_APISERVER_QUEUE_WAIT_SECONDS = prom.Histogram(
     'sky_apiserver_queue_wait_seconds',

--- a/sky/metrics/utils.py
+++ b/sky/metrics/utils.py
@@ -368,8 +368,13 @@ SKY_APISERVER_THREADS_EXHAUSTED_TOTAL = prom.Counter(
 #       thread comes back; a `lock_timeout` says another session holds the
 #       row lock.
 #
-# `site` is the name of the function that was called: a closed set, since
-# every call site passes a module-level function or a bound method.
+# `site` is the name of the function that was called. Bounded, not
+# attacker-influenced: every call site passes a module-level function or a
+# bound method, so the values are fixed at build time. It is not only the
+# eight OSS names, though -- `call_with_deadline` is also called from the
+# enterprise plugin's session and RBAC middlewares and its volume gate, which
+# contribute their own, so a hosted deployment has more. A callable with no
+# `__name__` (a partial) records `unknown` rather than widening the label.
 #
 # Two things are deliberately NOT counted here. Executor exhaustion, which
 # already has `sky_apiserver_threads_exhausted_total`; and whatever response

--- a/sky/server/auth/db_lookup.py
+++ b/sky/server/auth/db_lookup.py
@@ -101,6 +101,10 @@ TIMEOUT_CAUSE_DEADLINE = 'deadline'
 POOL_AUTH = 'auth_thread_executor'
 POOL_REQUEST = 'request_thread_executor'
 
+# Whether this process has already reported a metrics-recording failure; see
+# `_count_timeout`.
+_recording_failure_logged = False
+
 
 def _count_timeout(func: Callable[..., Any], cause: str, pool: str) -> None:
     """Count one auth-path timeout, on the pool whose slot it holds.
@@ -116,14 +120,29 @@ def _count_timeout(func: Callable[..., Any], cause: str, pool: str) -> None:
     """
     if not metrics_utils.METRICS_ENABLED:
         return
+    site = getattr(func, '__name__', 'unknown')
     try:
-        metrics_utils.SKY_APISERVER_AUTH_TIMEOUTS_TOTAL.labels(site=getattr(
-            func, '__name__', 'unknown'),
+        metrics_utils.SKY_APISERVER_AUTH_TIMEOUTS_TOTAL.labels(site=site,
                                                                cause=cause,
                                                                pool=pool).inc()
     except Exception as e:  # pylint: disable=broad-except
-        logger.warning(f'Failed to count an auth-path timeout: '
-                       f'{common_utils.format_exception(e)}')
+        # Once per process at WARNING, then quietly. The faults this guards
+        # against are persistent (a full or unwritable
+        # PROMETHEUS_MULTIPROC_DIR, a label value the client library rejects)
+        # and they happen on a path that fires at request rate during the
+        # incident this counter exists for, so an unconditional warning would
+        # flood the log exactly when it needs reading.
+        # TODO(hailong): use middleware_utils.note_recording_failure once
+        # #10691 lands; it rate-limits per process with a dropped count.
+        global _recording_failure_logged  # pylint: disable=global-statement
+        detail = common_utils.format_exception(e)
+        if _recording_failure_logged:
+            logger.debug(f'Failed to count an auth-path timeout: {detail}')
+            return
+        _recording_failure_logged = True
+        logger.warning(f'Failed to count an auth-path timeout: {detail}. The '
+                       f'request was answered normally and this observation '
+                       f'was dropped; further failures are logged at debug.')
 
 
 async def _run_with_deadline(pool: Any, pool_name: str,

--- a/sky/server/auth/db_lookup.py
+++ b/sky/server/auth/db_lookup.py
@@ -29,6 +29,7 @@ import fastapi
 
 from sky import exceptions
 from sky import sky_logging
+from sky.metrics import utils as metrics_utils
 from sky.server.requests import executor
 from sky.users import permission
 from sky.utils import common_utils
@@ -89,6 +90,28 @@ def _server_timeout_pgcode(exc: BaseException) -> Optional[str]:
     return None
 
 
+# `cause` of a timeout the client-side deadline produced, as opposed to one
+# the database itself ended (those are named by their Postgres setting, see
+# `_SERVER_TIMEOUT_PGCODES`).
+TIMEOUT_CAUSE_DEADLINE = 'deadline'
+
+
+def _count_timeout(func: Callable[..., Any], cause: str) -> None:
+    """Count one auth-path DB timeout.
+
+    Guarded: this runs while an exception from the auth path is in flight, so
+    a failure to record must not replace it. That would turn a retryable 503
+    into a bare 500 during exactly the database incident the counter exists
+    to make visible.
+    """
+    try:
+        metrics_utils.SKY_APISERVER_AUTH_DB_TIMEOUTS_TOTAL.labels(
+            site=getattr(func, '__name__', 'unknown'), cause=cause).inc()
+    except Exception as e:  # pylint: disable=broad-except
+        logger.warning(f'Failed to count an auth DB timeout: '
+                       f'{common_utils.format_exception(e)}')
+
+
 async def _run_with_deadline(pool: Any, func: Callable[..., Any],
                              *args: Any) -> Any:
     try:
@@ -98,8 +121,17 @@ async def _run_with_deadline(pool: Any, func: Callable[..., Any],
     except Exception as e:  # pylint: disable=broad-except
         pgcode = _server_timeout_pgcode(e)
         if pgcode is None:
+            if isinstance(e, asyncio.TimeoutError):
+                # The deadline elapsed. Counted here, at the one choke point
+                # every auth DB call goes through, rather than at the call
+                # sites: several of them convert the timeout to a 503 and one
+                # (the /api/health probe) swallows it entirely, so counting
+                # per caller would miss the cases with no client-visible
+                # symptom -- which are the early ones.
+                _count_timeout(func, TIMEOUT_CAUSE_DEADLINE)
             raise
         reason = _SERVER_TIMEOUT_PGCODES[pgcode]
+        _count_timeout(func, reason)
         logger.warning(f'Auth DB call {getattr(func, "__name__", func)} was '
                        f'cut off by the database\'s {reason} '
                        f'(pgcode {pgcode}): '

--- a/sky/server/auth/db_lookup.py
+++ b/sky/server/auth/db_lookup.py
@@ -110,10 +110,6 @@ TIMEOUT_CAUSE_DEADLINE = 'deadline'
 POOL_AUTH = 'auth_thread_executor'
 POOL_REQUEST = 'request_thread_executor'
 
-# Whether this process has already reported a metrics-recording failure; see
-# `_count_timeout`.
-_recording_failure_logged = False
-
 
 def _count_timeout(func: Callable[..., Any], cause: str, pool: str) -> None:
     """Count one auth-path timeout, on the pool whose slot it holds.
@@ -122,36 +118,22 @@ def _count_timeout(func: Callable[..., Any], cause: str, pool: str) -> None:
     metrics middleware (see `OnDemandThreadExecutor`, which does not even
     materialise its counter children, and `record_federation_phase`).
 
-    Guarded: this runs while an exception from the auth path is in flight, so
-    a failure to record must not replace it. That would turn a retryable 503
-    into a bare 500 during exactly the incident the counter exists to make
-    visible.
+    Recorded through `record_safely` because this runs while an exception from
+    the auth path is in flight: a failure to record must not replace it, which
+    would turn a retryable 503 into a bare 500 during exactly the incident the
+    counter exists to make visible.
     """
     if not metrics_utils.METRICS_ENABLED:
         return
     site = getattr(func, '__name__', 'unknown')
-    try:
-        metrics_utils.SKY_APISERVER_AUTH_TIMEOUTS_TOTAL.labels(site=site,
-                                                               cause=cause,
-                                                               pool=pool).inc()
-    except Exception as e:  # pylint: disable=broad-except
-        # Once per process at WARNING, then quietly. The faults this guards
-        # against are persistent (a full or unwritable
-        # PROMETHEUS_MULTIPROC_DIR, a label value the client library rejects)
-        # and they happen on a path that fires at request rate during the
-        # incident this counter exists for, so an unconditional warning would
-        # flood the log exactly when it needs reading.
-        # TODO(hailong): use middleware_utils.note_recording_failure once
-        # #10691 lands; it rate-limits per process with a dropped count.
-        global _recording_failure_logged  # pylint: disable=global-statement
-        detail = common_utils.format_exception(e)
-        if _recording_failure_logged:
-            logger.debug(f'Failed to count an auth-path timeout: {detail}')
-            return
-        _recording_failure_logged = True
-        logger.warning(f'Failed to count an auth-path timeout: {detail}. The '
-                       f'request was answered normally and this observation '
-                       f'was dropped; further failures are logged at debug.')
+    middleware_utils.record_safely('an auth-path timeout', _record_timeout,
+                                   site, cause, pool)
+
+
+def _record_timeout(site: str, cause: str, pool: str) -> None:
+    metrics_utils.SKY_APISERVER_AUTH_TIMEOUTS_TOTAL.labels(site=site,
+                                                           cause=cause,
+                                                           pool=pool).inc()
 
 
 async def _run_with_deadline(pool: Any, pool_name: str,

--- a/sky/server/auth/db_lookup.py
+++ b/sky/server/auth/db_lookup.py
@@ -95,25 +95,39 @@ def _server_timeout_pgcode(exc: BaseException) -> Optional[str]:
 # `_SERVER_TIMEOUT_PGCODES`).
 TIMEOUT_CAUSE_DEADLINE = 'deadline'
 
+# `pool` label values: which executor's slot the timed-out call is holding.
+# Spelled as `sky_apiserver_threads_exhausted_total{name}` spells it, so a
+# timeout can be read next to that pool's exhaustion and saturation.
+POOL_AUTH = 'auth_thread_executor'
+POOL_REQUEST = 'request_thread_executor'
 
-def _count_timeout(func: Callable[..., Any], cause: str) -> None:
-    """Count one auth-path DB timeout.
+
+def _count_timeout(func: Callable[..., Any], cause: str, pool: str) -> None:
+    """Count one auth-path timeout, on the pool whose slot it holds.
+
+    A no-op when metrics are off, like every other instrument outside the
+    metrics middleware (see `OnDemandThreadExecutor`, which does not even
+    materialise its counter children, and `record_federation_phase`).
 
     Guarded: this runs while an exception from the auth path is in flight, so
     a failure to record must not replace it. That would turn a retryable 503
-    into a bare 500 during exactly the database incident the counter exists
-    to make visible.
+    into a bare 500 during exactly the incident the counter exists to make
+    visible.
     """
+    if not metrics_utils.METRICS_ENABLED:
+        return
     try:
-        metrics_utils.SKY_APISERVER_AUTH_DB_TIMEOUTS_TOTAL.labels(
-            site=getattr(func, '__name__', 'unknown'), cause=cause).inc()
+        metrics_utils.SKY_APISERVER_AUTH_TIMEOUTS_TOTAL.labels(site=getattr(
+            func, '__name__', 'unknown'),
+                                                               cause=cause,
+                                                               pool=pool).inc()
     except Exception as e:  # pylint: disable=broad-except
-        logger.warning(f'Failed to count an auth DB timeout: '
+        logger.warning(f'Failed to count an auth-path timeout: '
                        f'{common_utils.format_exception(e)}')
 
 
-async def _run_with_deadline(pool: Any, func: Callable[..., Any],
-                             *args: Any) -> Any:
+async def _run_with_deadline(pool: Any, pool_name: str,
+                             func: Callable[..., Any], *args: Any) -> Any:
     try:
         return await asyncio.wait_for(context_utils.to_thread_with_executor(
             pool, func, *args),
@@ -123,15 +137,15 @@ async def _run_with_deadline(pool: Any, func: Callable[..., Any],
         if pgcode is None:
             if isinstance(e, asyncio.TimeoutError):
                 # The deadline elapsed. Counted here, at the one choke point
-                # every auth DB call goes through, rather than at the call
+                # every auth-path call goes through, rather than at the call
                 # sites: several of them convert the timeout to a 503 and one
                 # (the /api/health probe) swallows it entirely, so counting
                 # per caller would miss the cases with no client-visible
                 # symptom -- which are the early ones.
-                _count_timeout(func, TIMEOUT_CAUSE_DEADLINE)
+                _count_timeout(func, TIMEOUT_CAUSE_DEADLINE, pool_name)
             raise
         reason = _SERVER_TIMEOUT_PGCODES[pgcode]
-        _count_timeout(func, reason)
+        _count_timeout(func, reason, pool_name)
         logger.warning(f'Auth DB call {getattr(func, "__name__", func)} was '
                        f'cut off by the database\'s {reason} '
                        f'(pgcode {pgcode}): '
@@ -147,8 +161,8 @@ async def call_with_deadline(func: Callable[..., Any], *args: Any) -> Any:
     `_SERVER_TIMEOUT_PGCODES`) and ``ConcurrentWorkerExhaustedError`` when
     the executor is saturated.
     """
-    return await _run_with_deadline(executor.get_auth_thread_executor(), func,
-                                    *args)
+    return await _run_with_deadline(executor.get_auth_thread_executor(),
+                                    POOL_AUTH, func, *args)
 
 
 async def _call_on_request_pool(func: Callable[..., Any], *args: Any) -> Any:
@@ -163,7 +177,7 @@ async def _call_on_request_pool(func: Callable[..., Any], *args: Any) -> Any:
     logins exhaust authentication for every other request on this worker.
     """
     return await _run_with_deadline(executor.get_request_thread_executor(),
-                                    func, *args)
+                                    POOL_REQUEST, func, *args)
 
 
 async def ensure_role_for_authenticated_user(

--- a/tests/unit_tests/test_sky/server/test_auth_db_deadline.py
+++ b/tests/unit_tests/test_sky/server/test_auth_db_deadline.py
@@ -665,7 +665,7 @@ def _never_runs():
 def _timeouts(**labels) -> float:
     """Current value of the auth-DB-timeout counter for these labels."""
     total = 0.0
-    counter = metrics_utils.SKY_APISERVER_AUTH_DB_TIMEOUTS_TOTAL
+    counter = metrics_utils.SKY_APISERVER_AUTH_TIMEOUTS_TOTAL
     for family in counter.collect():
         for sample in family.samples:
             if not sample.name.endswith('_total'):
@@ -676,10 +676,13 @@ def _timeouts(**labels) -> float:
 
 
 @pytest.fixture
-def clear_timeouts():
-    metrics_utils.SKY_APISERVER_AUTH_DB_TIMEOUTS_TOTAL.clear()
+def clear_timeouts(monkeypatch):
+    # Recording is gated on METRICS_ENABLED, which is a module constant read
+    # at import and false unless the server was started with metrics on.
+    monkeypatch.setattr(metrics_utils, 'METRICS_ENABLED', True)
+    metrics_utils.SKY_APISERVER_AUTH_TIMEOUTS_TOTAL.clear()
     yield
-    metrics_utils.SKY_APISERVER_AUTH_DB_TIMEOUTS_TOTAL.clear()
+    metrics_utils.SKY_APISERVER_AUTH_TIMEOUTS_TOTAL.clear()
 
 
 class TestAuthDBTimeoutCounter:
@@ -704,7 +707,8 @@ class TestAuthDBTimeoutCounter:
             await db_lookup.call_with_deadline(_parked)
 
         assert _timeouts(site='_parked',
-                         cause=db_lookup.TIMEOUT_CAUSE_DEADLINE) == 1.0
+                         cause=db_lookup.TIMEOUT_CAUSE_DEADLINE,
+                         pool=db_lookup.POOL_AUTH) == 1.0
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize('pgcode, cause', [
@@ -737,8 +741,12 @@ class TestAuthDBTimeoutCounter:
         with pytest.raises(asyncio.TimeoutError):
             await db_lookup._call_on_request_pool(_parked_on_request_pool)
 
+        # The larger pool, and the one whose blocker is often a policy
+        # lock rather than the database: it must not read as auth pressure.
         assert _timeouts(site='_parked_on_request_pool',
-                         cause=db_lookup.TIMEOUT_CAUSE_DEADLINE) == 1.0
+                         cause=db_lookup.TIMEOUT_CAUSE_DEADLINE,
+                         pool=db_lookup.POOL_REQUEST) == 1.0
+        assert _timeouts(pool=db_lookup.POOL_AUTH) == 0.0
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize('pgcode', ['23505', '08006', '40P01', None])
@@ -768,6 +776,21 @@ class TestAuthDBTimeoutCounter:
         assert _timeouts() == 0.0
 
     @pytest.mark.asyncio
+    async def test_nothing_is_counted_when_metrics_are_disabled(
+            self, monkeypatch, clear_timeouts):
+        """Every instrument outside the metrics middleware is a no-op when
+        metrics are off; this one runs on the auth path, so it has to check
+        for itself rather than relying on the middleware not being
+        registered."""
+        monkeypatch.setattr(metrics_utils, 'METRICS_ENABLED', False)
+        monkeypatch.setattr(db_lookup, 'AUTH_DB_TIMEOUT_SECONDS', 5)
+
+        with pytest.raises(db_lookup.AuthDBTimeoutError):
+            await db_lookup.call_with_deadline(_raises_db_error('55P03'))
+
+        assert _timeouts() == 0.0
+
+    @pytest.mark.asyncio
     async def test_a_counting_failure_does_not_change_the_auth_answer(
             self, monkeypatch, clear_timeouts):
         """This runs with an auth-path exception in flight. A recording fault
@@ -776,10 +799,9 @@ class TestAuthDBTimeoutCounter:
         for."""
         monkeypatch.setattr(db_lookup, 'AUTH_DB_TIMEOUT_SECONDS', 5)
 
-        with mock.patch.object(
-                metrics_utils.SKY_APISERVER_AUTH_DB_TIMEOUTS_TOTAL,
-                'labels',
-                side_effect=RuntimeError('multiproc dir full')):
+        with mock.patch.object(metrics_utils.SKY_APISERVER_AUTH_TIMEOUTS_TOTAL,
+                               'labels',
+                               side_effect=RuntimeError('multiproc dir full')):
             with pytest.raises(db_lookup.AuthDBTimeoutError):
                 await db_lookup.call_with_deadline(_raises_db_error('55P03'))
 

--- a/tests/unit_tests/test_sky/server/test_auth_db_deadline.py
+++ b/tests/unit_tests/test_sky/server/test_auth_db_deadline.py
@@ -741,13 +741,15 @@ def clear_timeouts(monkeypatch):
     # Recording is gated on METRICS_ENABLED, which is a module constant read
     # at import and false unless the server was started with metrics on.
     monkeypatch.setattr(metrics_utils, 'METRICS_ENABLED', True)
-    # `_recording_failure_logged` is process-global and sticky: one test
-    # setting it as a side effect would otherwise decide whether another
-    # test sees the first-failure WARNING, and the failure would look like a
-    # logging bug rather than an ordering one.
-    monkeypatch.setattr(db_lookup, '_recording_failure_logged', False)
+    # The rate limiter is process-global and stateful: one test tripping it
+    # as a side effect would otherwise decide whether another test sees the
+    # first-failure WARNING, and the failure would look like a logging bug
+    # rather than an ordering one. Swap in a fresh one, as
+    # test_edge_error_counting.py does.
+    fresh = middleware_utils.RecordingFailureLog()
+    monkeypatch.setattr(middleware_utils, '_recording_failure_log', fresh)
     metrics_utils.SKY_APISERVER_AUTH_TIMEOUTS_TOTAL.clear()
-    yield
+    yield fresh
     metrics_utils.SKY_APISERVER_AUTH_TIMEOUTS_TOTAL.clear()
 
 
@@ -877,29 +879,28 @@ class TestAuthDBTimeoutCounter:
         """The faults this guards against are persistent, on a path that
         fires at request rate during the very incident the counter exists
         for, so an unconditional warning would flood the log exactly when it
-        needs reading."""
+        needs reading. Rate limiting is the shared one in middleware_utils,
+        so this pins that the auth path is wired into it, not that it works.
+        """
         monkeypatch.setattr(db_lookup, 'AUTH_DB_TIMEOUT_SECONDS', 5)
 
         with mock.patch.object(metrics_utils.SKY_APISERVER_AUTH_TIMEOUTS_TOTAL,
                                'labels',
                                side_effect=RuntimeError('multiproc dir full')):
-            with mock.patch.object(db_lookup.logger, 'warning') as warn:
-                with mock.patch.object(db_lookup.logger, 'debug') as debug:
-                    for _ in range(5):
-                        with pytest.raises(db_lookup.AuthDBTimeoutError):
-                            await db_lookup.call_with_deadline(
-                                _raises_db_error('55P03'))
+            with mock.patch.object(middleware_utils.logger, 'warning') as warn:
+                for _ in range(5):
+                    with pytest.raises(db_lookup.AuthDBTimeoutError):
+                        await db_lookup.call_with_deadline(
+                            _raises_db_error('55P03'))
 
-        # The deadline mapping logs its own warning per call, so count only
-        # the recording-failure ones.
         recording = [
-            c for c in warn.call_args_list if 'Failed to count' in c.args[0]
+            c for c in warn.call_args_list
+            if 'an auth-path timeout' in c.args[0]
         ]
         assert len(recording) == 1, warn.call_args_list
-        quiet = [
-            c for c in debug.call_args_list if 'Failed to count' in c.args[0]
-        ]
-        assert len(quiet) == 4, debug.call_args_list
+        # Every failure is still counted, so the suppressed ones are
+        # reported rather than lost.
+        assert clear_timeouts.failures == 5
 
     @pytest.mark.asyncio
     async def test_a_counting_failure_does_not_change_the_auth_answer(

--- a/tests/unit_tests/test_sky/server/test_auth_db_deadline.py
+++ b/tests/unit_tests/test_sky/server/test_auth_db_deadline.py
@@ -791,6 +791,49 @@ class TestAuthDBTimeoutCounter:
         assert _timeouts() == 0.0
 
     @pytest.mark.asyncio
+    async def test_a_callable_without_a_name_does_not_widen_the_label(
+            self, monkeypatch, clear_timeouts):
+        """`site` is claimed to be a closed set. Every call site in the
+        server passes a function or a bound method, but a callable with no
+        `__name__` (a partial, a class instance) must fall into one fixed
+        bucket rather than become an unbounded label value."""
+        monkeypatch.setattr(db_lookup, 'AUTH_DB_TIMEOUT_SECONDS', 5)
+        partial = functools.partial(_raises_db_error('55P03'))
+
+        with pytest.raises(db_lookup.AuthDBTimeoutError):
+            await db_lookup.call_with_deadline(partial)
+
+        assert _timeouts(site='unknown', cause='lock_timeout') == 1.0
+
+    @pytest.mark.asyncio
+    async def test_repeated_counting_failures_warn_once(self, monkeypatch,
+                                                        clear_timeouts):
+        """The faults this guards against are persistent, on a path that
+        fires at request rate during the very incident the counter exists
+        for, so an unconditional warning would flood the log exactly when it
+        needs reading."""
+        monkeypatch.setattr(db_lookup, 'AUTH_DB_TIMEOUT_SECONDS', 5)
+        monkeypatch.setattr(db_lookup, '_recording_failure_logged', False)
+
+        with mock.patch.object(metrics_utils.SKY_APISERVER_AUTH_TIMEOUTS_TOTAL,
+                               'labels',
+                               side_effect=RuntimeError('multiproc dir full')):
+            with mock.patch.object(db_lookup.logger, 'warning') as warn:
+                with mock.patch.object(db_lookup.logger, 'debug') as debug:
+                    for _ in range(5):
+                        with pytest.raises(db_lookup.AuthDBTimeoutError):
+                            await db_lookup.call_with_deadline(
+                                _raises_db_error('55P03'))
+
+        # The deadline mapping logs its own warning per call, so count only
+        # the recording-failure ones.
+        recording = [
+            c for c in warn.call_args_list if 'Failed to count' in c.args[0]
+        ]
+        assert len(recording) == 1, warn.call_args_list
+        assert debug.call_count == 4, debug.call_count
+
+    @pytest.mark.asyncio
     async def test_a_counting_failure_does_not_change_the_auth_answer(
             self, monkeypatch, clear_timeouts):
         """This runs with an auth-path exception in flight. A recording fault
@@ -837,18 +880,3 @@ class TestHealthProbeTimeoutIsOnlyVisibleHere:
         assert mock_request.state.auth_user is None
         # ...and the timeout is no longer invisible.
         assert _timeouts(cause=db_lookup.TIMEOUT_CAUSE_DEADLINE) == 1.0
-
-    @pytest.mark.asyncio
-    async def test_a_callable_without_a_name_does_not_widen_the_label(
-            self, monkeypatch, clear_timeouts):
-        """`site` is claimed to be a closed set. Every call site in the
-        server passes a function or a bound method, but a callable with no
-        `__name__` (a partial, a class instance) must fall into one fixed
-        bucket rather than become an unbounded label value."""
-        monkeypatch.setattr(db_lookup, 'AUTH_DB_TIMEOUT_SECONDS', 5)
-        partial = functools.partial(_raises_db_error('55P03'))
-
-        with pytest.raises(db_lookup.AuthDBTimeoutError):
-            await db_lookup.call_with_deadline(partial)
-
-        assert _timeouts(site='unknown', cause='lock_timeout') == 1.0

--- a/tests/unit_tests/test_sky/server/test_auth_db_deadline.py
+++ b/tests/unit_tests/test_sky/server/test_auth_db_deadline.py
@@ -680,6 +680,11 @@ def clear_timeouts(monkeypatch):
     # Recording is gated on METRICS_ENABLED, which is a module constant read
     # at import and false unless the server was started with metrics on.
     monkeypatch.setattr(metrics_utils, 'METRICS_ENABLED', True)
+    # `_recording_failure_logged` is process-global and sticky: one test
+    # setting it as a side effect would otherwise decide whether another
+    # test sees the first-failure WARNING, and the failure would look like a
+    # logging bug rather than an ordering one.
+    monkeypatch.setattr(db_lookup, '_recording_failure_logged', False)
     metrics_utils.SKY_APISERVER_AUTH_TIMEOUTS_TOTAL.clear()
     yield
     metrics_utils.SKY_APISERVER_AUTH_TIMEOUTS_TOTAL.clear()
@@ -813,7 +818,6 @@ class TestAuthDBTimeoutCounter:
         for, so an unconditional warning would flood the log exactly when it
         needs reading."""
         monkeypatch.setattr(db_lookup, 'AUTH_DB_TIMEOUT_SECONDS', 5)
-        monkeypatch.setattr(db_lookup, '_recording_failure_logged', False)
 
         with mock.patch.object(metrics_utils.SKY_APISERVER_AUTH_TIMEOUTS_TOTAL,
                                'labels',
@@ -831,7 +835,10 @@ class TestAuthDBTimeoutCounter:
             c for c in warn.call_args_list if 'Failed to count' in c.args[0]
         ]
         assert len(recording) == 1, warn.call_args_list
-        assert debug.call_count == 4, debug.call_count
+        quiet = [
+            c for c in debug.call_args_list if 'Failed to count' in c.args[0]
+        ]
+        assert len(quiet) == 4, debug.call_args_list
 
     @pytest.mark.asyncio
     async def test_a_counting_failure_does_not_change_the_auth_answer(

--- a/tests/unit_tests/test_sky/server/test_auth_db_deadline.py
+++ b/tests/unit_tests/test_sky/server/test_auth_db_deadline.py
@@ -30,6 +30,7 @@ These tests pin the containment behavior:
 # pylint: disable=protected-access,redefined-outer-name,missing-class-docstring
 
 import asyncio
+import functools
 import os
 import time
 import unittest.mock as mock
@@ -40,6 +41,7 @@ import sqlalchemy.exc
 
 from sky import exceptions
 from sky import models
+from sky.metrics import utils as metrics_utils
 from sky.server import server
 from sky.server.auth import db_lookup
 from sky.server.requests import threads
@@ -653,3 +655,178 @@ class TestServerSideTimeoutMapping:
 
         _assert_retryable_timeout_503(response)
         assert not call_next_sentinel.reached
+
+
+def _never_runs():
+    """A call the executor rejects before it ever runs."""
+    raise AssertionError('should not have been called')
+
+
+def _timeouts(**labels) -> float:
+    """Current value of the auth-DB-timeout counter for these labels."""
+    total = 0.0
+    counter = metrics_utils.SKY_APISERVER_AUTH_DB_TIMEOUTS_TOTAL
+    for family in counter.collect():
+        for sample in family.samples:
+            if not sample.name.endswith('_total'):
+                continue
+            if all(sample.labels.get(k) == v for k, v in labels.items()):
+                total += sample.value
+    return total
+
+
+@pytest.fixture
+def clear_timeouts():
+    metrics_utils.SKY_APISERVER_AUTH_DB_TIMEOUTS_TOTAL.clear()
+    yield
+    metrics_utils.SKY_APISERVER_AUTH_DB_TIMEOUTS_TOTAL.clear()
+
+
+class TestAuthDBTimeoutCounter:
+    """An auth DB call that times out must leave a trace in the metrics.
+
+    The deadline frees the caller but not the thread, so each of these costs
+    an auth executor slot until the call returns on its own. It was log-only:
+    in the 2026-09-08 incident the first one preceded the first
+    client-visible 503 by 13 minutes with nothing to alert on.
+    """
+
+    @pytest.mark.asyncio
+    async def test_the_client_side_deadline_is_counted(self, monkeypatch,
+                                                       clear_timeouts):
+        monkeypatch.setattr(db_lookup, 'AUTH_DB_TIMEOUT_SECONDS', 0.05)
+
+        def _parked(*args, **kwargs):
+            del args, kwargs
+            time.sleep(5)
+
+        with pytest.raises(asyncio.TimeoutError):
+            await db_lookup.call_with_deadline(_parked)
+
+        assert _timeouts(site='_parked',
+                         cause=db_lookup.TIMEOUT_CAUSE_DEADLINE) == 1.0
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize('pgcode, cause', [
+        ('55P03', 'lock_timeout'),
+        ('57014', 'statement_timeout'),
+        ('25P03', 'idle_in_transaction_session_timeout'),
+    ])
+    async def test_a_database_side_timeout_is_counted_by_its_setting(
+            self, monkeypatch, clear_timeouts, pgcode, cause):
+        """The two kinds mean opposite things -- the thread comes back from a
+        DB-side timeout and does not from a deadline -- so `cause` must tell
+        them apart, and a `lock_timeout` must be readable on its own."""
+        monkeypatch.setattr(db_lookup, 'AUTH_DB_TIMEOUT_SECONDS', 5)
+
+        with pytest.raises(db_lookup.AuthDBTimeoutError):
+            await db_lookup.call_with_deadline(_raises_db_error(pgcode))
+
+        assert _timeouts(cause=cause) == 1.0
+        assert _timeouts(cause=db_lookup.TIMEOUT_CAUSE_DEADLINE) == 0.0
+
+    @pytest.mark.asyncio
+    async def test_the_request_pool_variant_is_counted_too(
+            self, monkeypatch, clear_timeouts):
+        monkeypatch.setattr(db_lookup, 'AUTH_DB_TIMEOUT_SECONDS', 0.05)
+
+        def _parked_on_request_pool(*args, **kwargs):
+            del args, kwargs
+            time.sleep(5)
+
+        with pytest.raises(asyncio.TimeoutError):
+            await db_lookup._call_on_request_pool(_parked_on_request_pool)
+
+        assert _timeouts(site='_parked_on_request_pool',
+                         cause=db_lookup.TIMEOUT_CAUSE_DEADLINE) == 1.0
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize('pgcode', ['23505', '08006', '40P01', None])
+    async def test_other_db_errors_are_not_counted(self, monkeypatch,
+                                                   clear_timeouts, pgcode):
+        """Only timeouts. A unique violation or a dropped connection is a
+        different problem and must not dilute this counter."""
+        monkeypatch.setattr(db_lookup, 'AUTH_DB_TIMEOUT_SECONDS', 5)
+        with pytest.raises(sqlalchemy.exc.OperationalError):
+            await db_lookup.call_with_deadline(_raises_db_error(pgcode))
+        assert _timeouts() == 0.0
+
+    @pytest.mark.asyncio
+    async def test_executor_exhaustion_is_not_counted(self, monkeypatch,
+                                                      clear_timeouts):
+        """Exhaustion already has `sky_apiserver_threads_exhausted_total`;
+        counting it here too would double-count one event across two
+        metrics."""
+        monkeypatch.setattr(db_lookup, 'AUTH_DB_TIMEOUT_SECONDS', 5)
+        exhausted = threads.OnDemandThreadExecutor(name='test-exhausted-count',
+                                                   max_workers=0)
+        with mock.patch.object(db_lookup.executor,
+                               'get_auth_thread_executor',
+                               return_value=exhausted):
+            with pytest.raises(exceptions.ConcurrentWorkerExhaustedError):
+                await db_lookup.call_with_deadline(_never_runs)
+        assert _timeouts() == 0.0
+
+    @pytest.mark.asyncio
+    async def test_a_counting_failure_does_not_change_the_auth_answer(
+            self, monkeypatch, clear_timeouts):
+        """This runs with an auth-path exception in flight. A recording fault
+        must not replace it: that would turn the retryable 503 the client
+        needs into a bare 500, during the very DB incident this counter is
+        for."""
+        monkeypatch.setattr(db_lookup, 'AUTH_DB_TIMEOUT_SECONDS', 5)
+
+        with mock.patch.object(
+                metrics_utils.SKY_APISERVER_AUTH_DB_TIMEOUTS_TOTAL,
+                'labels',
+                side_effect=RuntimeError('multiproc dir full')):
+            with pytest.raises(db_lookup.AuthDBTimeoutError):
+                await db_lookup.call_with_deadline(_raises_db_error('55P03'))
+
+
+class TestHealthProbeTimeoutIsOnlyVisibleHere:
+    """The case that motivates counting at the choke point.
+
+    `/api/health` keeps its basic-auth lookup best-effort: on timeout it
+    proceeds unauthenticated so probes survive a DB incident. That is the
+    right behaviour and it means the request produces no error status, no
+    rejection, nothing a request-level metric can see -- while still having
+    leaked an auth executor thread. This counter is its only trace.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_swallowed_timeout_still_moves_the_counter(
+            self, mock_request, call_next_sentinel, clear_timeouts):
+        mock_request.url.path = '/api/health'
+        mock_request.headers = {'authorization': 'Basic dXNlcjpwYXNz'}
+        middleware = server.BasicAuthMiddleware(app=mock.Mock())
+
+        with mock.patch.object(server.loopback,
+                               'is_loopback_request',
+                               return_value=False), \
+                mock.patch('sky.global_user_state.get_user_by_name',
+                           _slow([])):
+            response = await middleware.dispatch(mock_request,
+                                                 call_next_sentinel)
+
+        # Unchanged: the probe still succeeds, unauthenticated.
+        assert response.status_code == 200
+        assert call_next_sentinel.reached
+        assert mock_request.state.auth_user is None
+        # ...and the timeout is no longer invisible.
+        assert _timeouts(cause=db_lookup.TIMEOUT_CAUSE_DEADLINE) == 1.0
+
+    @pytest.mark.asyncio
+    async def test_a_callable_without_a_name_does_not_widen_the_label(
+            self, monkeypatch, clear_timeouts):
+        """`site` is claimed to be a closed set. Every call site in the
+        server passes a function or a bound method, but a callable with no
+        `__name__` (a partial, a class instance) must fall into one fixed
+        bucket rather than become an unbounded label value."""
+        monkeypatch.setattr(db_lookup, 'AUTH_DB_TIMEOUT_SECONDS', 5)
+        partial = functools.partial(_raises_db_error('55P03'))
+
+        with pytest.raises(db_lookup.AuthDBTimeoutError):
+            await db_lookup.call_with_deadline(partial)
+
+        assert _timeouts(site='unknown', cause='lock_timeout') == 1.0


### PR DESCRIPTION
## Problem

An auth-path DB call that times out is the earliest signal that authentication is degrading, and it is log-only. In a production incident where the auth executor eventually saturated and every authenticated request 503d, the first deadline timeout landed **13 minutes before the first client-visible 503** — and nothing could alert on it. The request counter never saw it; no other metric did either.

The deadline is also not free. `asyncio.wait_for` frees the *caller*, never the *thread*: it cannot cancel a thread parked in a blocking libpq call. Every one of these costs an auth executor slot until the call returns on its own, so the count is a direct measure of how close that pool is to exhaustion.

## Change

One counter, incremented in `db_lookup._run_with_deadline` — the single point every auth DB call passes through.

```
sky_apiserver_auth_timeouts_total{site, cause, pool}
```

**Why at the choke point and not at the call sites.** Of the ten call sites, most convert the timeout into a retryable 503. The `/api/health` basic-auth probe does not: it swallows the timeout and proceeds unauthenticated, on purpose, so probes survive a DB incident. That request produces no error status and no rejection, so no request-level metric can see it — while the executor thread it leaked is gone all the same. Counting per caller would miss exactly the cases with no client-visible symptom, which are the early ones.

**`cause`** separates two things that mean the opposite of each other:

| cause | what happened | thread |
|---|---|---|
| `deadline` | the client-side `asyncio.wait_for` deadline elapsed | **still parked** — this is the pre-exhaustion signal |
| `lock_timeout` / `statement_timeout` / `idle_in_transaction_session_timeout` | the database ended the call at one of the bounds the auth path sets on its own transaction | comes back; `lock_timeout` says another session holds the `users` row lock |

**`pool`** is the executor the work ran on, spelled the way `sky_apiserver_threads_exhausted_total{name}` spells it so the two can be read side by side. It is load-bearing, not decoration: the deadline frees the caller and never the thread, so every `cause="deadline"` costs a slot in *that* pool until the call returns on its own.

| pool | what it means |
|---|---|
| `auth_thread_executor` (32) | short DB lookups. Losing slots here locks every authenticated request out, so this is the pre-exhaustion signal. |
| `request_thread_executor` (128) | role seeding, which reloads config and runs policy operations. Its blocker is often a policy lock rather than the database, and it is deliberately on the larger pool for that reason — **do not read it as auth-pool pressure.** |

**`site`** is the name of the function called. Bounded and not attacker-influenced — every call site passes a module-level function or a bound method, so the values are fixed at build time — but it is not only the eight OSS names: the enterprise plugin's session and RBAC middlewares and its volume gate call `call_with_deadline` with their own functions, so a hosted deployment has more. A callable without a `__name__` records `unknown` rather than widening the label.

**Not counted here:** executor exhaustion, which already has `sky_apiserver_threads_exhausted_total` — counting one event into two metrics would misstate both. The difference between this counter and the rejection/5xx counters is itself useful: it is the set of timeouts that produced no client-visible error.

Recording is guarded. It runs with an auth-path exception in flight, so a recording fault must not replace it — that would turn the retryable 503 a client needs into a bare 500 during the exact database incident this counter exists to reveal.

**No behaviour changes.** Every caller answers exactly as before; only a counter moves.

## Test plan

`pytest tests/unit_tests/test_sky/server/test_auth_db_deadline.py` (and the whole `test_sky/server/` directory) passes. New cases:

- the client-side deadline is counted, with the DB function as `site`;
- each of the three database-side timeouts is counted under its own `cause`, and is *not* counted as `deadline`;
- the request-pool variant (`_call_on_request_pool`) is counted too;
- other DB errors (unique violation, connection failure, deadlock, no SQLSTATE), non-DB errors, and executor exhaustion are **not** counted;
- a recording failure leaves the auth answer unchanged (still `AuthDBTimeoutError` → the same 503);
- a callable with no `__name__` records `site="unknown"` instead of widening the label;
- **the `/api/health` case**: the probe still returns 200 unauthenticated with `call_next` reached, and the timeout now moves the counter. This is the one the PR exists for — the request is invisible to every other metric.

Mutations, each applied alone, each breaking at least one test: dropping the deadline count (3 tests), labelling database-side timeouts as `deadline` (3), counting every exception instead of only timeouts (5), removing the recording guard (1), pinning `site` to a constant (2).

`pre-commit` clean on the changed files (isort, mypy, yapf, pylint). `db_lookup` is not on the `import sky` path and `sky.metrics.utils` was already imported there, so no import-time cost is added.

## Merge order with #10691

Independent in intent — this counter needs nothing from that PR — but the two
touch the same two files (`sky/server/auth/db_lookup.py`,
`tests/unit_tests/test_sky/server/test_auth_db_deadline.py`) and
`git merge-tree` reports content conflicts in both. Whichever merges second
rebases; the conflicts are adjacent additions, not competing changes.

One thing to fold in at that point: the recording-failure log here warns once
per process and then drops to debug, which is a flag standing in for
#10691's `middleware_utils.note_recording_failure` (per-process rate limit
with a dropped-failure count). There is a TODO on it — once #10691 is in, this
should use that instead of duplicating it.

## Follow-up, not in this PR

No alert rule yet: this needs its own noise check across the fleet before anything pages or posts on it. The counter has to exist and ship first.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10710" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
