### PR TITLE
Fix SLURM containerized run poisoned by exported `which` bash function

### DIFF
--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -95,12 +95,22 @@ SKY_PIP_CMD = f'{SKY_PYTHON_CMD} -m pip'
 SKY_RAY_CMD = (f'{SKY_PYTHON_CMD} $([ -s {SKY_RAY_PATH_FILE} ] && '
                f'cat {SKY_RAY_PATH_FILE} 2> /dev/null || command -v ray)')
 
-# Use $(which env) to find env, falling back to /usr/bin/env if which is
-# unavailable. This works around a Slurm quirk where srun's execvp() doesn't
-# check execute permissions, failing when $HOME/.local/bin/env (non-executable,
-# from uv installation) shadows /usr/bin/env.
-SKY_SLURM_UNSET_PYTHONPATH = ('$(which env 2>/dev/null || echo /usr/bin/env) '
-                              '-u PYTHONPATH')
+# Resolve `env` with the POSIX builtin `command -v` (as SKY_GET_PYTHON_PATH_CMD
+# and SKY_RAY_CMD above already do), falling back to /usr/bin/env. Using
+# `command -v` instead of `which` avoids two failure modes at once:
+#   1. A non-executable $HOME/.local/bin/env (left by a uv installation)
+#      shadowing /usr/bin/env on PATH: `command -v` only reports an executable
+#      match, so it skips the shadow, whereas a Slurm srun execvp() would pick
+#      it without an exec check.
+#   2. A `which` bash *function* re-imported into a container by
+#      `srun --export=ALL`: Debian/Ubuntu export one that calls `/usr/bin/which`
+#      with GNU-only flags. A minimal image's `/usr/bin/which` rejects them and
+#      prints "Usage: ..." to stdout, poisoning `$(which env ...)` so the run
+#      command begins with `Usage:` -> exit 127. `command -v` is a shell builtin
+#      and is immune to the exported function.
+SKY_SLURM_UNSET_PYTHONPATH = (
+    '$(command -v env 2>/dev/null || echo /usr/bin/env) '
+    '-u PYTHONPATH')
 SKY_SLURM_PYTHON_CMD = (f'{SKY_SLURM_UNSET_PYTHONPATH} '
                         f'$({SKY_GET_PYTHON_PATH_CMD})')
 

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -96,25 +96,30 @@ SKY_RAY_CMD = (f'{SKY_PYTHON_CMD} $([ -s {SKY_RAY_PATH_FILE} ] && '
                f'cat {SKY_RAY_PATH_FILE} 2> /dev/null || command -v ray)')
 
 # Resolve `env` by preferring the absolute path /usr/bin/env when it is an
-# executable file, then falling back to `command -v env`, then to a literal
-# /usr/bin/env. Every piece is POSIX (`[ -x ]`, `command -v`, `echo`), so it is
-# safe in any shell (bash/zsh/sh/dash) -- unlike bash's `type -P`, which in a
-# non-bash shell prints an error to stdout and poisons the substitution. This
-# avoids three failure modes:
+# executable file, then falling back to bash's `type -P env` (a PATH search
+# returning only an on-disk executable, ignoring functions/aliases/builtins),
+# then to a literal /usr/bin/env. `type -P` is a bashism, but it is safe here:
+# both consumers run this command under bash (task_codegen.py's
+# `build_task_runner_cmd` and slurm/instance.py's `_srun_on_node`, each
+# `bash -c ...`), and on standard layouts the `[ -x /usr/bin/env ]` branch
+# short-circuits before `type -P` is ever evaluated, so a non-bash shell never
+# reaches it. This avoids three failure modes:
 #   1. A non-executable $HOME/.local/bin/env (left by a uv installation)
 #      shadowing /usr/bin/env on PATH: `[ -x /usr/bin/env ]` selects the real
-#      binary first, and `command -v` only reports executables anyway, whereas
-#      a Slurm srun execvp() would pick the shadow without an exec check.
+#      binary first, and `type -P` only reports executables anyway, whereas a
+#      Slurm srun execvp() would pick the shadow without an exec check.
 #   2. A `which` bash function re-imported into a container by
 #      `srun --export=ALL` (Debian/Ubuntu export one calling `/usr/bin/which`
 #      with GNU-only flags); a minimal image's `/usr/bin/which` rejects them
 #      and prints "Usage: ..." to stdout, which would poison `$(which env ...)`
 #      -> the run command begins with `Usage:` -> exit 127. This never calls
 #      `which`.
-#   3. An exported `env` *function*: it would be invoked instead of the binary,
-#      but the common branch here expands to the literal path /usr/bin/env.
+#   3. An exported `env` *function*: the common branch expands to the literal
+#      path /usr/bin/env; and if that is absent, `type -P` returns only the
+#      on-disk executable, never the function (whereas `command -v env` would
+#      return the bare name `env` and invoke the function).
 SKY_SLURM_UNSET_PYTHONPATH = (
-    '$([ -x /usr/bin/env ] && echo /usr/bin/env || command -v env || '
+    '$([ -x /usr/bin/env ] && echo /usr/bin/env || type -P env 2>/dev/null || '
     'echo /usr/bin/env) -u PYTHONPATH')
 SKY_SLURM_PYTHON_CMD = (f'{SKY_SLURM_UNSET_PYTHONPATH} '
                         f'$({SKY_GET_PYTHON_PATH_CMD})')

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -81,7 +81,6 @@ SKY_GET_PYTHON_PATH_CMD = (
     f'cat {SKY_PYTHON_PATH_FILE} 2> /dev/null || '
     # POSIX builtin, present even when the `which` binary
     # is not (e.g. minimal RHEL/Rocky images ship no which).
-    # Stays POSIX (not bash's type -P): used across backends, not only Slurm.
     'command -v python3')
 # Python executable, e.g., /opt/conda/bin/python3
 SKY_PYTHON_CMD = (f'{SKY_UNSET_PYTHONPATH_AND_SET_CWD} '
@@ -96,27 +95,27 @@ SKY_PIP_CMD = f'{SKY_PYTHON_CMD} -m pip'
 SKY_RAY_CMD = (f'{SKY_PYTHON_CMD} $([ -s {SKY_RAY_PATH_FILE} ] && '
                f'cat {SKY_RAY_PATH_FILE} 2> /dev/null || command -v ray)')
 
-# Resolve `env` with bash's `type -P`, falling back to /usr/bin/env. `type -P`
-# forces a PATH search that returns only an *executable* file, ignoring shell
-# functions, aliases and builtins. This is safe because this constant is
-# Slurm-only and is always expanded under `/bin/bash -c` (see
-# task_codegen.py's `srun ... /bin/bash -c <bash_cmd>`), so bash is guaranteed;
-# the general-purpose SKY_GET_PYTHON_PATH_CMD / SKY_RAY_CMD above stay on the
-# POSIX `command -v` for portability. `type -P` avoids three failure modes:
+# Resolve `env` by preferring the absolute path /usr/bin/env when it is an
+# executable file, then falling back to `command -v env`, then to a literal
+# /usr/bin/env. Every piece is POSIX (`[ -x ]`, `command -v`, `echo`), so it is
+# safe in any shell (bash/zsh/sh/dash) -- unlike bash's `type -P`, which in a
+# non-bash shell prints an error to stdout and poisons the substitution. This
+# avoids three failure modes:
 #   1. A non-executable $HOME/.local/bin/env (left by a uv installation)
-#      shadowing /usr/bin/env on PATH: the search skips it, whereas a Slurm
-#      srun execvp() would pick it without an exec check.
+#      shadowing /usr/bin/env on PATH: `[ -x /usr/bin/env ]` selects the real
+#      binary first, and `command -v` only reports executables anyway, whereas
+#      a Slurm srun execvp() would pick the shadow without an exec check.
 #   2. A `which` bash function re-imported into a container by
 #      `srun --export=ALL` (Debian/Ubuntu export one calling `/usr/bin/which`
 #      with GNU-only flags); a minimal image's `/usr/bin/which` rejects them
 #      and prints "Usage: ..." to stdout, which would poison `$(which env ...)`
-#      -> the run command begins with `Usage:` -> exit 127.
-#   3. An exported `env` *function*: `command -v env` would return the bare
-#      name `env`, so the run command would invoke the function instead of the
-#      binary. `type -P` reports only the on-disk executable.
+#      -> the run command begins with `Usage:` -> exit 127. This never calls
+#      `which`.
+#   3. An exported `env` *function*: it would be invoked instead of the binary,
+#      but the common branch here expands to the literal path /usr/bin/env.
 SKY_SLURM_UNSET_PYTHONPATH = (
-    '$(type -P env 2>/dev/null || echo /usr/bin/env) '
-    '-u PYTHONPATH')
+    '$([ -x /usr/bin/env ] && echo /usr/bin/env || command -v env || '
+    'echo /usr/bin/env) -u PYTHONPATH')
 SKY_SLURM_PYTHON_CMD = (f'{SKY_SLURM_UNSET_PYTHONPATH} '
                         f'$({SKY_GET_PYTHON_PATH_CMD})')
 

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -81,6 +81,7 @@ SKY_GET_PYTHON_PATH_CMD = (
     f'cat {SKY_PYTHON_PATH_FILE} 2> /dev/null || '
     # POSIX builtin, present even when the `which` binary
     # is not (e.g. minimal RHEL/Rocky images ship no which).
+    # Stays POSIX (not bash's type -P): used across backends, not only Slurm.
     'command -v python3')
 # Python executable, e.g., /opt/conda/bin/python3
 SKY_PYTHON_CMD = (f'{SKY_UNSET_PYTHONPATH_AND_SET_CWD} '

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -95,21 +95,26 @@ SKY_PIP_CMD = f'{SKY_PYTHON_CMD} -m pip'
 SKY_RAY_CMD = (f'{SKY_PYTHON_CMD} $([ -s {SKY_RAY_PATH_FILE} ] && '
                f'cat {SKY_RAY_PATH_FILE} 2> /dev/null || command -v ray)')
 
-# Resolve `env` with the POSIX builtin `command -v` (as SKY_GET_PYTHON_PATH_CMD
-# and SKY_RAY_CMD above already do), falling back to /usr/bin/env. Using
-# `command -v` instead of `which` avoids two failure modes at once:
+# Resolve `env` with bash's `type -P`, falling back to /usr/bin/env. `type -P`
+# forces a PATH search that returns only an *executable* file, ignoring shell
+# functions, aliases and builtins. This is safe because this constant is
+# Slurm-only and is always expanded under `/bin/bash -c` (see
+# task_codegen.py's `srun ... /bin/bash -c <bash_cmd>`), so bash is guaranteed;
+# the general-purpose SKY_GET_PYTHON_PATH_CMD / SKY_RAY_CMD above stay on the
+# POSIX `command -v` for portability. `type -P` avoids three failure modes:
 #   1. A non-executable $HOME/.local/bin/env (left by a uv installation)
-#      shadowing /usr/bin/env on PATH: `command -v` only reports an executable
-#      match, so it skips the shadow, whereas a Slurm srun execvp() would pick
-#      it without an exec check.
-#   2. A `which` bash *function* re-imported into a container by
-#      `srun --export=ALL`: Debian/Ubuntu export one that calls `/usr/bin/which`
-#      with GNU-only flags. A minimal image's `/usr/bin/which` rejects them and
-#      prints "Usage: ..." to stdout, poisoning `$(which env ...)` so the run
-#      command begins with `Usage:` -> exit 127. `command -v` is a shell builtin
-#      and is immune to the exported function.
+#      shadowing /usr/bin/env on PATH: the search skips it, whereas a Slurm
+#      srun execvp() would pick it without an exec check.
+#   2. A `which` bash function re-imported into a container by
+#      `srun --export=ALL` (Debian/Ubuntu export one calling `/usr/bin/which`
+#      with GNU-only flags); a minimal image's `/usr/bin/which` rejects them
+#      and prints "Usage: ..." to stdout, which would poison `$(which env ...)`
+#      -> the run command begins with `Usage:` -> exit 127.
+#   3. An exported `env` *function*: `command -v env` would return the bare
+#      name `env`, so the run command would invoke the function instead of the
+#      binary. `type -P` reports only the on-disk executable.
 SKY_SLURM_UNSET_PYTHONPATH = (
-    '$(command -v env 2>/dev/null || echo /usr/bin/env) '
+    '$(type -P env 2>/dev/null || echo /usr/bin/env) '
     '-u PYTHONPATH')
 SKY_SLURM_PYTHON_CMD = (f'{SKY_SLURM_UNSET_PYTHONPATH} '
                         f'$({SKY_GET_PYTHON_PATH_CMD})')

--- a/tests/unit_tests/test_sky/skylet/test_slurm_env_resolution.py
+++ b/tests/unit_tests/test_sky/skylet/test_slurm_env_resolution.py
@@ -1,0 +1,76 @@
+"""Regression tests for SKY_SLURM_UNSET_PYTHONPATH's `env` resolution.
+
+The Slurm backend expands SKY_SLURM_UNSET_PYTHONPATH inside a command that runs
+under `bash -c` (see task_codegen.py's build_task_runner_cmd and
+slurm/instance.py's _srun_on_node). `srun --export=ALL` re-imports the submit
+host's exported bash functions into that shell, so the `env` resolver must be
+robust against two of them:
+
+  * an exported Debian/Ubuntu `which` function -- a minimal image's
+    `/usr/bin/which` prints "Usage: ..." to stdout, which would poison a
+    `$(which env ...)` substitution and make the run command start with
+    `Usage:` (exit 127);
+  * an exported `env` function -- it would be invoked in place of the binary.
+
+These tests execute the resolver under bash with each function exported and
+assert it still runs the real `env`. No Slurm, Pyxis, or Docker is needed.
+"""
+
+import shutil
+import subprocess
+
+import pytest
+
+from sky.skylet import constants
+
+# A `which` function like the one Debian/Ubuntu export, but pointed at a stub
+# that prints a usage banner to stdout -- the exact poison mechanism. The fix
+# must never call `which`, so this banner must not reach the resolved command.
+_WHICH_FUNCTION_PREAMBLE = (
+    'which() { echo "Usage: /usr/bin/which [-as] args"; }; export -f which')
+
+# An exported `env` function that would hijack a bare-name resolution.
+_ENV_FUNCTION_PREAMBLE = (
+    'env() { echo INTERCEPTED "$@"; }; export -f env')
+
+_SENTINEL = 'RESOLVED_OK'
+
+
+def _run_resolver(preamble: str) -> subprocess.CompletedProcess:
+    """Run SKY_SLURM_UNSET_PYTHONPATH under bash after a setup preamble.
+
+    Args:
+        preamble: shell statements exported before the resolver runs (e.g. an
+            adversarial function definition).
+
+    Returns:
+        The completed process; stdout should contain the sentinel when the
+        real `env` binary was resolved and executed.
+    """
+    resolver = constants.SKY_SLURM_UNSET_PYTHONPATH
+    script = f'{preamble}\n{resolver} echo {_SENTINEL}'
+    return subprocess.run(['bash', '-c', script],
+                          capture_output=True,
+                          text=True,
+                          check=False)
+
+
+@pytest.mark.skipif(shutil.which('bash') is None, reason='bash not available')
+@pytest.mark.parametrize('preamble', [
+    pytest.param('', id='baseline'),
+    pytest.param(_WHICH_FUNCTION_PREAMBLE, id='exported-which-function'),
+    pytest.param(_ENV_FUNCTION_PREAMBLE, id='exported-env-function'),
+])
+def test_env_resolver_runs_real_binary(preamble: str) -> None:
+    """The resolver runs the real `env` despite adversarial exported functions.
+
+    Args:
+        preamble: an exported-function definition (or empty for the baseline).
+    """
+    result = _run_resolver(preamble)
+    assert result.returncode == 0, result.stderr
+    assert _SENTINEL in result.stdout
+    # The `which`-poison banner must never reach the run command...
+    assert 'Usage:' not in result.stdout
+    # ...and an exported `env` function must never be invoked.
+    assert 'INTERCEPTED' not in result.stdout

--- a/tests/unit_tests/test_sky/skylet/test_slurm_env_resolution.py
+++ b/tests/unit_tests/test_sky/skylet/test_slurm_env_resolution.py
@@ -30,8 +30,7 @@ _WHICH_FUNCTION_PREAMBLE = (
     'which() { echo "Usage: /usr/bin/which [-as] args"; }; export -f which')
 
 # An exported `env` function that would hijack a bare-name resolution.
-_ENV_FUNCTION_PREAMBLE = (
-    'env() { echo INTERCEPTED "$@"; }; export -f env')
+_ENV_FUNCTION_PREAMBLE = ('env() { echo INTERCEPTED "$@"; }; export -f env')
 
 _SENTINEL = 'RESOLVED_OK'
 


### PR DESCRIPTION
## Summary

Fixes #10715.

On the SLURM backend, launching a task with a container image (Pyxis/enroot)
fails at the run step with `bash: line 1: Usage:: command not found` (exit 127)
when the submit host exports the Debian/Ubuntu `which` **bash function**.

`srun --export=ALL` re-imports that function into the container. It calls
`/usr/bin/which` with GNU-only flags; a minimal image's `/usr/bin/which`
(debianutils, only `[-as]`) rejects them and prints `Usage: /usr/bin/which
[-as] args` to **stdout**. That poisons the inline substitution in
`SKY_SLURM_UNSET_PYTHONPATH = '$(which env 2>/dev/null || echo /usr/bin/env) ...'`
— the substitution captures the usage text, so the generated run command
becomes a single command whose first token is `Usage:` → exit 127.

### Impact

This is not specific to any one image or task — `SKY_SLURM_UNSET_PYTHONPATH`
sits in the run-command scaffolding that wraps **every** containerized SLURM
task's setup and run ([`build_task_runner_cmd` in
`task_codegen.py`](https://github.com/skypilot-org/skypilot/blob/master/sky/backends/task_codegen.py),
under `srun --export=ALL --container-name=<name>:exec /bin/bash -c ...`), so the
failure lands before the user command is ever reached. On any submit host whose
environment exports a `which` shell function — the GNU-`which` function shipped
via `/etc/profile.d` on many RHEL/HPC login nodes, and on some Debian/Ubuntu
setups — **all** container tasks on that cluster fail with exit 127, regardless
of the task. The gate is narrow enough to have slipped past CI (a submit shell
with no exported `which` function never injects it, and bare-host/non-container
tasks are unaffected because the compute node's full GNU `which` accepts the
flags), but where it does trigger it takes down containerized SLURM entirely.

## Fix

Resolve `env` by preferring the absolute path `/usr/bin/env` when it is an
executable file, then falling back to bash's `type -P env` (a PATH search that
returns only an on-disk executable, ignoring functions/aliases/builtins), then
to a literal `/usr/bin/env`:

```python
SKY_SLURM_UNSET_PYTHONPATH = ('$([ -x /usr/bin/env ] && echo /usr/bin/env '
                              '|| type -P env 2>/dev/null '
                              '|| echo /usr/bin/env) -u PYTHONPATH')
```

This closes three failure modes:

1. **The reported `which`-function poisoning** — it never invokes `which`.
2. **A non-executable `~/.local/bin/env` shadow** left by a uv installation —
   the original reason the constant avoided a bare `/usr/bin/env`. `[ -x
   /usr/bin/env ]` selects the real binary first, and `type -P` only reports an
   executable match anyway.
3. **An exported `env` function** — the common branch expands to the literal
   path `/usr/bin/env`; and if that path is absent (e.g. a custom image with
   coreutils under `/opt/...`), `type -P env` still returns only the on-disk
   executable, never the function. (A bare `command -v env` would instead
   return the name `env` and the run command would invoke the function.)

### Why `type -P` is safe here

`type -P` is a bashism, but both consumers run the generated command under bash
— `sky/backends/task_codegen.py`'s `build_task_runner_cmd` and
`sky/provision/slurm/instance.py`'s `_srun_on_node`, each `bash -c ...`. It also
sits only in the fallback: on standard layouts the `[ -x /usr/bin/env ]` branch
short-circuits **before** `type -P` is evaluated, so even a non-bash shell never
reaches it while `/usr/bin/env` exists (verified in bash, zsh, sh, and dash).
The general-purpose `SKY_GET_PYTHON_PATH_CMD` / `SKY_RAY_CMD` stay on POSIX
`command -v` (one runs under `sh -c`), which is correct for them because they
resolve `python3`/`ray`, not a name a `srun --export=ALL` host is apt to export
as a function.

## Test plan

Minimal, cluster-free reproduction of the exact mechanism (no SLURM/Pyxis
needed) — the Debian `which` function as `srun --export=ALL` re-imports it, and
the run command as SkyPilot builds it (an inline `$(...)` inside a single
command handed to `bash -c`):

```bash
docker run --rm -i debian:latest bash -s <<'EOF'
which () { ( alias; eval ${which_declare} ) | /usr/bin/which --tty-only --read-alias --read-functions --show-tilde --show-dot "$@"; }
export -f which
RUN_CMD='$([ -x /usr/bin/env ] && echo /usr/bin/env || type -P env 2>/dev/null || echo /usr/bin/env) -u PYTHONPATH echo CONTAINER_RAN_OK'
bash -c "$RUN_CMD"; echo "exit=$?"
EOF
```

- Before (`$(which env ...)`): `bash: line 1: Usage:: command not found`, `exit=127`.
- After: `CONTAINER_RAN_OK`, `exit=0`.

Adversarial edge case — **no** `/usr/bin/env`, an exported `env` function, and
the real `env` elsewhere on `PATH` (a bare `command -v env` fallback would be
hijacked here):

```bash
docker run --rm -i debian:12 bash -s <<'EOF'
mkdir -p /opt/coreutils/bin && cp /usr/bin/env /opt/coreutils/bin/env && rm -f /usr/bin/env
export PATH=/opt/coreutils/bin:$PATH
env () { echo INTERCEPTED "$@"; }; export -f env
/bin/bash -c '$([ -x /usr/bin/env ] && echo /usr/bin/env || type -P env 2>/dev/null || echo /usr/bin/env) -u PYTHONPATH echo CONTAINER_RAN_OK'; echo "exit=$?"
EOF
```

Resolves `/opt/coreutils/bin/env`, prints `CONTAINER_RAN_OK`, `exit=0`.

### Automated regression test

`tests/unit_tests/test_sky/skylet/test_slurm_env_resolution.py` executes
`constants.SKY_SLURM_UNSET_PYTHONPATH` under `bash -c` (the real runtime shell,
no SLURM/Pyxis/Docker) with the adversarial functions exported, asserting the
real `env` runs each time:

- **baseline** — no exported functions.
- **exported `which` function** printing `Usage: ...` to stdout — output must
  contain no `Usage:` (the resolver never shells out to `which`).
- **exported `env` function** printing `INTERCEPTED` — output must contain no
  `INTERCEPTED` (the hijack is closed).
