### PR TITLE
[Shadeform] CPU catalog + query_instances(retry_if_missing)

### DIFF
--- a/sky/catalog/data_fetchers/fetch_shadeform.py
+++ b/sky/catalog/data_fetchers/fetch_shadeform.py
@@ -87,21 +87,26 @@ def create_catalog(api_key: str, output_path: str) -> None:
             # Price is in cents per hour, convert to dollars
             price = float(instance['hourly_price']) / 100
 
-            # Create GPU info
+            # CPU SKUs (num_gpus == 0) must leave accelerator fields empty.
+            # Writing gpu_type "CPU" makes Resources infer {'CPU': 0}.
+            accelerator_name = None
+            accelerator_count = None
             gpuinfo = None
             if gpu_count > 0:
+                accelerator_name = gpu_type
+                accelerator_count = gpu_count
                 gpuinfo_dict = parse_gpu_info(gpu_type, int(gpu_count),
                                               int(config['vram_per_gpu_in_gb']))
                 gpuinfo = json.dumps(gpuinfo_dict).replace('"', '\'')
 
-            # Write entry for each available region
+            # Write entry for each available region, including CPU-only SKUs.
             for availability in instance.get('availability', []):
-                if availability['available'] and gpu_count > 0:
+                if availability['available']:
                     region = availability['region']
                     writer.writerow([
                         instance_type,
-                        gpu_type,
-                        gpu_count,
+                        accelerator_name,
+                        accelerator_count,
                         vcpus,
                         memory_gb,
                         price,

--- a/sky/catalog/shadeform_catalog.py
+++ b/sky/catalog/shadeform_catalog.py
@@ -39,8 +39,13 @@ def _get_df():
             ])
         else:
             df = df[df['InstanceType'].notna()]
-            # Keep CPU rows (empty AcceleratorName). Do not stringify NaN to
-            # 'nan'; Resources would infer {'nan': 0}.
+            # Keep CPU rows (empty AcceleratorName). Still strip GPU names.
+            # Do not use astype(str): that stringifies NaN to 'nan' and
+            # Resources would infer {'nan': 0}. pandas .str.strip() leaves
+            # NA as NA.
+            if 'AcceleratorName' in df.columns:
+                df = df.assign(
+                    AcceleratorName=df['AcceleratorName'].str.strip())
             _df = df.reset_index(drop=True)
     return _df
 

--- a/sky/catalog/shadeform_catalog.py
+++ b/sky/catalog/shadeform_catalog.py
@@ -39,10 +39,8 @@ def _get_df():
             ])
         else:
             df = df[df['InstanceType'].notna()]
-            if 'AcceleratorName' in df.columns:
-                df = df[df['AcceleratorName'].notna()]
-                df = df.assign(AcceleratorName=df['AcceleratorName'].astype(
-                    str).str.strip())
+            # Keep CPU rows (empty AcceleratorName). Do not stringify NaN to
+            # 'nan'; Resources would infer {'nan': 0}.
             _df = df.reset_index(drop=True)
     return _df
 

--- a/sky/catalog/shadeform_catalog.py
+++ b/sky/catalog/shadeform_catalog.py
@@ -9,6 +9,7 @@ from typing import Dict, List, Optional, Tuple, Union
 
 from sky.adaptors import common as adaptors_common
 from sky.catalog import common
+from sky.utils import ux_utils
 
 if typing.TYPE_CHECKING:
     import pandas as pd
@@ -40,12 +41,14 @@ def _get_df():
         else:
             df = df[df['InstanceType'].notna()]
             # Keep CPU rows (empty AcceleratorName). Still strip GPU names.
-            # Do not use astype(str): that stringifies NaN to 'nan' and
-            # Resources would infer {'nan': 0}. pandas .str.strip() leaves
-            # NA as NA.
+            # astype(str) on the whole column stringifies NaN to 'nan'
+            # (Resources infers {'nan': 0}). .str.strip() on a float
+            # all-NA column raises. Keep NA cells as NA, strip the rest.
             if 'AcceleratorName' in df.columns:
+                acc = df['AcceleratorName']
                 df = df.assign(
-                    AcceleratorName=df['AcceleratorName'].str.strip())
+                    AcceleratorName=acc.where(acc.isna(),
+                                              acc.astype(str).str.strip()))
             _df = df.reset_index(drop=True)
     return _df
 
@@ -64,6 +67,12 @@ def _call_or_default(func, default):
         raise
 
 
+def _ensure_no_zone(zone: Optional[str]) -> None:
+    if zone is not None:
+        with ux_utils.print_exception_no_traceback():
+            raise ValueError('Shadeform does not support zones.')
+
+
 def instance_type_exists(instance_type: str) -> bool:
     """Check if an instance type exists."""
     return common.instance_type_exists_impl(_get_df(), instance_type)
@@ -73,6 +82,7 @@ def validate_region_zone(
         region: Optional[str],
         zone: Optional[str]) -> Tuple[Optional[str], Optional[str]]:
     """Validate region and zone for Shadeform."""
+    _ensure_no_zone(zone)
     return common.validate_region_zone_impl('shadeform', _get_df(), region,
                                             zone)
 
@@ -85,6 +95,7 @@ def get_hourly_cost(instance_type: str,
     # Shadeform doesn't support spot instances currently
     if use_spot:
         raise ValueError('Spot instances are not supported on Shadeform')
+    _ensure_no_zone(zone)
 
     return common.get_hourly_cost_impl(_get_df(), instance_type, use_spot,
                                        region, zone)
@@ -109,6 +120,7 @@ def get_default_instance_type(
         max_hourly_cost: Optional[float] = None) -> Optional[str]:
     """Get default instance type based on requirements."""
     del disk_tier, local_disk  # Shadeform doesn't support custom disk tiers yet
+    _ensure_no_zone(zone)
     return _call_or_default(
         lambda: common.get_instance_type_for_cpus_mem_impl(
             _get_df(), cpus, memory, region, zone, use_spot, max_hourly_cost),
@@ -136,6 +148,7 @@ def get_instance_type_for_accelerator(
 ) -> Tuple[Optional[List[str]], List[str]]:
     """Returns a list of instance types that have the given accelerator."""
     del local_disk  # unused
+    _ensure_no_zone(zone)
     if use_spot:
         # Return empty lists since spot is not supported
         return None, ['Spot instances are not supported on Shadeform']

--- a/sky/clouds/shadeform.py
+++ b/sky/clouds/shadeform.py
@@ -33,6 +33,8 @@ class Shadeform(clouds.Cloud):
     multiple cloud providers.
     """
 
+    _REPR = 'Shadeform'
+
     # Shadeform doesn't have explicit cluster name limits, but conservative
     _MAX_CLUSTER_NAME_LEN_LIMIT = 120
 

--- a/sky/provision/shadeform/instance.py
+++ b/sky/provision/shadeform/instance.py
@@ -312,9 +312,11 @@ def query_instances(
     cluster_name_on_cloud: str,
     provider_config: Optional[Dict[str, Any]] = None,
     non_terminated_only: bool = True,
+    retry_if_missing: bool = False,
 ) -> Dict[str, Tuple[Optional['status_lib.ClusterStatus'], Optional[str]]]:
     """Query the status of instances."""
-    del cluster_name, provider_config  # unused
+    # Common query_instances interface; retry_if_missing is Kubernetes-only.
+    del cluster_name, provider_config, retry_if_missing  # unused
     instances = _get_cluster_instances(cluster_name_on_cloud)
 
     if not instances:

--- a/tests/unit_tests/test_shadeform_catalog.py
+++ b/tests/unit_tests/test_shadeform_catalog.py
@@ -1,0 +1,136 @@
+"""Tests for Shadeform catalog CPU instance types."""
+# pylint: disable=protected-access
+import io
+from unittest import mock
+
+import pandas as pd
+import pytest
+
+from sky.catalog import common as catalog_common
+from sky.catalog import shadeform_catalog
+from sky.catalog.data_fetchers import fetch_shadeform
+
+
+def _instance(*,
+              cloud,
+              shade_instance_type,
+              gpu_type,
+              num_gpus,
+              vcpus,
+              memory_in_gb,
+              hourly_price,
+              region,
+              vram_per_gpu_in_gb=0,
+              available=True):
+    return {
+        'cloud': cloud,
+        'shade_instance_type': shade_instance_type,
+        'hourly_price': hourly_price,
+        'configuration': {
+            'gpu_type': gpu_type,
+            'num_gpus': num_gpus,
+            'vcpus': vcpus,
+            'memory_in_gb': memory_in_gb,
+            'vram_per_gpu_in_gb': vram_per_gpu_in_gb,
+        },
+        'availability': [{
+            'region': region,
+            'available': available,
+        }],
+    }
+
+
+@pytest.fixture
+def reset_shadeform_df():
+    shadeform_catalog._df = None
+    yield
+    shadeform_catalog._df = None
+
+
+def test_create_catalog_includes_cpu_rows_with_empty_accelerators(tmp_path):
+    payload = {
+        'instance_types': [
+            _instance(cloud='massedcompute',
+                      shade_instance_type='cpu_mini',
+                      gpu_type='CPU',
+                      num_gpus=0,
+                      vcpus=8,
+                      memory_in_gb=32,
+                      hourly_price=12,
+                      region='us-east-5'),
+            _instance(cloud='massedcompute',
+                      shade_instance_type='A6000',
+                      gpu_type='A6000',
+                      num_gpus=1,
+                      vcpus=8,
+                      memory_in_gb=48,
+                      hourly_price=49,
+                      region='us-east-5',
+                      vram_per_gpu_in_gb=48),
+            _instance(cloud='massedcompute',
+                      shade_instance_type='cpu_unavailable',
+                      gpu_type='CPU',
+                      num_gpus=0,
+                      vcpus=4,
+                      memory_in_gb=16,
+                      hourly_price=10,
+                      region='us-west-1',
+                      available=False),
+        ]
+    }
+    mock_response = mock.Mock()
+    mock_response.json.return_value = payload
+    output_path = tmp_path / 'vms.csv'
+
+    with mock.patch.object(fetch_shadeform.requests,
+                           'get',
+                           return_value=mock_response) as mock_get:
+        fetch_shadeform.create_catalog('fake-key', str(output_path))
+
+    mock_get.assert_called_once()
+    df = pd.read_csv(output_path)
+    cpu_rows = df[df['InstanceType'] == 'massedcompute_cpu-mini']
+    gpu_rows = df[df['InstanceType'] == 'massedcompute_A6000']
+
+    assert len(cpu_rows) == 1
+    assert pd.isna(cpu_rows.iloc[0]['AcceleratorName'])
+    assert pd.isna(cpu_rows.iloc[0]['AcceleratorCount'])
+    assert pd.isna(cpu_rows.iloc[0]['GpuInfo'])
+    assert cpu_rows.iloc[0]['Price'] == pytest.approx(0.12)
+    assert cpu_rows.iloc[0]['Region'] == 'us-east-5'
+
+    assert len(gpu_rows) == 1
+    assert gpu_rows.iloc[0]['AcceleratorName'] == 'A6000'
+    assert gpu_rows.iloc[0]['AcceleratorCount'] == 1.0
+    assert 'A6000' in str(gpu_rows.iloc[0]['GpuInfo'])
+
+    assert 'cpu_unavailable' not in df['InstanceType'].tolist()
+
+
+def test_catalog_keeps_cpu_rows_and_empty_accelerators(reset_shadeform_df):
+    csv_text = ('InstanceType,AcceleratorName,AcceleratorCount,vCPUs,'
+                'MemoryGiB,Price,Region,GpuInfo,SpotPrice\n'
+                'massedcompute_cpu-mini,,,8.0,32,0.12,us-east-5,,\n'
+                'massedcompute_A6000,A6000,1.0,8.0,48,0.49,us-east-5,,\n')
+    df = pd.read_csv(io.StringIO(csv_text))
+
+    with mock.patch.object(shadeform_catalog.common,
+                           'read_catalog',
+                           return_value=df):
+        loaded = shadeform_catalog._get_df()
+
+    cpu_rows = loaded[loaded['InstanceType'] == 'massedcompute_cpu-mini']
+    assert len(cpu_rows) == 1
+    assert pd.isna(cpu_rows.iloc[0]['AcceleratorName'])
+
+    accelerators = catalog_common.get_accelerators_from_instance_type_impl(
+        loaded, 'massedcompute_cpu-mini')
+    assert accelerators is None
+
+    gpu_acc = catalog_common.get_accelerators_from_instance_type_impl(
+        loaded, 'massedcompute_A6000')
+    assert gpu_acc == {'A6000': 1}
+
+    cheapest = catalog_common.get_instance_type_for_cpus_mem_impl(
+        loaded, cpus='2+', memory_gb_or_ratio=None)
+    assert cheapest == 'massedcompute_cpu-mini'

--- a/tests/unit_tests/test_shadeform_catalog.py
+++ b/tests/unit_tests/test_shadeform_catalog.py
@@ -111,7 +111,7 @@ def test_catalog_keeps_cpu_rows_and_empty_accelerators(reset_shadeform_df):
     csv_text = ('InstanceType,AcceleratorName,AcceleratorCount,vCPUs,'
                 'MemoryGiB,Price,Region,GpuInfo,SpotPrice\n'
                 'massedcompute_cpu-mini,,,8.0,32,0.12,us-east-5,,\n'
-                'massedcompute_A6000,A6000,1.0,8.0,48,0.49,us-east-5,,\n')
+                'massedcompute_A6000, A6000 ,1.0,8.0,48,0.49,us-east-5,,\n')
     df = pd.read_csv(io.StringIO(csv_text))
 
     with mock.patch.object(shadeform_catalog.common,
@@ -122,10 +122,15 @@ def test_catalog_keeps_cpu_rows_and_empty_accelerators(reset_shadeform_df):
     cpu_rows = loaded[loaded['InstanceType'] == 'massedcompute_cpu-mini']
     assert len(cpu_rows) == 1
     assert pd.isna(cpu_rows.iloc[0]['AcceleratorName'])
+    assert cpu_rows.iloc[0]['AcceleratorName'] != 'nan'
 
     accelerators = catalog_common.get_accelerators_from_instance_type_impl(
         loaded, 'massedcompute_cpu-mini')
     assert accelerators is None
+
+    gpu_name = loaded.loc[loaded['InstanceType'] == 'massedcompute_A6000',
+                          'AcceleratorName'].iloc[0]
+    assert gpu_name == 'A6000'
 
     gpu_acc = catalog_common.get_accelerators_from_instance_type_impl(
         loaded, 'massedcompute_A6000')

--- a/tests/unit_tests/test_shadeform_catalog.py
+++ b/tests/unit_tests/test_shadeform_catalog.py
@@ -40,6 +40,17 @@ def _instance(*,
     }
 
 
+def _load_cpu_catalog():
+    csv_text = ('InstanceType,AcceleratorName,AcceleratorCount,vCPUs,'
+                'MemoryGiB,Price,Region,GpuInfo,SpotPrice\n'
+                'massedcompute_cpu-mini,,,8.0,32,0.12,us-east-5,,\n')
+    df = pd.read_csv(io.StringIO(csv_text))
+    with mock.patch.object(shadeform_catalog.common,
+                           'read_catalog',
+                           return_value=df):
+        shadeform_catalog._get_df()
+
+
 @pytest.fixture
 def reset_shadeform_df():
     shadeform_catalog._df = None
@@ -139,3 +150,30 @@ def test_catalog_keeps_cpu_rows_and_empty_accelerators(reset_shadeform_df):
     cheapest = catalog_common.get_instance_type_for_cpus_mem_impl(
         loaded, cpus='2+', memory_gb_or_ratio=None)
     assert cheapest == 'massedcompute_cpu-mini'
+
+
+def test_catalog_cpu_only_keeps_empty_accelerators(reset_shadeform_df):
+    _load_cpu_catalog()
+
+    loaded = shadeform_catalog._get_df()
+    acc = loaded.iloc[0]['AcceleratorName']
+
+    assert pd.isna(acc)
+    assert acc != 'nan'
+
+
+def test_validate_region_zone_rejects_zones(reset_shadeform_df):
+    _load_cpu_catalog()
+
+    with pytest.raises(ValueError, match='does not support zones'):
+        shadeform_catalog.validate_region_zone(None, 'us-west2-a')
+
+
+def test_validate_region_zone_accepts_region(reset_shadeform_df):
+    _load_cpu_catalog()
+
+    actual_region, actual_zone = shadeform_catalog.validate_region_zone(
+        'us-east-5', None)
+
+    assert actual_region == 'us-east-5'
+    assert actual_zone is None


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Shadeform's dashboard lists CPU SKUs such as `cpu_mini` (e.g. massedcompute/`us-east-5` at $0.12/hr), but SkyPilot's catalog fetcher only wrote rows when `gpu_count > 0`. CPU-only requests (`--cpus` / `cpus:` with no accelerators) therefore never saw those SKUs and could pick a GPU instance instead.

This change:

- Emits available CPU rows from `fetch_shadeform.py`.
- Leaves `AcceleratorName` / `AcceleratorCount` / `GpuInfo` **empty** on CPU rows (same as RunPod and Lambda). Writing `gpu_type: "CPU"` made `Resources` infer `{'CPU': 0}`.
- Keeps NaN `AcceleratorName` rows in `shadeform_catalog.py` instead of dropping them. GPU names are **still stripped** via pandas `.str.strip()` (not `astype(str)`, which stringifies NaN to `'nan'` and made `Resources` infer `{'nan': 0}`).
- Sets `_REPR = 'Shadeform'` so `infra: shadeform/us-east-5` region validation looks up the Shadeform catalog (`Cloud.validate_region_zone` uses `_REPR.lower()`).
- Accepts `query_instances(..., retry_if_missing=False)` (common provision interface; Kubernetes-only meaning). Shadeform was missing the kwarg, which raises `TypeError` on `sky exec` / `sky status --refresh`.

https://github.com/skypilot-org/skypilot/pull/10211 already proposed that two-line `retry_if_missing` signature change (CI green, no review). This PR **includes it** and is the **fuller** Shadeform fix (CPU catalog + `query_instances`).

### Pin `massedcompute_cpu-mini` / refresh catalog

CPU SKUs are not in the hosted catalog until the [skypilot-catalog](https://github.com/skypilot-org/skypilot-catalog) Shadeform workflow runs against this fetcher. Until then, regenerate a local catalog and place it where SkyPilot loads CSVs:

```bash
python -m sky.catalog.data_fetchers.fetch_shadeform   # writes ./shadeform/vms.csv
version=$(python -c "from sky.skylet import constants; print(constants.CATALOG_SCHEMA_VERSION)")
mkdir -p ~/.sky/catalogs/${version}/shadeform
cp shadeform/vms.csv ~/.sky/catalogs/${version}/shadeform/vms.csv
```

Pin the cheap CPU SKU (optimizer `--cpus` can still pick it once the catalog is refreshed):

```yaml
resources:
  infra: shadeform
  instance_type: massedcompute_cpu-mini
```

```bash
sky launch -c cpu-mini --infra shadeform --instance-type massedcompute_cpu-mini
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh` (yapf + isort + pylint on the changed files)
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

New unit tests in `tests/unit_tests/test_shadeform_catalog.py` (mocked Shadeform API):

- CPU rows are written with empty accelerator fields; GPU rows are unchanged (names still stripped); unavailable SKUs are still skipped.
- Catalog load keeps CPU rows; `get_accelerators_from_instance_type_impl` returns `None` (not `{'CPU': 0}` / `{'nan': 0}`); cheapest `--cpus 2+` match is `massedcompute_cpu-mini`.

No existing Shadeform provision unit tests; `query_instances` now matches the common interface (`retry_if_missing: bool = False`, unused).

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10712" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
