### PR TITLE
[Core] debug-dump: bound the recent-activity request scan and add summary provenance

### DIFF
--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -1048,7 +1048,10 @@ class RequestTaskFilter:
             timestamp.
         finished_after: if provided, only include requests finished at or after
             this timestamp. Requests still in progress (finished_at IS NULL)
-            are always included.
+            are always included. This is a listing semantic: a caller using it
+            as a time window (e.g. a recent-activity scan) must additionally
+            bound those unfinished rows by created_at client-side; see
+            _populate_recent_context in sky/utils/debug_utils.py.
         limit: the number of requests to show. If None, show all requests.
 
     Raises:

--- a/sky/utils/debug_utils.py
+++ b/sky/utils/debug_utils.py
@@ -317,6 +317,12 @@ class DebugDumpContext(TypedDict):
     # into the dump.
     request_ids_via_job: Set[str]
     request_ids_via_cluster: Set[str]
+    # Composition of the recent-activity request scan (see
+    # _populate_recent_context), recorded at scan time and surfaced in
+    # summary.json's provenance block so a scope explosion is explainable
+    # from the dump's structured output alone. Empty when the scan does
+    # not run.
+    recent_request_scan: Dict[str, int]
     errors: List[Dict[str, str]]
     # Per-dump accumulator (sibling of ``errors``) of deadline-timed-out ops
     # whose worker thread was abandoned; see _run_with_deadline /
@@ -777,15 +783,46 @@ def _populate_recent_context(
     # Get recent requests (cluster names are handled by
     # _get_clusters_from_requests during cross-linking)
     try:
+        # The DB-level finished_after filter has listing semantics
+        # ('finished_at >= ? OR finished_at IS NULL'), so it also returns
+        # every never-finished request regardless of age -- including
+        # terminal rows (e.g. CANCELLED) whose finished_at was never
+        # written. The created_at backstop below is what bounds the scan:
+        # an unfinished request only counts as recent when it was created
+        # within the window. Without it, stale rows match any cutoff and
+        # explode the dump's context via cross-linking.
         requests = requests_lib.get_request_tasks(
-            requests_lib.RequestTaskFilter(finished_after=cutoff_time,
-                                           fields=['request_id',
-                                                   'finished_at']))
+            requests_lib.RequestTaskFilter(
+                finished_after=cutoff_time,
+                fields=['request_id', 'created_at', 'finished_at', 'status']))
+        scan = debug_dump_context['recent_request_scan']
+        scan['scanned'] = len(requests)
+        scan['included'] = 0
+        scan['included_unfinished'] = 0
+        scan['skipped_stale_unfinished'] = 0
+        now = time.time()
         for request in requests:
+            created_at = request.created_at or 0
+            if request.finished_at is None:
+                if created_at < cutoff_time:
+                    scan['skipped_stale_unfinished'] += 1
+                    continue
+                scan['included_unfinished'] += 1
+            scan['included'] += 1
             logger.debug(f'Recent: including request {request.request_id} '
-                         f'(finished_at={request.finished_at},'
+                         f'(status={request.status.value}, '
+                         f'created_at={created_at:.0f}, '
+                         f'age={now - created_at:.0f}s, '
+                         f'finished_at={request.finished_at},'
                          f' cutoff={cutoff_time:.0f})')
             debug_dump_context['request_ids'].add(request.request_id)
+        logger.debug(
+            f'Recent requests scan: {scan["scanned"]} rows matched the '
+            f'finished_after filter; included {scan["included"]} '
+            f'({scan["included_unfinished"]} unfinished, created within '
+            f'the window); skipped {scan["skipped_stale_unfinished"]} '
+            f'stale unfinished rows (finished_at=None, created before '
+            f'the cutoff)')
     except Exception as e:  # pylint: disable=broad-except
         logger.warning(f'Failed to get recent requests: {e}')
         debug_dump_context['errors'].append({
@@ -2250,6 +2287,9 @@ def _build_debug_dump(
     # _get_requests_from_clusters. Combined with the via_cluster skip in
     # _get_clusters_from_requests, a cluster shared by many requests
     # (e.g. the controller) cannot drag unrelated jobs or clusters in.
+    # Snapshot the user-seeded request IDs before cross-linking mutates
+    # the context; used for the provenance breakdown in summary.json.
+    user_request_ids = set(debug_dump_context['request_ids'])
     # One reachability cache for the whole dump: the cross-link scans, the
     # clusters section, and the managed-jobs section share per-context
     # probe results, so a defunct context is probed exactly once per dump.
@@ -2396,6 +2436,19 @@ def _build_debug_dump(
             'cluster_names': sorted(debug_dump_context['cluster_names']),
             'managed_job_ids': sorted(debug_dump_context['managed_job_ids']),
         },
+        # Where the collected requests came from, so a scope explosion is
+        # explainable from summary.json alone. Buckets may overlap
+        # slightly (e.g. a system daemon request also matched by the
+        # recent scan); recent_scan holds the request-scan composition
+        # recorded by _populate_recent_context ({} when it did not run).
+        'provenance': {
+            'user_requested': len(user_request_ids),
+            'recent_scan': dict(debug_dump_context['recent_request_scan']),
+            'via_cluster': len(debug_dump_context['request_ids_via_cluster']),
+            'via_job': len(debug_dump_context['request_ids_via_job']),
+            'system': len(
+                set(SYSTEM_REQUEST_IDS) & debug_dump_context['request_ids']),
+        },
         'section_timings': section_timings,
         'errors': errors,
     }
@@ -2481,6 +2534,7 @@ def create_debug_dump(
         # populate these sidecars (see DebugDumpContext docstring).
         request_ids_via_job=set(),
         request_ids_via_cluster=set(),
+        recent_request_scan={},
         errors=[],
         timed_out_ops=[],
     )

--- a/sky/utils/debug_utils.py
+++ b/sky/utils/debug_utils.py
@@ -317,6 +317,11 @@ class DebugDumpContext(TypedDict):
     # into the dump.
     request_ids_via_job: Set[str]
     request_ids_via_cluster: Set[str]
+    # Attribution-only sidecar for the recent-activity request scan (see
+    # _populate_recent_context): which requests the scan first added to
+    # request_ids, surfaced in summary.json's provenance block. Unlike
+    # via_job / via_cluster it carries no expansion restriction.
+    request_ids_recent: Set[str]
     # Composition of the recent-activity request scan (see
     # _populate_recent_context), recorded at scan time and surfaced in
     # summary.json's provenance block so a scope explosion is explainable
@@ -791,6 +796,7 @@ def _populate_recent_context(
         # an unfinished request only counts as recent when it was created
         # within the window. Without it, stale rows match any cutoff and
         # explode the dump's context via cross-linking.
+        scan_start = time.time()
         requests = requests_lib.get_request_tasks(
             requests_lib.RequestTaskFilter(
                 finished_after=cutoff_time,
@@ -800,6 +806,7 @@ def _populate_recent_context(
         scan['included'] = 0
         scan['included_unfinished'] = 0
         scan['skipped_stale_unfinished'] = 0
+        scan['dropped_by_window_check'] = 0
         now = time.time()
         for request in requests:
             created_at = request.created_at or 0
@@ -808,6 +815,17 @@ def _populate_recent_context(
                     scan['skipped_stale_unfinished'] += 1
                     continue
                 scan['included_unfinished'] += 1
+            elif request.finished_at < cutoff_time:
+                # Fail-closed re-check of the DB-level finished_after
+                # filter. The default sqlite backend already excludes
+                # finished-before-cutoff rows in SQL, but
+                # register_request_storage (sky/server/plugins.py) can swap
+                # in a custom request backend, and finished_after drift
+                # there must not silently re-admit stale finished rows the
+                # NULL-only backstop above does not gate. Mirrors the
+                # cluster branch's client-side strict comparison below.
+                scan['dropped_by_window_check'] += 1
+                continue
             scan['included'] += 1
             logger.debug(f'Recent: including request {request.request_id} '
                          f'(status={request.status.value}, '
@@ -815,14 +833,30 @@ def _populate_recent_context(
                          f'age={now - created_at:.0f}s, '
                          f'finished_at={request.finished_at},'
                          f' cutoff={cutoff_time:.0f})')
+            if request.request_id not in debug_dump_context['request_ids']:
+                # Attribution-only tag (mirrors the via_cluster / via_job
+                # tag-only-new idiom): which requests the recent scan first
+                # added, for the summary provenance block. No expansion
+                # restriction.
+                debug_dump_context['request_ids_recent'].add(request.request_id)
             debug_dump_context['request_ids'].add(request.request_id)
-        logger.debug(
+        scan['duration_s'] = int(time.time() - scan_start)
+        composition = (
             f'Recent requests scan: {scan["scanned"]} rows matched the '
             f'finished_after filter; included {scan["included"]} '
             f'({scan["included_unfinished"]} unfinished, created within '
             f'the window); skipped {scan["skipped_stale_unfinished"]} '
             f'stale unfinished rows (finished_at=None, created before '
-            f'the cutoff)')
+            f'the cutoff); dropped {scan["dropped_by_window_check"]} by '
+            f'the client-side window check')
+        if (scan['skipped_stale_unfinished'] + scan['dropped_by_window_check'] >
+                0):
+            # WARNING, not debug: stale unfinished rows are a
+            # finished_at-hygiene signal operators should see at default
+            # log levels, not a tool failure.
+            logger.warning(composition)
+        else:
+            logger.debug(composition)
     except Exception as e:  # pylint: disable=broad-except
         logger.warning(f'Failed to get recent requests: {e}')
         debug_dump_context['errors'].append({
@@ -2426,6 +2460,26 @@ def _build_debug_dump(
         json.dump(errors, f, indent=2, default=str)
 
     # Write summary file
+    # Where the collected requests came from, so a scope explosion is
+    # explainable from summary.json alone. The six buckets are exclusive
+    # and sum exactly to collected.request_count: the sidecars are
+    # disjoint by construction (every request-ID adder tags only IDs it
+    # is first to add -- user seeds, then the recent scan, then the
+    # cluster/job cross-links, then SYSTEM_REQUEST_IDS), and the set
+    # subtractions below keep that explicit in attribution order even if
+    # the helpers are ever reordered. untracked != 0 is a tripwire for a
+    # future context adder that forgets to record provenance.
+    final_request_ids = debug_dump_context['request_ids']
+    user_ids = user_request_ids & final_request_ids
+    recent_ids = debug_dump_context['request_ids_recent'] - user_ids
+    via_cluster_ids = (debug_dump_context['request_ids_via_cluster'] -
+                       user_ids - recent_ids)
+    via_job_ids = (debug_dump_context['request_ids_via_job'] - user_ids -
+                   recent_ids - via_cluster_ids)
+    attributed_ids = (user_ids | recent_ids | via_cluster_ids | via_job_ids)
+    system_ids = ((set(SYSTEM_REQUEST_IDS) & final_request_ids) -
+                  attributed_ids)
+    untracked_ids = final_request_ids - attributed_ids - system_ids
     summary: Dict[str, Any] = {
         'requested': requested,
         'collected': {
@@ -2436,18 +2490,16 @@ def _build_debug_dump(
             'cluster_names': sorted(debug_dump_context['cluster_names']),
             'managed_job_ids': sorted(debug_dump_context['managed_job_ids']),
         },
-        # Where the collected requests came from, so a scope explosion is
-        # explainable from summary.json alone. Buckets may overlap
-        # slightly (e.g. a system daemon request also matched by the
-        # recent scan); recent_scan holds the request-scan composition
-        # recorded by _populate_recent_context ({} when it did not run).
+        # recent_scan holds the request-scan composition recorded by
+        # _populate_recent_context ({} when it did not run).
         'provenance': {
-            'user_requested': len(user_request_ids),
+            'user_requested': len(user_ids),
+            'via_recent_scan': len(recent_ids),
+            'via_cluster': len(via_cluster_ids),
+            'via_job': len(via_job_ids),
+            'system': len(system_ids),
+            'untracked': len(untracked_ids),
             'recent_scan': dict(debug_dump_context['recent_request_scan']),
-            'via_cluster': len(debug_dump_context['request_ids_via_cluster']),
-            'via_job': len(debug_dump_context['request_ids_via_job']),
-            'system': len(
-                set(SYSTEM_REQUEST_IDS) & debug_dump_context['request_ids']),
         },
         'section_timings': section_timings,
         'errors': errors,
@@ -2534,6 +2586,7 @@ def create_debug_dump(
         # populate these sidecars (see DebugDumpContext docstring).
         request_ids_via_job=set(),
         request_ids_via_cluster=set(),
+        request_ids_recent=set(),
         recent_request_scan={},
         errors=[],
         timed_out_ops=[],

--- a/tests/unit_tests/test_sky/utils/test_debug_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_debug_utils.py
@@ -47,6 +47,7 @@ def _make_context(
     errors: Optional[List[Dict[str, str]]] = None,
     request_ids_via_job: Optional[Set[str]] = None,
     request_ids_via_cluster: Optional[Set[str]] = None,
+    recent_request_scan: Optional[Dict[str, int]] = None,
 ) -> debug_utils.DebugDumpContext:
     """Helper to create a DebugDumpContext."""
     return debug_utils.DebugDumpContext(
@@ -55,6 +56,8 @@ def _make_context(
         managed_job_ids=managed_job_ids or set(),
         request_ids_via_job=request_ids_via_job or set(),
         request_ids_via_cluster=request_ids_via_cluster or set(),
+        recent_request_scan=recent_request_scan
+        if recent_request_scan is not None else {},
         errors=errors if errors is not None else [],
         timed_out_ops=[],
     )
@@ -1083,8 +1086,10 @@ class TestPopulateRecentContext:
     @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
     def test_still_running_requests_included(self, mock_get_tasks,
                                              mock_get_clusters, mock_queue_v2):
-        """Requests without finished_at (still running) should be included
-        because the DB filter uses (finished_at >= ? OR finished_at IS NULL)."""
+        """Unfinished requests created within the window should be
+        included: the DB filter returns them via the
+        finished_at IS NULL arm, and the created_at backstop keeps them
+        (they are recent activity)."""
         running_request = _make_request(request_id='req-running',
                                         finished_at=None)
         mock_get_tasks.return_value = [running_request]
@@ -1097,6 +1102,125 @@ class TestPopulateRecentContext:
                                              reachability=_StubReachability())
 
         assert 'req-running' in ctx['request_ids']
+        assert ctx['recent_request_scan']['included_unfinished'] == 1
+
+    @mock.patch('sky.jobs.server.core.queue_v2')
+    @mock.patch('sky.utils.debug_utils.global_user_state.get_clusters')
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_stale_unfinished_requests_excluded(self, mock_get_tasks,
+                                                mock_get_clusters,
+                                                mock_queue_v2):
+        """Unfinished requests older than the window must be excluded.
+
+        The DB finished_after filter matches every finished_at IS NULL row
+        regardless of age (including terminal rows, e.g. CANCELLED, whose
+        finished_at was never written); without the created_at backstop
+        these stale rows match any cutoff and explode the dump's context
+        via cross-linking."""
+        now = time.time()
+        stale_request = _make_request(request_id='req-stale',
+                                      created_at=now - 93 * 24 * 3600,
+                                      finished_at=None,
+                                      status='CANCELLED')
+        mock_get_tasks.return_value = [stale_request]
+        mock_get_clusters.return_value = []
+        mock_queue_v2.return_value = ([], 0, {}, 0, [])
+
+        ctx = _make_context()
+        debug_utils._populate_recent_context(ctx,
+                                             minutes=60.0,
+                                             reachability=_StubReachability())
+
+        assert 'req-stale' not in ctx['request_ids']
+        assert ctx['recent_request_scan']['skipped_stale_unfinished'] == 1
+        assert ctx['recent_request_scan']['included'] == 0
+
+    @mock.patch('sky.jobs.server.core.queue_v2')
+    @mock.patch('sky.utils.debug_utils.global_user_state.get_clusters')
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_finished_in_window_with_old_created_at_included(
+            self, mock_get_tasks, mock_get_clusters, mock_queue_v2):
+        """A request created before the window but finished within it is
+        still recent activity: the created_at backstop only gates
+        unfinished rows, never finished ones."""
+        now = time.time()
+        request = _make_request(request_id='req-finished',
+                                created_at=now - 93 * 24 * 3600,
+                                finished_at=now - 60)
+        mock_get_tasks.return_value = [request]
+        mock_get_clusters.return_value = []
+        mock_queue_v2.return_value = ([], 0, {}, 0, [])
+
+        ctx = _make_context()
+        debug_utils._populate_recent_context(ctx,
+                                             minutes=60.0,
+                                             reachability=_StubReachability())
+
+        assert 'req-finished' in ctx['request_ids']
+        assert ctx['recent_request_scan']['included'] == 1
+        assert ctx['recent_request_scan']['included_unfinished'] == 0
+        assert ctx['recent_request_scan']['skipped_stale_unfinished'] == 0
+
+    @mock.patch('sky.jobs.server.core.queue_v2')
+    @mock.patch('sky.utils.debug_utils.global_user_state.get_clusters')
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_scan_composition_counts(self, mock_get_tasks, mock_get_clusters,
+                                     mock_queue_v2):
+        """The scan should record its composition (scanned / included /
+        unfinished among included / stale skipped) on the context so it
+        can be surfaced in summary.json."""
+        now = time.time()
+        mock_get_tasks.return_value = [
+            # Finished within the window.
+            _make_request(request_id='req-a', finished_at=now - 60),
+            # Unfinished, created within the window.
+            _make_request(request_id='req-b',
+                          created_at=now - 60,
+                          finished_at=None),
+            # Unfinished, created before the window (stale).
+            _make_request(request_id='req-c',
+                          created_at=now - 93 * 24 * 3600,
+                          finished_at=None,
+                          status='CANCELLED'),
+        ]
+        mock_get_clusters.return_value = []
+        mock_queue_v2.return_value = ([], 0, {}, 0, [])
+
+        ctx = _make_context()
+        debug_utils._populate_recent_context(ctx,
+                                             minutes=60.0,
+                                             reachability=_StubReachability())
+
+        assert ctx['request_ids'] == {'req-a', 'req-b'}
+        assert ctx['recent_request_scan'] == {
+            'scanned': 3,
+            'included': 2,
+            'included_unfinished': 1,
+            'skipped_stale_unfinished': 1,
+        }
+
+    @mock.patch('sky.jobs.server.core.queue_v2')
+    @mock.patch('sky.utils.debug_utils.global_user_state.get_clusters')
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_scan_fetches_created_at_for_backstop(self, mock_get_tasks,
+                                                  mock_get_clusters,
+                                                  mock_queue_v2):
+        """The scan must fetch created_at (and status, for the log line)
+        alongside finished_at: the created_at backstop and the enriched
+        per-request log line both depend on them."""
+        mock_get_tasks.return_value = []
+        mock_get_clusters.return_value = []
+        mock_queue_v2.return_value = ([], 0, {}, 0, [])
+
+        ctx = _make_context()
+        debug_utils._populate_recent_context(ctx,
+                                             minutes=60.0,
+                                             reachability=_StubReachability())
+
+        task_filter = mock_get_tasks.call_args[0][0]
+        assert 'created_at' in task_filter.fields
+        assert 'status' in task_filter.fields
+        assert 'finished_at' in task_filter.fields
 
     @mock.patch('sky.jobs.server.core.queue_v2')
     @mock.patch('sky.utils.debug_utils.global_user_state.get_clusters')
@@ -1615,6 +1739,42 @@ class TestCreateDebugDump:
             assert collected['request_count'] >= 2  # At least our 2 + system
             assert collected['cluster_count'] >= 1
             assert collected['managed_job_count'] >= 1
+
+    @mock.patch('sky.utils.debug_utils._dump_managed_job_info')
+    @mock.patch('sky.utils.debug_utils._dump_cluster_info')
+    @mock.patch('sky.utils.debug_utils._dump_request_id_info')
+    @mock.patch('sky.utils.debug_utils._dump_server_info')
+    @mock.patch('sky.utils.debug_utils._get_clusters_from_managed_jobs')
+    @mock.patch('sky.utils.debug_utils._get_clusters_from_requests')
+    @mock.patch('sky.utils.debug_utils._get_managed_jobs_from_requests')
+    @mock.patch('sky.utils.debug_utils._get_requests_from_managed_jobs')
+    @mock.patch('sky.utils.debug_utils._get_requests_from_clusters')
+    def test_summary_contains_provenance(
+            self, mock_req_from_clusters, mock_req_from_jobs,
+            mock_jobs_from_req, mock_clusters_from_req, mock_clusters_from_jobs,
+            mock_dump_server, mock_dump_requests, mock_dump_clusters,
+            mock_dump_jobs, tmp_path):
+        """Summary should break down where the collected requests came
+        from, so a scope explosion is explainable from summary.json."""
+        with mock.patch('sky.utils.debug_utils.DEBUG_DUMP_DIR',
+                        str(tmp_path / 'debug_dumps')):
+            result = debug_utils.create_debug_dump(request_ids=['req-1'],)
+
+        with zipfile.ZipFile(result, 'r') as zf:
+            summary_files = [
+                n for n in zf.namelist() if n.endswith('summary.json')
+            ]
+            summary_data = json.loads(zf.read(summary_files[0]))
+
+        provenance = summary_data['provenance']
+        assert provenance['user_requested'] == 1
+        # Cross-link helpers are mocked out in this test.
+        assert provenance['via_cluster'] == 0
+        assert provenance['via_job'] == 0
+        # System daemon request IDs are always added.
+        assert provenance['system'] >= 1
+        # No recent_minutes, so the recent scan did not run.
+        assert provenance['recent_scan'] == {}
 
     @mock.patch('sky.utils.debug_utils._dump_managed_job_info')
     @mock.patch('sky.utils.debug_utils._dump_cluster_info')

--- a/tests/unit_tests/test_sky/utils/test_debug_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_debug_utils.py
@@ -21,12 +21,19 @@ from sky.adaptors import kubernetes as adaptors_kubernetes
 from sky.jobs import utils as managed_job_utils
 from sky.server import constants as server_constants
 from sky.server.requests import log_provider as log_provider_lib
+from sky.server.requests import payloads
 from sky.server.requests import request_names
+from sky.server.requests import requests as requests_lib
 from sky.skylet import constants as skylet_constants
 from sky.utils import common
 from sky.utils import debug_dump_helpers
 from sky.utils import debug_utils
 from sky.utils import status_lib
+
+
+def _dummy_entrypoint():
+    """Picklable no-op entrypoint for constructing real Request rows."""
+    return None
 
 
 class _StubReachability:
@@ -47,6 +54,7 @@ def _make_context(
     errors: Optional[List[Dict[str, str]]] = None,
     request_ids_via_job: Optional[Set[str]] = None,
     request_ids_via_cluster: Optional[Set[str]] = None,
+    request_ids_recent: Optional[Set[str]] = None,
     recent_request_scan: Optional[Dict[str, int]] = None,
 ) -> debug_utils.DebugDumpContext:
     """Helper to create a DebugDumpContext."""
@@ -56,6 +64,7 @@ def _make_context(
         managed_job_ids=managed_job_ids or set(),
         request_ids_via_job=request_ids_via_job or set(),
         request_ids_via_cluster=request_ids_via_cluster or set(),
+        request_ids_recent=request_ids_recent or set(),
         recent_request_scan=recent_request_scan
         if recent_request_scan is not None else {},
         errors=errors if errors is not None else [],
@@ -1127,13 +1136,20 @@ class TestPopulateRecentContext:
         mock_queue_v2.return_value = ([], 0, {}, 0, [])
 
         ctx = _make_context()
-        debug_utils._populate_recent_context(ctx,
-                                             minutes=60.0,
-                                             reachability=_StubReachability())
+        # SkyPilot loggers do not propagate, so caplog cannot see the
+        # record; patch the logger directly (see test_db_retries.py).
+        with mock.patch.object(debug_utils.logger, 'warning') as warn:
+            debug_utils._populate_recent_context(
+                ctx, minutes=60.0, reachability=_StubReachability())
 
         assert 'req-stale' not in ctx['request_ids']
         assert ctx['recent_request_scan']['skipped_stale_unfinished'] == 1
         assert ctx['recent_request_scan']['included'] == 0
+        # The aggregate composition line is a finished_at-hygiene signal:
+        # it must surface at WARNING (not debug) whenever stale rows were
+        # skipped.
+        assert any(
+            'Recent requests scan:' in c.args[0] for c in warn.call_args_list)
 
     @mock.patch('sky.jobs.server.core.queue_v2')
     @mock.patch('sky.utils.debug_utils.global_user_state.get_clusters')
@@ -1152,14 +1168,78 @@ class TestPopulateRecentContext:
         mock_queue_v2.return_value = ([], 0, {}, 0, [])
 
         ctx = _make_context()
-        debug_utils._populate_recent_context(ctx,
-                                             minutes=60.0,
-                                             reachability=_StubReachability())
+        with mock.patch.object(debug_utils.logger, 'warning') as warn, \
+             mock.patch.object(debug_utils.logger, 'debug') as debug_log:
+            debug_utils._populate_recent_context(
+                ctx, minutes=60.0, reachability=_StubReachability())
 
         assert 'req-finished' in ctx['request_ids']
         assert ctx['recent_request_scan']['included'] == 1
         assert ctx['recent_request_scan']['included_unfinished'] == 0
         assert ctx['recent_request_scan']['skipped_stale_unfinished'] == 0
+        # Nothing was skipped, so the composition line stays at debug.
+        assert not any(
+            'Recent requests scan:' in c.args[0] for c in warn.call_args_list)
+        assert any('Recent requests scan:' in c.args[0]
+                   for c in debug_log.call_args_list)
+
+    @mock.patch('sky.jobs.server.core.queue_v2')
+    @mock.patch('sky.utils.debug_utils.global_user_state.get_clusters')
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_finished_before_cutoff_dropped_by_window_check(
+            self, mock_get_tasks, mock_get_clusters, mock_queue_v2):
+        """A finished row with finished_at < cutoff must never enter the
+        context, even if the DB-level filter fails to exclude it (e.g. a
+        custom request backend with drifted finished_after semantics):
+        the client-side window check drops and counts it. Fail-closed
+        counterpart of the sqlite filter's 'finished_at >= ?' arm."""
+        now = time.time()
+        stale_finished = _make_request(request_id='req-stale-finished',
+                                       created_at=now - 93 * 24 * 3600,
+                                       finished_at=now - 93 * 24 * 3600 + 60,
+                                       status='SUCCEEDED')
+        mock_get_tasks.return_value = [stale_finished]
+        mock_get_clusters.return_value = []
+        mock_queue_v2.return_value = ([], 0, {}, 0, [])
+
+        ctx = _make_context()
+        debug_utils._populate_recent_context(ctx,
+                                             minutes=60.0,
+                                             reachability=_StubReachability())
+
+        assert 'req-stale-finished' not in ctx['request_ids']
+        assert ctx['recent_request_scan']['dropped_by_window_check'] == 1
+        assert ctx['recent_request_scan']['included'] == 0
+
+    @mock.patch('sky.jobs.server.core.queue_v2')
+    @mock.patch('sky.utils.debug_utils.global_user_state.get_clusters')
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_recent_scan_tags_only_new_request_ids(self, mock_get_tasks,
+                                                   mock_get_clusters,
+                                                   mock_queue_v2):
+        """The scan tags only IDs it is first to add to the context: an
+        ID that was already user-seeded is matched but not re-tagged, so
+        summary.json attributes it to the user, not the scan (mirrors the
+        via_cluster / via_job tag-only-new idiom)."""
+        now = time.time()
+        mock_get_tasks.return_value = [
+            _make_request(request_id='req-new',
+                          created_at=now - 60,
+                          finished_at=None),
+            _make_request(request_id='req-seeded',
+                          created_at=now - 60,
+                          finished_at=None),
+        ]
+        mock_get_clusters.return_value = []
+        mock_queue_v2.return_value = ([], 0, {}, 0, [])
+
+        ctx = _make_context(request_ids={'req-seeded'})
+        debug_utils._populate_recent_context(ctx,
+                                             minutes=60.0,
+                                             reachability=_StubReachability())
+
+        assert ctx['request_ids'] == {'req-new', 'req-seeded'}
+        assert ctx['request_ids_recent'] == {'req-new'}
 
     @mock.patch('sky.jobs.server.core.queue_v2')
     @mock.patch('sky.utils.debug_utils.global_user_state.get_clusters')
@@ -1167,8 +1247,9 @@ class TestPopulateRecentContext:
     def test_scan_composition_counts(self, mock_get_tasks, mock_get_clusters,
                                      mock_queue_v2):
         """The scan should record its composition (scanned / included /
-        unfinished among included / stale skipped) on the context so it
-        can be surfaced in summary.json."""
+        unfinished among included / stale skipped / dropped by the
+        client-side window check / duration) on the context so it can be
+        surfaced in summary.json."""
         now = time.time()
         mock_get_tasks.return_value = [
             # Finished within the window.
@@ -1192,12 +1273,16 @@ class TestPopulateRecentContext:
                                              reachability=_StubReachability())
 
         assert ctx['request_ids'] == {'req-a', 'req-b'}
-        assert ctx['recent_request_scan'] == {
-            'scanned': 3,
-            'included': 2,
-            'included_unfinished': 1,
-            'skipped_stale_unfinished': 1,
-        }
+        # Per-key (not dict equality): duration_s is a measured value and
+        # would make an exact-equality assertion flaky. Every successful
+        # scan must produce the same six keys.
+        scan = ctx['recent_request_scan']
+        assert scan['scanned'] == 3
+        assert scan['included'] == 2
+        assert scan['included_unfinished'] == 1
+        assert scan['skipped_stale_unfinished'] == 1
+        assert scan['dropped_by_window_check'] == 0
+        assert scan['duration_s'] >= 0
 
     @mock.patch('sky.jobs.server.core.queue_v2')
     @mock.patch('sky.utils.debug_utils.global_user_state.get_clusters')
@@ -1265,6 +1350,115 @@ class TestPopulateRecentContext:
                                              reachability=_StubReachability())
 
         assert 'newly-launched' in ctx['cluster_names']
+
+
+# ---------------------------------------------------------------------------
+# Tests for the recent-activity request scan against a real requests DB.
+#
+# The tests above mock get_request_tasks; these persist real Request rows
+# through the sqlite backend so the scan's client-side backstop is
+# exercised through the actual SQL + row-decode path.
+# ---------------------------------------------------------------------------
+class TestPopulateRecentContextRealDatabase:
+
+    @pytest.fixture(autouse=True)
+    def isolated_request_database(self, tmp_path):
+        """Create an isolated request database for each test.
+
+        Deliberately duplicated from
+        tests/unit_tests/test_sky/server/requests/test_requests.py rather
+        than imported across test modules (cross-module test imports are
+        fragile).
+        """
+        temp_db_path = tmp_path / 'requests.db'
+        temp_log_path = tmp_path / 'logs'
+        temp_log_path.mkdir()
+        temp_debug_log_path = tmp_path / 'debug_logs'
+        temp_debug_log_path.mkdir()
+        with mock.patch('sky.server.constants.API_SERVER_REQUEST_DB_PATH',
+                        str(temp_db_path)):
+            with mock.patch('sky.server.constants.REQUEST_LOG_PATH_PREFIX',
+                            str(temp_log_path)):
+                with mock.patch('sky.sky_logging.DEBUG_LOG_DIR',
+                                str(temp_debug_log_path)):
+                    # Reset the global database variable to force
+                    # re-initialization.
+                    requests_lib._DB = None
+                    yield
+                    requests_lib._DB = None
+
+    @staticmethod
+    def _persist_request(request_id: str, status: 'requests_lib.RequestStatus',
+                         created_at: float,
+                         finished_at: Optional[float]) -> None:
+        """Persist a real Request row with an explicit created_at."""
+        request = requests_lib.Request(request_id=request_id,
+                                       name='test-request',
+                                       entrypoint=_dummy_entrypoint,
+                                       request_body=payloads.RequestBody(),
+                                       status=status,
+                                       created_at=created_at,
+                                       user_id='test-user',
+                                       finished_at=finished_at)
+        requests_lib._add_or_update_request_no_lock(request)
+
+    @mock.patch('sky.jobs.server.core.queue_v2')
+    @mock.patch('sky.utils.debug_utils.global_user_state.get_clusters')
+    @mock.patch('sky.utils.debug_utils._jobs_controller_unreachable_context')
+    def test_scan_through_real_db(self, mock_dead_context, mock_get_clusters,
+                                  mock_queue_v2):
+        """The four production-mirroring row shapes: only the
+        fresh-unfinished and old-created-finished-in-window rows are
+        recent activity; the stale-NULL row is skipped by the created_at
+        backstop and the finished-long-ago row never matches the DB
+        filter."""
+        now = time.time()
+        requests_lib._ensure_db_initialized()
+        # 1. Recent-created, unfinished: recent activity.
+        self._persist_request('req-fresh-unfinished',
+                              requests_lib.RequestStatus.RUNNING,
+                              created_at=now - 60,
+                              finished_at=None)
+        # 2. Old-created, terminal status, finished_at never written
+        #    (the production stale shape): must be excluded.
+        self._persist_request('req-stale-unfinished',
+                              requests_lib.RequestStatus.CANCELLED,
+                              created_at=now - 93 * 24 * 3600,
+                              finished_at=None)
+        # 3. Old-created, finished within the window: recent activity --
+        #    the backstop only gates unfinished rows.
+        self._persist_request('req-old-finished-in-window',
+                              requests_lib.RequestStatus.SUCCEEDED,
+                              created_at=now - 93 * 24 * 3600,
+                              finished_at=now - 60)
+        # 4. Finished long ago: excluded by the DB-level filter itself.
+        self._persist_request('req-finished-long-ago',
+                              requests_lib.RequestStatus.SUCCEEDED,
+                              created_at=now - 93 * 24 * 3600,
+                              finished_at=now - 93 * 24 * 3600 + 60)
+        mock_get_clusters.return_value = []
+        mock_dead_context.return_value = None
+        mock_queue_v2.return_value = ([], 0, {}, 0, [])
+
+        ctx = _make_context()
+        debug_utils._populate_recent_context(ctx,
+                                             minutes=60.0,
+                                             reachability=_StubReachability())
+
+        assert ctx['request_ids'] == {
+            'req-fresh-unfinished', 'req-old-finished-in-window'
+        }
+        assert ctx['request_ids_recent'] == ctx['request_ids']
+        scan = ctx['recent_request_scan']
+        # The finished-long-ago row is excluded by the SQL
+        # ('finished_at >= ? OR finished_at IS NULL'), so only three rows
+        # are scanned.
+        assert scan['scanned'] == 3
+        assert scan['included'] == 2
+        assert scan['included_unfinished'] == 1
+        assert scan['skipped_stale_unfinished'] == 1
+        assert scan['dropped_by_window_check'] == 0
+        assert scan['duration_s'] >= 0
 
 
 # ---------------------------------------------------------------------------
@@ -1769,12 +1963,99 @@ class TestCreateDebugDump:
         provenance = summary_data['provenance']
         assert provenance['user_requested'] == 1
         # Cross-link helpers are mocked out in this test.
+        assert provenance['via_recent_scan'] == 0
         assert provenance['via_cluster'] == 0
         assert provenance['via_job'] == 0
         # System daemon request IDs are always added.
         assert provenance['system'] >= 1
+        # The six buckets are exclusive and must sum exactly to the
+        # collected request count; untracked is a tripwire for a context
+        # adder that forgets to record provenance.
+        assert provenance['untracked'] == 0
+        bucket_sum = sum(provenance[bucket] for bucket in [
+            'user_requested', 'via_recent_scan', 'via_cluster', 'via_job',
+            'system', 'untracked'
+        ])
+        assert bucket_sum == summary_data['collected']['request_count']
         # No recent_minutes, so the recent scan did not run.
         assert provenance['recent_scan'] == {}
+
+    @mock.patch('sky.jobs.server.core.queue_v2')
+    @mock.patch('sky.utils.debug_utils._jobs_controller_unreachable_context')
+    @mock.patch('sky.utils.debug_utils.global_user_state.get_clusters')
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    @mock.patch('sky.utils.debug_utils._dump_managed_job_info')
+    @mock.patch('sky.utils.debug_utils._dump_cluster_info')
+    @mock.patch('sky.utils.debug_utils._dump_request_id_info')
+    @mock.patch('sky.utils.debug_utils._dump_server_info')
+    @mock.patch('sky.utils.debug_utils._get_clusters_from_managed_jobs')
+    @mock.patch('sky.utils.debug_utils._get_clusters_from_requests')
+    @mock.patch('sky.utils.debug_utils._get_managed_jobs_from_requests')
+    @mock.patch('sky.utils.debug_utils._get_requests_from_managed_jobs')
+    @mock.patch('sky.utils.debug_utils._get_requests_from_clusters')
+    def test_summary_provenance_with_recent_scan(
+            self, mock_req_from_clusters, mock_req_from_jobs,
+            mock_jobs_from_req, mock_clusters_from_req, mock_clusters_from_jobs,
+            mock_dump_server, mock_dump_requests, mock_dump_clusters,
+            mock_dump_jobs, mock_get_tasks, mock_get_clusters,
+            mock_dead_context, mock_queue_v2, tmp_path):
+        """End-to-end with recent_minutes: _populate_recent_context runs
+        for real (only its DB / kube-context / managed-jobs dependencies
+        are mocked), so the provenance buckets must attribute the
+        scan-added request to via_recent_scan and the six-bucket sum
+        invariant must hold on the produced summary.json."""
+        now = time.time()
+        mock_get_tasks.return_value = [
+            # In-window: unfinished, created within the window.
+            _make_request(request_id='req-recent',
+                          created_at=now - 60,
+                          finished_at=None),
+            # Stale: unfinished, created long before the window.
+            _make_request(request_id='req-stale',
+                          created_at=now - 93 * 24 * 3600,
+                          finished_at=None,
+                          status='CANCELLED'),
+        ]
+        mock_get_clusters.return_value = []
+        mock_dead_context.return_value = None
+        mock_queue_v2.return_value = ([], 0, {}, 0, [])
+
+        with mock.patch('sky.utils.debug_utils.DEBUG_DUMP_DIR',
+                        str(tmp_path / 'debug_dumps')):
+            result = debug_utils.create_debug_dump(request_ids=['req-1'],
+                                                   recent_minutes=60.0)
+
+        with zipfile.ZipFile(result, 'r') as zf:
+            summary_files = [
+                n for n in zf.namelist() if n.endswith('summary.json')
+            ]
+            summary_data = json.loads(zf.read(summary_files[0]))
+
+        provenance = summary_data['provenance']
+        collected = summary_data['collected']
+        # req-1 was user-requested; req-recent was first added by the
+        # recent scan; the stale row was skipped by the created_at
+        # backstop.
+        assert provenance['user_requested'] == 1
+        assert provenance['via_recent_scan'] == 1
+        assert provenance['via_cluster'] == 0
+        assert provenance['via_job'] == 0
+        assert provenance['system'] >= 1
+        assert provenance['untracked'] == 0
+        bucket_sum = sum(provenance[bucket] for bucket in [
+            'user_requested', 'via_recent_scan', 'via_cluster', 'via_job',
+            'system', 'untracked'
+        ])
+        assert bucket_sum == collected['request_count']
+        assert 'req-recent' in collected['request_ids']
+        assert 'req-stale' not in collected['request_ids']
+        scan = provenance['recent_scan']
+        assert scan['scanned'] == 2
+        assert scan['included'] == 1
+        assert scan['included_unfinished'] == 1
+        assert scan['skipped_stale_unfinished'] == 1
+        assert scan['dropped_by_window_check'] == 0
+        assert scan['duration_s'] >= 0
 
     @mock.patch('sky.utils.debug_utils._dump_managed_job_info')
     @mock.patch('sky.utils.debug_utils._dump_cluster_info')


### PR DESCRIPTION
## Problem

On a long-lived server with many stale unfinished requests, `sky debug-dump --recent-minutes 1.0` pulled in **7119 requests** even though only 173 had genuinely finished within the window. 97.6% of the included rows had `finished_at IS NULL` with a median age of ~93 days (mostly CANCELLED rows whose `finished_at` was never written on the cancel path).

Mechanism: the recent-activity scan reused `RequestTaskFilter(finished_after=...)`, which is a **listing** filter — its SQL renders `(finished_at >= ? OR finished_at IS NULL)`, so every never-finished request matches any cutoff regardless of age, with no `created_at` bound and no limit. Cross-linking then snowballed those 7119 rows into 9546 requests / 3610 clusters / 794 managed jobs, making the dump's per-section budget mathematically impossible to satisfy. `summary.json` paired `recent_minutes=1.0` with `request_count=9546` and no provenance breakdown, so the explosion was not explainable from the structured output alone.

## What this PR does

Commit 1 (`created_at` backstop):
- An unfinished request now counts as recent only when it was **created within the window**. Requests finished within the window are unaffected regardless of `created_at`, so no genuine recent activity is lost.
- The per-request `Recent: including` log line now carries status / created_at / age, and the scan emits one aggregate composition line.

Commit 2 (supersedes commit 1's provenance block, which could overlap, with exclusive buckets):
- `summary.json` gains **six exclusive provenance buckets** — `user_requested` / `via_recent_scan` / `via_cluster` / `via_job` / `system` / `untracked` — that sum exactly to `collected.request_count`. `via_recent_scan` is attributed through a tag-only-new sidecar (mirroring the existing `via_cluster` / `via_job` idiom), and `untracked != 0` is a tripwire for a future context adder that forgets provenance. On the server above, the scan would have read `scanned 7119, included the 173 requests that genuinely finished within the window plus the few unfinished ones created within it, and skipped the remaining ~6940 as stale` instead of silently pulling everything in.
- The scan records its full composition on the context (`scanned` / `included` / `included_unfinished` / `skipped_stale_unfinished` / `dropped_by_window_check` / `duration_s`), surfaced under `provenance.recent_scan`, with a deterministic key shape on every successful scan.
- **Fail-closed window re-check**: a finished row with `finished_at < cutoff` never enters the context even if the DB-level filter fails to exclude it — e.g. a custom request backend registered via the public `register_request_storage` plugin API whose `finished_after` semantics drift from the default sqlite backend. Mirrors the sibling cluster branch's client-side strict comparison; unreachable under the default backend.
- The aggregate composition line is promoted to **WARNING** whenever stale or out-of-window rows were dropped — a `finished_at`-hygiene signal operators should see at default log levels, not a tool failure.
- `RequestTaskFilter.finished_after`'s docstring now documents the listing semantic so the next caller does not unwittingly reuse it as a time window. Docstring-only; the filter's SQL and all its other callers are untouched.

No new user-facing configuration knobs; reverting the PR restores pre-fix behavior exactly.

## Known residuals (out of scope, follow-ups)

- The managed-jobs branch of the same scan uses `end_at = job.get('end_at') or time.time()`, so a never-ended managed job still matches any cutoff — the same pattern family on the jobs side. This PR fixes only the request-row seeding, which is what the evidence shows; the jobs-side residual is left for a separate change.
- `finished_at` is never written on the cancel/crash paths, which is the root data-quality gap that produced the stale-NULL population (and which the retention GC cannot clean, since its `finished_at < ?` predicate is NULL-rejecting). Separate PR.

## Testing

Unit tests (`tests/unit_tests/test_sky/utils/test_debug_utils.py`):
- Existing recent-scan tests extended and new tests added: fail-closed `dropped_by_window_check` pin; tag-only-new `request_ids_recent` attribution; per-key scan-composition assertions (including `duration_s >= 0`); WARNING-level (and DEBUG-when-clean) aggregate-line assertions; six-bucket sum-equals-`request_count` + `untracked == 0` assertions in both the provenance test and a new end-to-end `create_debug_dump(recent_minutes=...)` test with `_populate_recent_context` running for real.
- New DB-backed test class persists real `Request` rows through the sqlite backend (four production-mirroring row shapes: fresh-unfinished, stale-NULL terminal, old-created-finished-in-window, finished-long-ago) and runs the scan through the real `get_request_tasks` SQL + decode path. Its `isolated_database` fixture is deliberately duplicated from `tests/unit_tests/test_sky/server/requests/test_requests.py` rather than imported across test modules (cross-module test imports are fragile).
- `PYTHONPATH=. pytest tests/unit_tests/test_sky/utils/test_debug_utils.py -n 2 -q`: 216 passed, 8 failed — all 8 in `TestDumpKubeContextsInfo` / `TestCollectClusterKubernetesResources`, re-verified byte-identical with the changes stashed (environment-dependent kubeconfig behavior in this devspace, pre-existing on the base commit).
- `format.sh --files` on the three changed files: yapf/isort clean, mypy clean (601 files), pylint 10.00/10 on both changed `sky/` files.

End-to-end against a local API server running this branch, seeded through the real `requests_lib` write path with production-mirroring rows (93-day-old CANCELLED with `finished_at=None`; created-2h-ago SUCCEEDED finished within the last minute; created-in-window RUNNING with `finished_at=None`):
- `sky debug-dump --recent-minutes 1`: stale row excluded (`skipped_stale_unfinished` counted), `request_count` 8, the six buckets sum exactly to it with `untracked == 0` and `via_recent_scan == 1`, `dropped_by_window_check == 0`, `duration_s` present, composition line at WARNING in `debug_dump.log`.
- `sky debug-dump --recent-minutes 30`: finished-in-window and fresh-unfinished rows both included, only the stale row skipped (`skipped_stale_unfinished == 1`), bucket-sum invariant holds.
- Seeded rows deleted and the server stopped afterwards.

## Notes for reviewers

- The second commit supersedes the first commit's provenance block (overlapping buckets → exclusive buckets); both are kept as separate commits so the backstop-only state remains a clean revert point.
- This may conflict with other in-flight debug-dump changes touching `sky/utils/debug_utils.py`; happy to rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
