### PR TITLE
[Serve] Resume persisted replica teardown during recovery

### DIFF
--- a/sky/serve/replica_managers.py
+++ b/sky/serve/replica_managers.py
@@ -981,10 +981,15 @@ class SkyPilotReplicaManager(ReplicaManager):
                            purge: bool = False) -> None:
         left_in_record = not (is_scale_down or purge)
         if left_in_record:
-            assert sync_down_logs, (
-                'For the replica left in the record, '
-                'the logs should always be synced down. '
-                'So that the user can see the logs to debug.')
+            info = serve_state.get_replica_info_from_id(self._service_name,
+                                                        replica_id)
+            assert info is not None
+            # Recovery resumes teardown after log collection was attempted.
+            assert (sync_down_logs or
+                    info.status_property.sky_down_status is not None), (
+                        'For the replica left in the record, '
+                        'the logs should always be synced down. '
+                        'So that the user can see the logs to debug.')
 
         if replica_id in self._launch_thread_pool:
             info = serve_state.get_replica_info_from_id(self._service_name,

--- a/tests/unit_tests/test_serve_replica_managers.py
+++ b/tests/unit_tests/test_serve_replica_managers.py
@@ -4,7 +4,10 @@ Currently focused on `SkyPilotReplicaManager.__init__` startup ordering:
 the daemon threads (especially `_job_status_fetcher`) must NOT race the
 main thread for `self.lock` before `_recover_replica_operations` runs.
 """
+import threading
 from unittest import mock
+
+import pytest
 
 from sky.serve import replica_managers
 
@@ -137,3 +140,52 @@ class TestSkyPilotReplicaManagerInitOrdering:
         assert '_thread_pool_refresher' in started_targets
         assert '_job_status_fetcher' in started_targets
         assert '_replica_prober' in started_targets
+
+
+@pytest.mark.parametrize('down_status', [
+    replica_managers.common_utils.ProcessStatus.SCHEDULED,
+    replica_managers.common_utils.ProcessStatus.RUNNING,
+    replica_managers.common_utils.ProcessStatus.SUCCEEDED,
+])
+def test_recover_failed_replica_termination(down_status):
+    manager = object.__new__(replica_managers.SkyPilotReplicaManager)
+    manager._service_name = 'svc'
+    manager.lock = threading.RLock()
+    manager._launch_thread_pool = {}
+    manager._down_thread_pool = {}
+    info = mock.Mock(replica_id=1, cluster_name='svc-1')
+    info.status_property.purged = False
+    info.status_property.is_scale_down = False
+    info.status_property.sky_down_status = down_status
+
+    def replicas_at_status(_name, status):
+        if status == replica_managers.serve_state.ReplicaStatus.SHUTTING_DOWN:
+            return [info]
+        return []
+
+    with mock.patch.object(
+            replica_managers.serve_state, 'get_replicas_at_status',
+            side_effect=replicas_at_status), \
+         mock.patch.object(
+             replica_managers.serve_state, 'get_replica_info_from_id',
+             return_value=info), \
+         mock.patch.object(
+             replica_managers.global_user_state, 'cluster_with_name_exists',
+             return_value=False), \
+         mock.patch.object(manager, '_handle_sky_down_finish') as finished:
+        manager._recover_replica_operations()
+    finished.assert_called_once_with(info, format_exc=None)
+
+
+def test_new_failed_replica_termination_requires_logs():
+    manager = object.__new__(replica_managers.SkyPilotReplicaManager)
+    manager._service_name = 'svc'
+    info = mock.Mock()
+    info.status_property.sky_down_status = None
+    with mock.patch.object(replica_managers.serve_state,
+                           'get_replica_info_from_id',
+                           return_value=info), \
+         pytest.raises(AssertionError, match='logs should always'):
+        manager._terminate_replica(1,
+                                   sync_down_logs=False,
+                                   replica_drain_delay_seconds=0)


### PR DESCRIPTION
A controller restart during failed-replica teardown can fail in `_recover_replica_operations()`: recovery calls `_terminate_replica(sync_down_logs=False)`, but the latter unconditionally requires log syncing for replicas retained for debugging. The assertion prevents controller recovery even when teardown was already persisted.

Allow recovery without repeating log collection when `sky_down_status` is already set. Fresh teardown still requires log syncing. This avoids trying to consume the launch log again after the previous teardown attempt.

Regression coverage exercises recovery with persisted `SCHEDULED`, `RUNNING`, and `SUCCEEDED` teardown states when the cluster is already gone, plus the fresh-teardown guard. This is a narrow fix for persisted teardown; it does not address every interrupted-launch recovery path.

Tested:
- Before the fix: 3 regression failures, 3 passes.
- After the fix: all 6 tests in `test_serve_replica_managers.py` pass (`pytest -c /dev/null --noconftest -p no:cacheprovider`).
- `mypy sky/serve/replica_managers.py`: passed.
- YAPF diff check on both changed files and `git diff --check`: passed.
- Full `format.sh --files ...` could not run locally because pylint is unavailable. Ruff does not match the existing repository formatting/lint conventions; files retain upstream YAPF style.
- Cloud smoke tests have not been run for this upstream branch.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10717" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->