### PR TITLE
[Server] Refuse an upload that cannot fit on the server's local disk

### DIFF
--- a/sky/client/common.py
+++ b/sky/client/common.py
@@ -47,15 +47,6 @@ logger = sky_logging.init_logger(__name__)
 
 # The chunk size for downloading the logs from the API server.
 _DOWNLOAD_CHUNK_BYTES = 8192
-# The chunk size for the zip file to be uploaded to the API server. We split
-# the zip file into chunks to avoid network issues for large request body that
-# can be caused by NGINX's client_max_body_size or Cloudflare's upload limit.
-# As of 09/25/2025, the upload limit for Cloudflare's free plan is 100MB
-# (not 100MiB; 100MB = 100,000,000 bytes):
-# https://developers.cloudflare.com/support/troubleshooting/http-status-codes/4xx-client-error/error-413/
-# We use 95MB to leave headroom for HTTP headers and request overhead.
-_UPLOAD_CHUNK_BYTES = 95 * 1000 * 1000
-
 FILE_UPLOAD_LOGS_DIR = os.path.join(constants.SKY_LOGS_DIRECTORY,
                                     'file_uploads')
 _FILE_UPLOAD_LOCK_DIR = '~/.sky/locks/file_uploads'
@@ -212,7 +203,8 @@ def _upload_chunk_with_retry(params: UploadChunkParams) -> str:
                     'chunk_index': str(params.chunk_index),
                     'total_chunks': str(params.total_chunks),
                 },
-                content=FileChunkIterator(f, _UPLOAD_CHUNK_BYTES,
+                content=FileChunkIterator(f,
+                                          server_constants.UPLOAD_CHUNK_BYTES,
                                           params.chunk_index),
                 headers={
                     'Content-Type': 'application/octet-stream',
@@ -407,7 +399,8 @@ def upload_mounts_to_api_server(
                         status: rich_utils.GeneralStatus,
                         upload_logger: logging.Logger):
             zip_file_size = os.path.getsize(zip_file_path)
-            total_chunks = int(math.ceil(zip_file_size / _UPLOAD_CHUNK_BYTES))
+            total_chunks = int(
+                math.ceil(zip_file_size / server_constants.UPLOAD_CHUNK_BYTES))
             timeout = httpx.Timeout(None, read=180.0)
             status.update(
                 ux_utils.spinner_message(

--- a/sky/server/constants.py
+++ b/sky/server/constants.py
@@ -178,6 +178,21 @@ DEFAULT_LOGS_RETENTION_HOURS = 720  # 30 days
 # to Loki (e.g., GPU inventory from billing plugin).
 SERVER_HEARTBEAT_INTERVAL_SECONDS = 600  # 10 minutes
 
+# The chunk size for the zip file to be uploaded to the API server. We split
+# the zip file into chunks to avoid network issues for large request body that
+# can be caused by NGINX's client_max_body_size or Cloudflare's upload limit.
+# As of 09/25/2025, the upload limit for Cloudflare's free plan is 100MB
+# (not 100MiB; 100MB = 100,000,000 bytes):
+# https://developers.cloudflare.com/support/troubleshooting/http-status-codes/4xx-client-error/error-413/
+# We use 95MB to leave headroom for HTTP headers and request overhead.
+UPLOAD_CHUNK_BYTES = 95 * 1000 * 1000
+
+# Largest total upload the server accepts, as declared by the chunk count.
+# Checked before any chunk is written, and independently of how much local
+# disk is free: an upload is extracted later, so the space available at
+# extraction time cannot be known here.
+MAX_UPLOAD_TOTAL_BYTES = 100 * 1000 * 1000 * 1000  # 100 GB
+
 # Interval for the daemon that sweeps expired managed-job API access tokens
 # from the service_account_tokens table. These tokens are normally revoked
 # by the jobs controller on completion, but the daemon ensures any tokens

--- a/sky/server/local_disk.py
+++ b/sky/server/local_disk.py
@@ -257,6 +257,20 @@ def budget() -> Optional[Budget]:
     return None
 
 
+def available_bytes() -> Optional[int]:
+    """Bytes still writable before this container reaches its budget.
+
+    Measures against the declared allowance -- the limit if there is one,
+    otherwise the request -- so a caller can refuse work that would not
+    fit. Returns None when neither field is exposed, which means the
+    caller has no budget to check against.
+    """
+    declared = budget()
+    if declared is None:
+        return None
+    return max(declared.total_bytes - scan().used_bytes, 0)
+
+
 def _count_unreadable(error: OSError) -> int:
     """Returns 1 if *error* hides bytes from the walk, 0 if it does not."""
     return 0 if error.errno == errno.ENOENT else 1

--- a/sky/server/local_disk.py
+++ b/sky/server/local_disk.py
@@ -25,8 +25,10 @@ Three notes on matching what the platform sees:
 * Not every root is charged to the container. A deployment can mount a
   persistent volume partway into the tree -- the same directory is local in
   one layout and shared in another -- and those bytes belong to the volume's
-  budget, not this container's. Each filesystem is classified, and only the
-  charged roots are compared against the budget.
+  budget, not this container's. Each filesystem is classified, and a root
+  that is not charged is left unwalked: its bytes do not count either way,
+  and it is where a network filesystem turns up, on which walking many
+  small files takes minutes rather than milliseconds.
 """
 import dataclasses
 import errno
@@ -71,7 +73,7 @@ DEFAULT_SCAN_MAX_ENTRIES = 2_000_000
 DEFAULT_USED_BYTES_TTL_SECONDS = 10.0
 
 _used_bytes_lock = threading.Lock()
-_used_bytes_cache: Optional[Tuple[float, int]] = None
+_used_bytes_cache: Optional[Tuple[float, int, bool]] = None
 # Bytes callers have admitted but that no walk has counted yet. Cleared by
 # the next walk, which sees them on disk.
 _admitted_bytes = 0
@@ -98,6 +100,9 @@ class RootUsage:
     # having gone away. Those bytes are missing from used_bytes, so a
     # non-zero count means the size is a lower bound.
     unreadable: int = 0
+    # False when the root was skipped rather than measured, so a zero here
+    # is not a measurement.
+    walked: bool = True
     # Mount point of the filesystem holding this root, so a root can be
     # joined to its entry in Snapshot.filesystems. None if it could not
     # be determined.
@@ -158,6 +163,11 @@ class Snapshot:
         return filesystem is not None and filesystem.charged_to_ephemeral
 
     @property
+    def truncated(self) -> bool:
+        """Whether any walk stopped early, making ``used_bytes`` partial."""
+        return any(usage.truncated for usage in self.roots.values())
+
+    @property
     def headroom_bytes(self) -> Optional[int]:
         """Room left before the budget stops the server writing.
 
@@ -182,10 +192,11 @@ def local_roots() -> Dict[str, str]:
     HOME are honored the way the owning modules resolve their own paths,
     and so a blob storage backend installed after import is included.
 
-    Deliberately excludes ``~/sky_logs``: in multi-replica deployments it
-    is on shared storage, where it does not count against this container's
-    local disk and where a directory walk is prohibitively slow. Its
+    Excludes ``~/sky_logs`` outright: it does not count against this
+    container's local disk in any layout that persists it, and its
     filesystem is already reported by the sky_logs retention instruments.
+    Roots that turn out to be on a volume are dropped later, by ``scan``,
+    which is what knows their filesystem.
     """
     roots = {
         'request_logs': runtime_utils.expanduser(
@@ -284,7 +295,12 @@ def available_bytes(
     declared = budget()
     if declared is None:
         return None
-    return max(declared.total_bytes - _used_bytes(max_age_seconds), 0)
+    used, truncated = _used_bytes(max_age_seconds)
+    if truncated:
+        # A partial walk under-reports usage, which would overstate what is
+        # left. Report no budget bound rather than a generous one.
+        return None
+    return max(declared.total_bytes - used, 0)
 
 
 def debit(num_bytes: int) -> None:
@@ -302,8 +318,8 @@ def debit(num_bytes: int) -> None:
         _admitted_bytes += num_bytes
 
 
-def _used_bytes(max_age_seconds: float) -> int:
-    """Returns the used-bytes total, walking if the cache has aged out.
+def _used_bytes(max_age_seconds: float) -> Tuple[int, bool]:
+    """Returns (used bytes, whether the walk behind it was partial).
 
     The lock spans the walk so a burst of callers arriving on a cold
     cache produces one walk rather than one each.
@@ -313,11 +329,12 @@ def _used_bytes(max_age_seconds: float) -> int:
         cached = _used_bytes_cache
         if (cached is not None and
                 time.monotonic() - cached[0] <= max_age_seconds):
-            return cached[1] + _admitted_bytes
-        used = scan().used_bytes
-        _used_bytes_cache = (time.monotonic(), used)
+            return cached[1] + _admitted_bytes, cached[2]
+        snapshot = scan()
+        _used_bytes_cache = (time.monotonic(), snapshot.used_bytes,
+                             snapshot.truncated)
         _admitted_bytes = 0
-        return used
+        return snapshot.used_bytes, snapshot.truncated
 
 
 def _nearest_existing(path: str) -> str:
@@ -552,22 +569,39 @@ def scan(
     timeout_seconds: float = DEFAULT_SCAN_TIMEOUT_SECONDS,
     max_entries: int = DEFAULT_SCAN_MAX_ENTRIES,
 ) -> Snapshot:
-    """Measures every local root, sharing one deadline across all of them."""
+    """Measures the roots that count, sharing one deadline across them.
+
+    A root on a filesystem the platform does not charge to this container
+    is not walked. Its bytes are excluded from the total either way, and
+    such a root is where a persistent volume gets mounted -- on a network
+    filesystem, where a walk of many small files takes minutes. The
+    filesystem behind it is still reported; for a volume shared between
+    replicas its free space is the meaningful number anyway.
+    """
     started = time.monotonic()
     deadline = started + timeout_seconds
+    # Not in use in this deployment; emitting a 0 would read as a measured
+    # emptiness.
+    present = [(name, path)
+               for name, path in local_roots().items()
+               if os.path.isdir(path)]
+    filesystems = _filesystem_usage([path for _, path in present])
     roots: Dict[str, RootUsage] = {}
-    measured: List[Tuple[str, str]] = []
-    for name, path in local_roots().items():
-        if not os.path.isdir(path):
-            # Not in use in this deployment; emitting a 0 would read as a
-            # measured emptiness.
+    for name, path in present:
+        mountpoint = _mountpoint(path)
+        filesystem = filesystems.get(mountpoint) if mountpoint else None
+        if filesystem is None or not filesystem.charged_to_ephemeral:
+            roots[name] = RootUsage(path=path,
+                                    used_bytes=0,
+                                    files=0,
+                                    truncated=False,
+                                    walked=False,
+                                    mountpoint=mountpoint)
             continue
-        measured.append((name, path))
         usage = _scan_root(path, deadline, max_entries)
-        usage.mountpoint = _mountpoint(path)
+        usage.mountpoint = mountpoint
         roots[name] = usage
     return Snapshot(roots=roots,
-                    filesystems=_filesystem_usage(
-                        [path for _, path in measured]),
+                    filesystems=filesystems,
                     budget=budget(),
                     duration_seconds=time.monotonic() - started)

--- a/sky/server/local_disk.py
+++ b/sky/server/local_disk.py
@@ -72,6 +72,9 @@ DEFAULT_USED_BYTES_TTL_SECONDS = 10.0
 
 _used_bytes_lock = threading.Lock()
 _used_bytes_cache: Optional[Tuple[float, int]] = None
+# Bytes callers have admitted but that no walk has counted yet. Cleared by
+# the next walk, which sees them on disk.
+_admitted_bytes = 0
 
 # Bytes per st_blocks unit, fixed by POSIX regardless of the filesystem's
 # own block size.
@@ -284,21 +287,72 @@ def available_bytes(
     return max(declared.total_bytes - _used_bytes(max_age_seconds), 0)
 
 
+def debit(num_bytes: int) -> None:
+    """Counts *num_bytes* as used until the next walk of the roots.
+
+    Lets concurrent callers see work each other has admitted but not yet
+    written. Without it they measure against the same free space and
+    overcommit together, and a caller arriving just after a completed
+    write measures against a total that predates it.
+    """
+    global _admitted_bytes
+    if num_bytes <= 0:
+        return
+    with _used_bytes_lock:
+        _admitted_bytes += num_bytes
+
+
 def _used_bytes(max_age_seconds: float) -> int:
-    """Returns the cached used-bytes total, walking if it has aged out.
+    """Returns the used-bytes total, walking if the cache has aged out.
 
     The lock spans the walk so a burst of callers arriving on a cold
     cache produces one walk rather than one each.
     """
-    global _used_bytes_cache
+    global _used_bytes_cache, _admitted_bytes
     with _used_bytes_lock:
         cached = _used_bytes_cache
         if (cached is not None and
                 time.monotonic() - cached[0] <= max_age_seconds):
-            return cached[1]
+            return cached[1] + _admitted_bytes
         used = scan().used_bytes
         _used_bytes_cache = (time.monotonic(), used)
+        _admitted_bytes = 0
         return used
+
+
+def _nearest_existing(path: str) -> str:
+    """Returns *path*, or its closest ancestor that exists."""
+    current = os.path.abspath(path)
+    while not os.path.exists(current):
+        parent = os.path.dirname(current)
+        if parent == current:
+            break
+        current = parent
+    return current
+
+
+def available_for_path(
+    path: str,
+    max_age_seconds: float = DEFAULT_USED_BYTES_TTL_SECONDS,
+) -> Optional[int]:
+    """Bytes writable at *path*, by whichever boundary applies to it.
+
+    A destination the platform does not charge to this container -- a
+    persistent volume, say -- is bounded by the free space on its own
+    filesystem and not by the container's ephemeral-storage budget. A
+    destination that is charged is bounded by both. Returns None when
+    neither boundary can be determined.
+    """
+    filesystems = _filesystem_usage([_nearest_existing(path)])
+    if not filesystems:
+        return None
+    filesystem = next(iter(filesystems.values()))
+    bounds = [filesystem.avail_bytes]
+    if filesystem.charged_to_ephemeral:
+        against_budget = available_bytes(max_age_seconds)
+        if against_budget is not None:
+            bounds.append(against_budget)
+    return min(bounds)
 
 
 def _count_unreadable(error: OSError) -> int:

--- a/sky/server/local_disk.py
+++ b/sky/server/local_disk.py
@@ -31,6 +31,7 @@ Three notes on matching what the platform sees:
 import dataclasses
 import errno
 import os
+import threading
 import time
 from typing import Dict, List, Optional, Tuple
 
@@ -65,6 +66,12 @@ BUDGET_SOURCE_REQUEST = 'request'
 # is never mistaken for a small one.
 DEFAULT_SCAN_TIMEOUT_SECONDS = 20.0
 DEFAULT_SCAN_MAX_ENTRIES = 2_000_000
+
+# How long available_bytes() reuses one walk of the roots.
+DEFAULT_USED_BYTES_TTL_SECONDS = 10.0
+
+_used_bytes_lock = threading.Lock()
+_used_bytes_cache: Optional[Tuple[float, int]] = None
 
 # Bytes per st_blocks unit, fixed by POSIX regardless of the filesystem's
 # own block size.
@@ -257,18 +264,41 @@ def budget() -> Optional[Budget]:
     return None
 
 
-def available_bytes() -> Optional[int]:
+def available_bytes(
+        max_age_seconds: float = DEFAULT_USED_BYTES_TTL_SECONDS
+) -> Optional[int]:
     """Bytes still writable before this container reaches its budget.
 
     Measures against the declared allowance -- the limit if there is one,
     otherwise the request -- so a caller can refuse work that would not
     fit. Returns None when neither field is exposed, which means the
     caller has no budget to check against.
+
+    The walk behind the used-bytes term is cached for *max_age_seconds*.
+    Its cost scales with the number of files on disk and not with the
+    caller's payload, so walking per call would dominate a small one.
     """
     declared = budget()
     if declared is None:
         return None
-    return max(declared.total_bytes - scan().used_bytes, 0)
+    return max(declared.total_bytes - _used_bytes(max_age_seconds), 0)
+
+
+def _used_bytes(max_age_seconds: float) -> int:
+    """Returns the cached used-bytes total, walking if it has aged out.
+
+    The lock spans the walk so a burst of callers arriving on a cold
+    cache produces one walk rather than one each.
+    """
+    global _used_bytes_cache
+    with _used_bytes_lock:
+        cached = _used_bytes_cache
+        if (cached is not None and
+                time.monotonic() - cached[0] <= max_age_seconds):
+            return cached[1]
+        used = scan().used_bytes
+        _used_bytes_cache = (time.monotonic(), used)
+        return used
 
 
 def _count_unreadable(error: OSError) -> int:

--- a/sky/server/metrics.py
+++ b/sky/server/metrics.py
@@ -537,7 +537,10 @@ _LOCAL_DISK_ROOT_CHARGED_HELP = (
     'a persistent volume or a memory-backed tmpfs mounted into the tree. '
     'Only the roots marked 1 go into '
     'sky_apiserver_local_disk_headroom_bytes, so this is what makes that '
-    'number reproducible from the per-root series.')
+    'number reproducible from the per-root series. A root marked 0 is not '
+    'measured at all -- it reports no size or file count -- because a '
+    'volume is where a network filesystem turns up and walking one is '
+    'prohibitively slow.')
 
 _LOCAL_DISK_SCAN_DURATION_HELP = (
     'Wall-clock seconds the last walk of all local roots took. Runs off the '
@@ -633,12 +636,15 @@ class LocalDiskUsageCollector:
             _LOCAL_DISK_UNREADABLE_HELP,
             labels=['root'])
         for root, usage in snapshot.roots.items():
+            charged.add_metric(
+                [root], 1 if snapshot.is_charged_to_ephemeral(root) else 0)
+            if not usage.walked:
+                # A zero here would read as a measurement.
+                continue
             used.add_metric([root], usage.used_bytes)
             files.add_metric([root], usage.files)
             truncated.add_metric([root], 1 if usage.truncated else 0)
             unreadable.add_metric([root], usage.unreadable)
-            charged.add_metric(
-                [root], 1 if snapshot.is_charged_to_ephemeral(root) else 0)
         yield used
         yield files
         yield truncated

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -1793,23 +1793,64 @@ def _publish_chunk(zip_file_path: pathlib.Path, final_path: pathlib.Path,
     return set(f'part{i}' for i in range(total_chunks)) - existing
 
 
+# Filesystem allocation unit assumed when sizing an extraction. Every
+# mainstream filesystem the server runs on uses 4 KiB.
+_EXTRACT_BLOCK_BYTES = 4096
+
+
 def _gb(num_bytes: int) -> str:
     return f'{num_bytes / 1000 ** 3:.1f} GB'
 
 
-def _check_extraction_fits(members: List[zipfile.ZipInfo]) -> None:
-    """Raises if extracting *members* would exhaust the local-disk budget."""
-    available = local_disk.available_bytes()
+def _upload_too_large(num_bytes: int) -> fastapi.HTTPException:
+    return fastapi.HTTPException(
+        status_code=413,
+        detail=(f'Upload of {_gb(num_bytes)} exceeds the '
+                f'{_gb(server_constants.MAX_UPLOAD_TOTAL_BYTES)} limit on a '
+                'single upload. Upload fewer or smaller files.'))
+
+
+def _stored_bytes(directory: Optional[pathlib.Path]) -> int:
+    """Bytes the chunks already received for one upload occupy."""
+    if directory is None:
+        return 0
+    total = 0
+    try:
+        with os.scandir(directory) as entries:
+            for entry in entries:
+                if entry.is_file(follow_symlinks=False):
+                    total += entry.stat(follow_symlinks=False).st_size
+    except OSError:
+        return 0
+    return total
+
+
+def _on_disk_bytes(members: List[zipfile.ZipInfo]) -> int:
+    """Disk the extracted *members* occupy, in whole filesystem blocks.
+
+    An archive of many tiny files costs far more on disk than the sum of
+    its apparent sizes, and the same rounding is what the accounting side
+    measures.
+    """
+    return sum(
+        max(-(-member.file_size // _EXTRACT_BLOCK_BYTES), 1) *
+        _EXTRACT_BLOCK_BYTES for member in members)
+
+
+def _check_extraction_fits(members: List[zipfile.ZipInfo],
+                           target_dir: pathlib.Path) -> None:
+    """Raises if extracting *members* into *target_dir* would not fit."""
+    available = local_disk.available_for_path(str(target_dir))
     if available is None:
         return
-    needed = sum(member.file_size for member in members)
+    needed = _on_disk_bytes(members)
     if needed > available:
         raise fastapi.HTTPException(
             status_code=507,
-            detail=(f'Extracting this upload needs {_gb(needed)} of local '
-                    f'disk, but only {_gb(available)} of the API server\'s '
-                    'ephemeral-storage budget is left. Upload fewer or '
-                    'smaller files.'))
+            detail=(f'Extracting this upload needs {_gb(needed)} of disk '
+                    f'under {target_dir}, but only {_gb(available)} is '
+                    'available there. Upload fewer or smaller files.'))
+    local_disk.debit(needed)
 
 
 async def _receive_and_assemble_chunks(
@@ -1850,12 +1891,7 @@ async def _receive_and_assemble_chunks(
         )
     declared_bytes = total_chunks * server_constants.UPLOAD_CHUNK_BYTES
     if declared_bytes > server_constants.MAX_UPLOAD_TOTAL_BYTES:
-        raise fastapi.HTTPException(
-            status_code=413,
-            detail=(
-                f'Upload of {_gb(declared_bytes)} exceeds the '
-                f'{_gb(server_constants.MAX_UPLOAD_TOTAL_BYTES)} limit on a '
-                'single upload. Upload fewer or smaller files.'))
+        raise _upload_too_large(declared_bytes)
     # Write chunk to a unique private path first, so concurrent uploads for
     # a same blob does not interleave with each other.
     if total_chunks == 1:
@@ -1870,9 +1906,19 @@ async def _receive_and_assemble_chunks(
         final_path = chunk_dir / f'part{chunk_index}'
         zip_file_path = chunk_dir / f'part{chunk_index}.tmp.{uuid.uuid4().hex}'
 
+    # The declared chunk count bounds nothing on its own: a client is free
+    # to stream a chunk of any size. Bound what this upload has actually
+    # put on disk, across its chunks.
+    stored = await asyncio.to_thread(_stored_bytes,
+                                     chunk_dir if total_chunks > 1 else None)
+    allowance = server_constants.MAX_UPLOAD_TOTAL_BYTES - stored
     try:
+        written = 0
         async with aiofiles.open(zip_file_path, 'wb') as f:
             async for chunk in request.stream():
+                written += len(chunk)
+                if written > allowance:
+                    raise _upload_too_large(stored + written)
                 await f.write(chunk)
     except starlette.requests.ClientDisconnect as e:
         # Client disconnected, remove the zip file.
@@ -1880,6 +1926,9 @@ async def _receive_and_assemble_chunks(
         raise fastapi.HTTPException(
             status_code=400,
             detail='Client disconnected, please try again.') from e
+    except fastapi.HTTPException:
+        await asyncio.to_thread(zip_file_path.unlink, missing_ok=True)
+        raise
     except Exception as e:
         logger.error(f'Error uploading zip file: {zip_file_path}')
         # Client disconnected, remove the zip file.
@@ -2092,7 +2141,7 @@ async def unzip_file(zip_file_path: pathlib.Path,
         try:
             with zipfile.ZipFile(zip_file_path, 'r') as zipf:
                 members = zipf.infolist()
-                _check_extraction_fits(members)
+                _check_extraction_fits(members, client_file_mounts_dir)
                 for member in members:
                     # Determine the new path
                     original_path = os.path.normpath(member.filename)

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -68,6 +68,7 @@ from sky.server import constants as server_constants
 from sky.server import csp_utils
 from sky.server import daemons
 from sky.server import download_utils
+from sky.server import local_disk
 from sky.server import loop_stall
 from sky.server import metrics
 from sky.server import middleware_utils
@@ -1792,6 +1793,25 @@ def _publish_chunk(zip_file_path: pathlib.Path, final_path: pathlib.Path,
     return set(f'part{i}' for i in range(total_chunks)) - existing
 
 
+def _gb(num_bytes: int) -> str:
+    return f'{num_bytes / 1000 ** 3:.1f} GB'
+
+
+def _check_extraction_fits(members: List[zipfile.ZipInfo]) -> None:
+    """Raises if extracting *members* would exhaust the local-disk budget."""
+    available = local_disk.available_bytes()
+    if available is None:
+        return
+    needed = sum(member.file_size for member in members)
+    if needed > available:
+        raise fastapi.HTTPException(
+            status_code=507,
+            detail=(f'Extracting this upload needs {_gb(needed)} of local '
+                    f'disk, but only {_gb(available)} of the API server\'s '
+                    'ephemeral-storage budget is left. Upload fewer or '
+                    'smaller files.'))
+
+
 async def _receive_and_assemble_chunks(
     base_dir: pathlib.Path,
     zip_name: str,
@@ -1828,6 +1848,14 @@ async def _receive_and_assemble_chunks(
         raise ValueError(
             f'Invalid total_chunks: {total_chunks}. Please use a valid integer.'
         )
+    declared_bytes = total_chunks * server_constants.UPLOAD_CHUNK_BYTES
+    if declared_bytes > server_constants.MAX_UPLOAD_TOTAL_BYTES:
+        raise fastapi.HTTPException(
+            status_code=413,
+            detail=(
+                f'Upload of {_gb(declared_bytes)} exceeds the '
+                f'{_gb(server_constants.MAX_UPLOAD_TOTAL_BYTES)} limit on a '
+                'single upload. Upload fewer or smaller files.'))
     # Write chunk to a unique private path first, so concurrent uploads for
     # a same blob does not interleave with each other.
     if total_chunks == 1:
@@ -2063,7 +2091,9 @@ async def unzip_file(zip_file_path: pathlib.Path,
     def _do_unzip() -> None:
         try:
             with zipfile.ZipFile(zip_file_path, 'r') as zipf:
-                for member in zipf.infolist():
+                members = zipf.infolist()
+                _check_extraction_fits(members)
+                for member in members:
                     # Determine the new path
                     original_path = os.path.normpath(member.filename)
                     new_path = client_file_mounts_dir / original_path.lstrip(
@@ -2117,6 +2147,10 @@ async def unzip_file(zip_file_path: pathlib.Path,
             raise fastapi.HTTPException(
                 status_code=400,
                 detail=f'Invalid zip file: {common_utils.format_exception(e)}')
+        except fastapi.HTTPException:
+            # Keep a deliberate status code; the handler below would
+            # rewrite it to a 500.
+            raise
         except Exception as e:
             logger.error(f'Error unzipping file: {zip_file_path}')
             raise fastapi.HTTPException(

--- a/tests/unit_tests/test_local_disk_accounting.py
+++ b/tests/unit_tests/test_local_disk_accounting.py
@@ -37,8 +37,9 @@ def roots(tmp_path, monkeypatch):
 
 @pytest.fixture(autouse=True)
 def _fresh_used_bytes_cache(monkeypatch):
-    """The used-bytes cache is module-level, so it would cross tests."""
+    """The cache and the debit are module-level, so they cross tests."""
     monkeypatch.setattr(local_disk, '_used_bytes_cache', None)
+    monkeypatch.setattr(local_disk, '_admitted_bytes', 0)
 
 
 @pytest.fixture(autouse=True)
@@ -442,3 +443,61 @@ def test_available_reads_the_budget_fresh_even_on_a_cache_hit(
 
     assert second - first == 1024**3
     assert len(calls) == 1
+
+
+def test_debit_counts_against_available_until_the_next_walk(roots, monkeypatch):
+    """Concurrent callers have to see work each other has admitted."""
+    present, _ = roots
+    _write(str(present / 'a.log'), 4096)
+    monkeypatch.setenv(local_disk.EPHEMERAL_STORAGE_LIMIT_ENV_VAR, str(1024**3))
+
+    before = local_disk.available_bytes()
+    local_disk.debit(100 * 1024)
+
+    assert local_disk.available_bytes() == before - 100 * 1024
+    # A fresh walk sees those bytes on disk, so the debit is cleared.
+    local_disk.available_bytes(max_age_seconds=-1.0)
+    assert local_disk.available_bytes() == before
+
+
+def test_debit_ignores_a_non_positive_amount(roots, monkeypatch):
+    present, _ = roots
+    _write(str(present / 'a.log'), 4096)
+    monkeypatch.setenv(local_disk.EPHEMERAL_STORAGE_LIMIT_ENV_VAR, str(1024**3))
+    before = local_disk.available_bytes()
+
+    local_disk.debit(0)
+    local_disk.debit(-5)
+
+    assert local_disk.available_bytes() == before
+
+
+def test_a_destination_not_charged_to_this_container_ignores_the_budget(
+        tmp_path, monkeypatch):
+    """A persistent volume's bytes belong to the volume, not the budget.
+
+    The chart mounts one over part of the tree, so an extraction's
+    destination is not always charged to this container.
+    """
+    monkeypatch.setattr(local_disk, '_charged_to_ephemeral',
+                        lambda mountpoint, sources, device: False)
+    monkeypatch.setattr(local_disk, 'available_bytes', lambda *a, **k: 0)
+
+    assert local_disk.available_for_path(str(tmp_path)) > 0
+
+
+def test_a_charged_destination_is_bounded_by_the_budget_too(
+        tmp_path, monkeypatch):
+    monkeypatch.setattr(local_disk, '_charged_to_ephemeral',
+                        lambda mountpoint, sources, device: True)
+    monkeypatch.setattr(local_disk, 'available_bytes', lambda *a, **k: 4096)
+
+    assert local_disk.available_for_path(str(tmp_path)) == 4096
+
+
+def test_availability_resolves_a_path_that_does_not_exist_yet(tmp_path):
+    """An extraction target may not have been created yet."""
+    missing = tmp_path / 'not' / 'created' / 'yet'
+
+    assert local_disk.available_for_path(str(missing)) == \
+        local_disk.available_for_path(str(tmp_path))

--- a/tests/unit_tests/test_local_disk_accounting.py
+++ b/tests/unit_tests/test_local_disk_accounting.py
@@ -36,6 +36,12 @@ def roots(tmp_path, monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _fresh_used_bytes_cache(monkeypatch):
+    """The used-bytes cache is module-level, so it would cross tests."""
+    monkeypatch.setattr(local_disk, '_used_bytes_cache', None)
+
+
+@pytest.fixture(autouse=True)
 def _no_budget(monkeypatch):
     monkeypatch.delenv(local_disk.EPHEMERAL_STORAGE_LIMIT_ENV_VAR,
                        raising=False)
@@ -380,3 +386,59 @@ def test_available_never_goes_negative(roots, monkeypatch):
     monkeypatch.setenv(local_disk.EPHEMERAL_STORAGE_LIMIT_ENV_VAR, '1')
 
     assert local_disk.available_bytes() == 0
+
+
+def _counting_scan(monkeypatch):
+    """Replaces the walk with a counter over the real one."""
+    calls = []
+    real_scan = local_disk.scan
+
+    def counting(*args, **kwargs):
+        calls.append(1)
+        return real_scan(*args, **kwargs)
+
+    monkeypatch.setattr(local_disk, 'scan', counting)
+    return calls
+
+
+def test_available_reuses_one_walk_within_the_ttl(roots, monkeypatch):
+    """The walk costs the same whatever the caller is about to write."""
+    present, _ = roots
+    _write(str(present / 'a.log'), 4096)
+    monkeypatch.setenv(local_disk.EPHEMERAL_STORAGE_LIMIT_ENV_VAR, str(1024**3))
+    calls = _counting_scan(monkeypatch)
+
+    first = local_disk.available_bytes()
+    for _ in range(20):
+        assert local_disk.available_bytes() == first
+
+    assert len(calls) == 1
+
+
+def test_available_walks_again_once_the_cache_ages_out(roots, monkeypatch):
+    present, _ = roots
+    _write(str(present / 'a.log'), 4096)
+    monkeypatch.setenv(local_disk.EPHEMERAL_STORAGE_LIMIT_ENV_VAR, str(1024**3))
+    calls = _counting_scan(monkeypatch)
+
+    local_disk.available_bytes()
+    local_disk.available_bytes(max_age_seconds=-1.0)
+
+    assert len(calls) == 2
+
+
+def test_available_reads_the_budget_fresh_even_on_a_cache_hit(
+        roots, monkeypatch):
+    """Only the walk is cached; the declared budget is env and cheap."""
+    present, _ = roots
+    _write(str(present / 'a.log'), 4096)
+    calls = _counting_scan(monkeypatch)
+
+    monkeypatch.setenv(local_disk.EPHEMERAL_STORAGE_LIMIT_ENV_VAR, str(1024**3))
+    first = local_disk.available_bytes()
+    monkeypatch.setenv(local_disk.EPHEMERAL_STORAGE_LIMIT_ENV_VAR,
+                       str(2 * 1024**3))
+    second = local_disk.available_bytes()
+
+    assert second - first == 1024**3
+    assert len(calls) == 1

--- a/tests/unit_tests/test_local_disk_accounting.py
+++ b/tests/unit_tests/test_local_disk_accounting.py
@@ -244,15 +244,22 @@ def test_only_charged_roots_count_against_the_budget(roots, monkeypatch):
     assert snapshot.used_bytes == snapshot.roots['present'].used_bytes
     assert snapshot.used_bytes < 8 * 1024 * 1024
     assert snapshot.headroom_bytes == 1024**3 - snapshot.used_bytes
-    # Both roots still report their own size; only the aggregate is scoped.
-    assert snapshot.roots['other'].used_bytes >= 8 * 1024 * 1024
+    # 'other' is listed with its filesystem but never walked, so its zero
+    # is not a measurement.
+    assert snapshot.roots['other'].walked is False
+    assert snapshot.roots['present'].walked is True
 
+    families = _families(metrics.LocalDiskUsageCollector())
     charged = {
-        s.labels['root']: s.value
-        for s in _families(metrics.LocalDiskUsageCollector())
-        ['sky_apiserver_local_disk_root_charged_to_ephemeral'].samples
+        s.labels['root']: s.value for s in
+        families['sky_apiserver_local_disk_root_charged_to_ephemeral'].samples
     }
     assert charged == {'present': 1.0, 'other': 0.0}
+    reported = {
+        s.labels['root']
+        for s in families['sky_apiserver_local_disk_used_bytes'].samples
+    }
+    assert reported == {'present'}
 
 
 def test_charging_follows_the_device_then_the_mount_source(tmp_path):
@@ -501,3 +508,55 @@ def test_availability_resolves_a_path_that_does_not_exist_yet(tmp_path):
 
     assert local_disk.available_for_path(str(missing)) == \
         local_disk.available_for_path(str(tmp_path))
+
+
+def test_an_unwalked_root_is_not_walked_at_all(roots, monkeypatch):
+    """The point of skipping it is to not touch the filesystem.
+
+    A volume mounted into the tree sits on a network filesystem, where a
+    walk of many small files takes minutes.
+    """
+    present, other = roots
+    _write(str(other / 'b.log'), 4096)
+    visited = []
+    real_scandir = os.scandir
+
+    def tracking_scandir(path):
+        visited.append(str(path))
+        return real_scandir(path)
+
+    monkeypatch.setattr(local_disk, '_mountpoint', lambda path: path)
+    monkeypatch.setattr(
+        local_disk, '_charged_to_ephemeral',
+        lambda mountpoint, sources, device: mountpoint == str(present))
+    monkeypatch.setattr(local_disk.os, 'scandir', tracking_scandir)
+
+    local_disk.scan()
+
+    assert not any(str(other) in path for path in visited)
+
+
+def test_a_truncated_walk_reports_no_budget_bound(roots, monkeypatch):
+    """A partial walk under-reports usage, so it cannot bound the budget."""
+    present, _ = roots
+    for i in range(20):
+        _write(str(present / f'{i}.log'), 1024)
+    monkeypatch.setenv(local_disk.EPHEMERAL_STORAGE_LIMIT_ENV_VAR, str(1024**3))
+
+    assert local_disk.scan(max_entries=5).truncated is True
+
+    monkeypatch.setattr(local_disk, 'scan',
+                        lambda *a, **k: _truncated_snapshot())
+    assert local_disk.available_bytes(max_age_seconds=-1.0) is None
+
+
+def _truncated_snapshot():
+    usage = local_disk.RootUsage(path='/x',
+                                 used_bytes=1024,
+                                 files=1,
+                                 truncated=True,
+                                 mountpoint='/x')
+    return local_disk.Snapshot(roots={'x': usage},
+                               filesystems={},
+                               budget=local_disk.budget(),
+                               duration_seconds=0.0)

--- a/tests/unit_tests/test_local_disk_accounting.py
+++ b/tests/unit_tests/test_local_disk_accounting.py
@@ -345,3 +345,38 @@ def test_a_root_inside_another_root_is_measured_once(tmp_path, monkeypatch):
 
     assert list(snapshot.roots) == ['outer']
     assert snapshot.roots['outer'].files == 1
+
+
+def test_available_is_absent_without_a_declared_budget(roots):
+    present, _ = roots
+    _write(str(present / 'a.log'), 4096)
+
+    assert local_disk.available_bytes() is None
+
+
+def test_available_counts_a_request_as_well_as_a_limit(roots, monkeypatch):
+    """A guard measures against whatever the deployment declared.
+
+    Unlike the published headroom gauge, which reports only an enforced
+    limit, refusing work that would overrun a declared request is correct
+    on its own terms.
+    """
+    present, _ = roots
+    _write(str(present / 'a.log'), 64 * 1024)
+    used = local_disk.scan().used_bytes
+
+    monkeypatch.setenv(local_disk.EPHEMERAL_STORAGE_REQUEST_ENV_VAR,
+                       str(1024**3))
+    assert local_disk.available_bytes() == 1024**3 - used
+
+    monkeypatch.setenv(local_disk.EPHEMERAL_STORAGE_LIMIT_ENV_VAR,
+                       str(2 * 1024**3))
+    assert local_disk.available_bytes() == 2 * 1024**3 - used
+
+
+def test_available_never_goes_negative(roots, monkeypatch):
+    present, _ = roots
+    _write(str(present / 'a.log'), 64 * 1024)
+    monkeypatch.setenv(local_disk.EPHEMERAL_STORAGE_LIMIT_ENV_VAR, '1')
+
+    assert local_disk.available_bytes() == 0

--- a/tests/unit_tests/test_sky/server/test_blob_upload_metrics.py
+++ b/tests/unit_tests/test_sky/server/test_blob_upload_metrics.py
@@ -80,7 +80,7 @@ def test_client_upload_records_size_on_miss_and_hit(blob_upload_app, tmp_path,
                         str(tmp_path / 'logs'))
     monkeypatch.setattr(client_common, '_FILE_UPLOAD_LOCK_DIR',
                         str(tmp_path / 'locks'))
-    monkeypatch.setattr(client_common, '_UPLOAD_CHUNK_BYTES', chunk_bytes)
+    monkeypatch.setattr(server_constants, 'UPLOAD_CHUNK_BYTES', chunk_bytes)
     monkeypatch.setattr(
         client_common.tempfile, 'NamedTemporaryFile',
         functools.partial(client_common.tempfile.NamedTemporaryFile,

--- a/tests/unit_tests/test_sky/server/test_server.py
+++ b/tests/unit_tests/test_sky/server/test_server.py
@@ -8,6 +8,7 @@ import pathlib
 import threading
 import time
 from unittest import mock
+import zipfile
 
 import fastapi
 import prometheus_client as prom
@@ -1790,3 +1791,99 @@ async def test_receive_chunks_skips_the_directory_listing_for_one_chunk(
     assert result is None
     assert listed == []
     assert (tmp_path / 'upload.zip').read_bytes() == b'chunk'
+
+
+def _chunks_for(total_bytes: int) -> int:
+    """Chunk count a client would declare for an upload of *total_bytes*."""
+    return -(-total_bytes // server_constants.UPLOAD_CHUNK_BYTES)
+
+
+@pytest.mark.asyncio
+async def test_receive_chunks_rejects_a_chunk_group_over_the_total_cap(
+        tmp_path):
+    """The cap is checked from the declared chunk count, before any write.
+
+    The upload and its extraction are not synchronous, so the space free at
+    extraction time cannot be known here; the cap is absolute.
+    """
+    over_cap = _chunks_for(server_constants.MAX_UPLOAD_TOTAL_BYTES) + 1
+
+    with pytest.raises(fastapi.HTTPException) as exc_info:
+        await server._receive_and_assemble_chunks(base_dir=tmp_path,
+                                                  zip_name='upload',
+                                                  request=_FakeUploadRequest(),
+                                                  chunk_index=0,
+                                                  total_chunks=over_cap,
+                                                  extract=False,
+                                                  assemble=False)
+
+    assert exc_info.value.status_code == 413
+    assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.asyncio
+async def test_receive_chunks_accepts_a_chunk_group_at_the_total_cap(tmp_path):
+    at_cap = server_constants.MAX_UPLOAD_TOTAL_BYTES \
+        // server_constants.UPLOAD_CHUNK_BYTES
+
+    result = await server._receive_and_assemble_chunks(
+        base_dir=tmp_path,
+        zip_name='upload',
+        request=_FakeUploadRequest(),
+        chunk_index=0,
+        total_chunks=at_cap,
+        extract=False,
+        assemble=False)
+
+    assert result is not None
+    assert result.status == api_responses.UploadStatus.UPLOADING.value
+
+
+def _write_zip(path: pathlib.Path, member_bytes: int) -> None:
+    with zipfile.ZipFile(path, 'w') as zipf:
+        zipf.writestr('payload.bin', b'\0' * member_bytes)
+
+
+@pytest.mark.asyncio
+async def test_unzip_refuses_an_extraction_that_would_not_fit(
+        tmp_path, monkeypatch):
+    zip_path = tmp_path / 'upload.zip'
+    _write_zip(zip_path, 4096)
+    monkeypatch.setattr(server.local_disk, 'available_bytes', lambda: 1024)
+    target = tmp_path / 'out'
+    target.mkdir()
+
+    with pytest.raises(fastapi.HTTPException) as exc_info:
+        await server.unzip_file(zip_path, target)
+
+    assert exc_info.value.status_code == 507
+    assert list(target.iterdir()) == []
+    # The zip is garbage once refused, and the existing cleanup removes it.
+    assert not zip_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_unzip_proceeds_when_the_extraction_fits(tmp_path, monkeypatch):
+    zip_path = tmp_path / 'upload.zip'
+    _write_zip(zip_path, 4096)
+    monkeypatch.setattr(server.local_disk, 'available_bytes', lambda: 1024**3)
+    target = tmp_path / 'out'
+    target.mkdir()
+
+    await server.unzip_file(zip_path, target)
+
+    assert (target / 'payload.bin').stat().st_size == 4096
+
+
+@pytest.mark.asyncio
+async def test_unzip_proceeds_when_no_budget_is_declared(tmp_path, monkeypatch):
+    """With no budget exposed there is nothing to check against."""
+    zip_path = tmp_path / 'upload.zip'
+    _write_zip(zip_path, 4096)
+    monkeypatch.setattr(server.local_disk, 'available_bytes', lambda: None)
+    target = tmp_path / 'out'
+    target.mkdir()
+
+    await server.unzip_file(zip_path, target)
+
+    assert (target / 'payload.bin').stat().st_size == 4096

--- a/tests/unit_tests/test_sky/server/test_server.py
+++ b/tests/unit_tests/test_sky/server/test_server.py
@@ -1849,7 +1849,8 @@ async def test_unzip_refuses_an_extraction_that_would_not_fit(
         tmp_path, monkeypatch):
     zip_path = tmp_path / 'upload.zip'
     _write_zip(zip_path, 4096)
-    monkeypatch.setattr(server.local_disk, 'available_bytes', lambda: 1024)
+    monkeypatch.setattr(server.local_disk, 'available_for_path',
+                        lambda path: 1024)
     target = tmp_path / 'out'
     target.mkdir()
 
@@ -1866,7 +1867,8 @@ async def test_unzip_refuses_an_extraction_that_would_not_fit(
 async def test_unzip_proceeds_when_the_extraction_fits(tmp_path, monkeypatch):
     zip_path = tmp_path / 'upload.zip'
     _write_zip(zip_path, 4096)
-    monkeypatch.setattr(server.local_disk, 'available_bytes', lambda: 1024**3)
+    monkeypatch.setattr(server.local_disk, 'available_for_path',
+                        lambda path: 1024**3)
     target = tmp_path / 'out'
     target.mkdir()
 
@@ -1880,10 +1882,107 @@ async def test_unzip_proceeds_when_no_budget_is_declared(tmp_path, monkeypatch):
     """With no budget exposed there is nothing to check against."""
     zip_path = tmp_path / 'upload.zip'
     _write_zip(zip_path, 4096)
-    monkeypatch.setattr(server.local_disk, 'available_bytes', lambda: None)
+    monkeypatch.setattr(server.local_disk, 'available_for_path',
+                        lambda path: None)
     target = tmp_path / 'out'
     target.mkdir()
 
     await server.unzip_file(zip_path, target)
 
     assert (target / 'payload.bin').stat().st_size == 4096
+
+
+@pytest.mark.asyncio
+async def test_receive_chunks_bounds_the_bytes_actually_streamed(
+        tmp_path, monkeypatch):
+    """A client may stream a chunk of any size, whatever it declared.
+
+    The declared chunk count is only a claim, so the cap has to be
+    enforced against the bytes that reach disk.
+    """
+    monkeypatch.setattr(server_constants, 'MAX_UPLOAD_TOTAL_BYTES', 8)
+
+    with pytest.raises(fastapi.HTTPException) as exc_info:
+        await server._receive_and_assemble_chunks(
+            base_dir=tmp_path,
+            zip_name='upload',
+            request=_FakeUploadRequest(payload=b'0123456789'),
+            chunk_index=0,
+            total_chunks=1,
+            extract=False,
+            assemble=False)
+
+    assert exc_info.value.status_code == 413
+    assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.asyncio
+async def test_receive_chunks_counts_the_chunks_already_stored(
+        tmp_path, monkeypatch):
+    """The cap covers one upload's chunks together, not each in turn."""
+    monkeypatch.setattr(server_constants, 'MAX_UPLOAD_TOTAL_BYTES', 8)
+    chunk_dir = tmp_path / 'upload'
+    chunk_dir.mkdir()
+    (chunk_dir / 'part0').write_bytes(b'12345')
+
+    with pytest.raises(fastapi.HTTPException) as exc_info:
+        await server._receive_and_assemble_chunks(
+            base_dir=tmp_path,
+            zip_name='upload',
+            request=_FakeUploadRequest(payload=b'6789'),
+            chunk_index=1,
+            total_chunks=2,
+            extract=False,
+            assemble=False)
+
+    assert exc_info.value.status_code == 413
+    # The refused chunk leaves nothing behind; part0 is untouched.
+    assert [p.name for p in chunk_dir.iterdir()] == ['part0']
+
+
+def test_on_disk_size_rounds_each_member_up_to_a_block():
+    """Many tiny files cost far more than the sum of their sizes."""
+    tiny = [zipfile.ZipInfo('f') for _ in range(1000)]
+    for member in tiny:
+        member.file_size = 1
+
+    assert server._on_disk_bytes(tiny) == 1000 * server._EXTRACT_BLOCK_BYTES
+    # An empty member still occupies a block.
+    empty = zipfile.ZipInfo('d/')
+    assert server._on_disk_bytes([empty]) == server._EXTRACT_BLOCK_BYTES
+
+
+@pytest.mark.asyncio
+async def test_unzip_refuses_an_archive_of_tiny_files_that_would_not_fit(
+        tmp_path, monkeypatch):
+    zip_path = tmp_path / 'upload.zip'
+    with zipfile.ZipFile(zip_path, 'w') as zipf:
+        for i in range(64):
+            zipf.writestr(f'f{i}', b'x')
+    target = tmp_path / 'out'
+    target.mkdir()
+    # Well above the 64 apparent bytes, well below the 64 blocks on disk.
+    monkeypatch.setattr(server.local_disk, 'available_for_path',
+                        lambda path: 16 * 1024)
+
+    with pytest.raises(fastapi.HTTPException) as exc_info:
+        await server.unzip_file(zip_path, target)
+
+    assert exc_info.value.status_code == 507
+
+
+@pytest.mark.asyncio
+async def test_unzip_debits_what_it_admits(tmp_path, monkeypatch):
+    """A second extraction must see what the first was allowed to write."""
+    debited = []
+    monkeypatch.setattr(server.local_disk, 'available_for_path',
+                        lambda path: 1024**3)
+    monkeypatch.setattr(server.local_disk, 'debit', debited.append)
+    zip_path = tmp_path / 'upload.zip'
+    _write_zip(zip_path, 4096)
+    target = tmp_path / 'out'
+    target.mkdir()
+
+    await server.unzip_file(zip_path, target)
+
+    assert debited == [server._EXTRACT_BLOCK_BYTES]


### PR DESCRIPTION
Two guards on the path that puts client file mounts on the API server's disk, built on the accounting added in #10674.

**At extraction.** Size the archive by what it will occupy — each member rounded up to a whole filesystem block, since an archive of many tiny files costs far more than the sum of its apparent sizes, and that rounding is what the accounting side measures. Compare it against what is available at the destination and refuse the whole extraction if it does not fit. `ZipFile.infolist()` reports the sizes before the first byte is written, so the check costs nothing, and today's alternative is filling the disk mid-extraction and being evicted.

Availability is resolved per destination, not against one global number. A deployment can mount a persistent volume over part of the tree an extraction writes into; bytes written there belong to that volume, so such a destination is bounded by its own filesystem's free space and not by this container's ephemeral-storage budget. A destination that *is* charged to the container is bounded by both. The budget itself is the declared allowance: the limit if there is one, otherwise the request. With no budget and no readable filesystem there is nothing to check against and extraction proceeds unchanged.

A check that passes holds its space for as long as the extraction writes. Without that, concurrent extractions each measure against the same free space and overcommit together — a walk cannot see bytes that have not been written yet.

The walk runs on demand, with no cache. Measuring only the charged roots makes it cheap: in production 5.2 to 6.0 us per file, so 18 ms to 60 ms on the pods measured and under a second at the largest file counts these directories have reached. Where the extraction target is on a volume there is no walk at all, only a `statvfs`. One caller reaches this — the check before an extraction — and the metrics collector walks separately, so a cache would buy staleness rather than speed.

**At upload.** Cap a single upload at whatever `SKYPILOT_MAX_UPLOAD_TOTAL_BYTES` says, as an integer number of bytes. Opt-in: unset, unparseable or non-positive enforces nothing, and such a deployment uploads exactly as it did before. This cap ignores free space deliberately — an upload is extracted at a later, unrelated time, so the space available then cannot be known while the chunks are still arriving.

The declared chunk count is only a claim — a client is free to stream a chunk of any size — so the cap is enforced against the bytes that actually reach disk, less what this upload's earlier chunks already occupy, which covers the chunks together rather than each in turn. The declared count is still checked first, as a reject on chunk 0 before anything is transferred.

Status codes: 507 for an extraction that does not fit, 413 for an upload over the configured cap.

The chunk size moves to `sky/server/constants.py` so the server can compute the declared total from the chunk count.

**Keeping the walk off network filesystems.** The accounting walk now measures only the roots charged to this container, and this change puts it on the upload path, so that matters. A deployment can mount a persistent volume over part of the tree — over the clients dir under one upgrade strategy, over all of `~/.sky` under another — and a walk there runs at network-filesystem latency: measured in production, 8.4 ms per file against 0.008 ms on local disk. At the file counts these directories reach, that is twenty minutes. Those bytes were already excluded from the total, so walking them only ever cost time; an unwalked root still reports its filesystem, and reports no size or file count rather than a zero that would read as a measurement. A truncated walk now yields no budget bound at all, since subtracting a partial total would overstate what is left.

One thing deliberately left out: inode headroom. `f_favail` reads 0 on some of the filesystems the server runs on, which would turn into false refusals. The block rounding covers the space side of the same tiny-files case.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

New unit tests cover: the cap enforced from the declared chunk count with nothing written, and accepted at the boundary; the cap enforced against the streamed bytes when a chunk exceeds its declared size; the cap covering a chunk group's stored chunks together; block rounding, including an empty member; an extraction refused with 507 and the zip cleaned up, one that fits, and one with no budget to check; a refused archive of tiny files that passes on apparent size; the debit issued on admission, counted until the next walk and cleared by it; a destination not charged to the container ignoring the budget, a charged one bounded by it; and a destination path that does not exist yet.

Ran `tests/unit_tests/test_local_disk_accounting.py` (32 passed) and `tests/unit_tests/test_sky/server/test_server.py` (82 passed). `tests/unit_tests/test_zip_and_unzip.py::test_unzip_file` fails on macOS both with and without this change — the test builds member names from `TMPDIR`, which is under `/var` there, so the zip-slip check rejects them; it passes on Linux.
