### PR TITLE
[Test] Guard the blob-upload route scan against FastAPI router wrappers

### DIFF
--- a/tests/unit_tests/test_sky/server/test_blob_upload_metrics.py
+++ b/tests/unit_tests/test_sky/server/test_blob_upload_metrics.py
@@ -16,13 +16,22 @@ from sky.server import server
 from sky.server.blob import local_blob_storage
 
 _METRIC = 'sky_apiserver_blob_check_size_bytes'
+_UPLOAD_ROUTE_PATHS = ('/upload_v2/blob', '/upload_v2')
 
 
 @pytest.fixture(name='blob_upload_app')
 def _blob_upload_app(tmp_path, monkeypatch):
     app = fastapi.FastAPI()
-    app.router.routes.extend(route for route in server.app.routes
-                             if route.path in ('/upload_v2/blob', '/upload_v2'))
+    # FastAPI >=0.137 also puts private included-router wrappers, which have
+    # no ``path``, in ``app.routes``. The upload routes are registered on the
+    # app itself, so a guarded flat scan still reaches both.
+    upload_routes = [
+        route for route in server.app.routes
+        if getattr(route, 'path', None) in _UPLOAD_ROUTE_PATHS
+    ]
+    found_paths = {route.path for route in upload_routes}
+    assert found_paths == set(_UPLOAD_ROUTE_PATHS), found_paths
+    app.router.routes.extend(upload_routes)
     requests = []
 
     @app.middleware('http')


### PR DESCRIPTION
The `blob_upload_app` fixture in `tests/unit_tests/test_sky/server/test_blob_upload_metrics.py` copies the two `/upload_v2*` routes off the real app by scanning `server.app.routes` and reading `route.path` directly.

FastAPI >= 0.137 reworked router inclusion, so `app.routes` now also holds private `_IncludedRouter` wrappers, which have no `path`. The generator then blows up while building the fixture and all 12 tests in the file error out at setup:

```
tests/unit_tests/test_sky/server/test_blob_upload_metrics.py:25: in <genexpr>
    if route.path in ("/upload_v2/blob", "/upload_v2")
E   AttributeError: "_IncludedRouter" object has no attribute "path"
```

Our own `pytest.yml` resolves `fastapi==0.128.8`, where `app.routes` is still flat, so master is green. Downstream environments that install additional packages after `skypilot[all]` resolve a newer fastapi (seen with `fastapi==0.141.1`) and hit this.

## Summary

- Read `path` through a guarded `getattr`, the same way `tests/unit_tests/test_metrics_federation.py` already does.
- Assert that both expected paths were actually found. Both routes are registered on the app itself (`@app.get("/upload_v2/blob")`, `@app.post("/upload_v2")`), so a guarded flat scan still reaches them; if a future FastAPI reshuffle moves them under a wrapper, the fixture now fails loudly here instead of silently handing the tests an app with no routes.

The two other places in the test suite that walk `app.routes` (`test_metrics_federation.py`, `test_sky/users/test_viewer_route_coverage.py`) were already hardened for this; this file was the last unguarded one.

## Test plan

Ran the file on both fastapi versions, from an isolated `HOME` with a `fastapi==0.141.1` overlay on `PYTHONPATH` to reproduce the downstream resolution:

| arm | fastapi | result |
|---|---|---|
| this branch | 0.141.1 | `tests=12 failures=0 errors=0` |
| this branch | 0.115.13 | `tests=12 failures=0 errors=0` |
| master (fix reverted) | 0.141.1 | 12 setup errors, `AttributeError: '_IncludedRouter' object has no attribute 'path'` |
| master (fix reverted) | 0.115.13 | passes (why CI is green today) |

```bash
uv pip install --target /tmp/fa141 fastapi==0.141.1
PYTHONPATH=/tmp/fa141:$PWD pytest tests/unit_tests/test_sky/server/test_blob_upload_metrics.py -n 0
```

Also confirmed the new assertion has teeth: pointing `_UPLOAD_ROUTE_PATHS` at a non-existent path fails with `AssertionError: {'/upload_v2/blob'}` rather than letting the tests run against an empty app.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10711" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->