### PR TITLE
[CI] Let the nightly notifier depend on every other job

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -470,16 +470,18 @@ jobs:
 
   notify-slack-failure:
     runs-on: ubuntu-latest
-    needs: [check-date, nightly-build-pypi, smoke-tests-aws, smoke-tests-kubernetes-resource-heavy, smoke-tests-kubernetes-no-resource-heavy, smoke-tests-kubernetes-no-resource-heavy-limit-deps, smoke-tests-remote-server-kubernetes, smoke-tests-kubernetes-jobs-consolidation, smoke-tests-slurm-minimal, backward-compat-test-nightly, backward-compat-test-stable, publish-and-validate-both, trigger-docker-and-helm-release, tag-nightly-release, notify-downstream]
+    needs: [check-date, nightly-build-pypi, smoke-tests-aws, smoke-tests-kubernetes-resource-heavy, smoke-tests-kubernetes-no-resource-heavy, smoke-tests-kubernetes-no-resource-heavy-limit-deps, smoke-tests-remote-server-kubernetes, smoke-tests-kubernetes-jobs-consolidation, smoke-tests-slurm-minimal, backward-compat-test-nightly, backward-compat-test-stable, publish-and-validate-both, trigger-docker-and-helm-release, tag-nightly-release, notify-downstream, summary]
     # Fire when any upstream job failed OR the run was cancelled. A cancelled
     # run (e.g. someone stopping it while Buildkite lanes are still waiting)
     # publishes no nightly and dispatches nothing downstream, exactly like a
     # failure -- but `failure()` alone is false for it, so 2026-09-10's nightly
     # was skipped with no Slack message at all.
     #
-    # `notify-downstream` is in `needs` so this job stays pending until the
-    # downstream dispatch is terminal. Without it, a cancel landing while only
-    # that job is still running would find this one already evaluated+skipped.
+    # The `needs` list names every other job in the workflow -- including the
+    # parallel `notify-downstream` and `summary` -- so this job cannot be
+    # evaluated early. A job left out of it can reach a terminal state last,
+    # and a cancel landing after that would find this one already skipped.
+    # (`gate-tests` is covered transitively: every lane needs it.)
     if: failure() || cancelled()
     steps:
       - name: Prepare failure message


### PR DESCRIPTION
Follow-up to #10719, which merged just before this last review point landed.

## Why

Review flagged the same shape of bug more than once on #10719: a job left **outside** `notify-slack-failure`'s `needs` can be the last one running.

GitHub evaluates a job's `if` once every job in its `needs` reaches a terminal state. If the notifier's dependencies all finish while some *other* job is still going, the notifier evaluates `failure() || cancelled()` as false right then and is permanently skipped. Cancelling the run afterwards cannot bring it back — exactly the silence #10719 set out to fix.

#10719 patched in `notify-downstream`. `summary` has the same property: it depends only on `check-date`, `nightly-build-pypi` and the lanes, so it runs in parallel with the publish / tag / dispatch jobs and is still outside `needs`.

## What

Rather than patch in one more job, `needs` now names **every** other job in the workflow — that's the invariant that actually prevents early evaluation, instead of a list that has to be remembered every time a job is added. `gate-tests` is covered transitively (every lane needs it).

One line plus a comment explaining the invariant.

## Test plan

- YAML parses; asserted that `set(all jobs) - set(notify.needs) == {gate-tests}`, and that `gate-tests` is reachable transitively via every lane.
- Re-ran the 5-scenario harness from #10719 (renders the real `${{ }}` expressions and executes the step body) with `summary` added to the `needs.*` set, confirming the wording is unchanged: cancel mid-flight, cancel-before-dispatch, cancel-after-publish, plain failure, mixed failure+cancel.
- The end-to-end cancel test on #10719 ([run 34551889366](https://github.com/skypilot-org/skypilot/actions/runs/34551889366)) already proved `notify-slack-failure` runs and delivers to Slack on a cancelled run; this change only widens when it is allowed to evaluate, so that result still holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
