### PR TITLE
[Core] Bound every debug-dump phase behind the overall deadline

### DIFF
--- a/sky/core.py
+++ b/sky/core.py
@@ -2,6 +2,7 @@
 import concurrent.futures
 import json
 import shlex
+import time
 import typing
 from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
@@ -2020,8 +2021,11 @@ def create_debug_dump(request_ids: Optional[List[str]] = None,
             stop the whole collection by; when reached, collection stops early
             and a partial dump is returned. Passing an absolute deadline lets an
             out-of-process caller charge already-elapsed time (e.g. executor
-            queue wait) against the budget rather than ignoring it. None means
-            no deadline.
+            queue wait) against the budget rather than ignoring it. When None
+            (the default), the server applies its own backstop budget of
+            debug_utils._DEFAULT_DEBUG_DUMP_DEADLINE_S (1800s) so every
+            API-initiated dump is bounded; see that constant's comment for the
+            derivation. Explicit deadlines pass through verbatim.
 
     Returns:
         Path to the created zip file on the server.
@@ -2033,6 +2037,16 @@ def create_debug_dump(request_ids: Optional[List[str]] = None,
             recent_minutes is None):
         raise ValueError('At least one of request_ids, cluster_names, '
                          'managed_job_ids, or recent_minutes must be provided.')
+
+    if overall_deadline is None:
+        # Invariant: every API-initiated dump is bounded even when the caller
+        # sends no deadline -- an unbounded dump holds an API-server worker
+        # (and its executor slot) for as long as a single hung collection
+        # call persists. 1800s ~ 2x the largest observed near-feasible run
+        # (see debug_utils._DEFAULT_DEBUG_DUMP_DEADLINE_S); callers that need
+        # more can always pass an explicit overall_deadline.
+        overall_deadline = (time.time() +
+                            debug_utils._DEFAULT_DEBUG_DUMP_DEADLINE_S)  # pylint: disable=protected-access
 
     debug_dump_path = debug_utils.create_debug_dump(
         request_ids=request_ids,

--- a/sky/core.py
+++ b/sky/core.py
@@ -2023,9 +2023,9 @@ def create_debug_dump(request_ids: Optional[List[str]] = None,
             out-of-process caller charge already-elapsed time (e.g. executor
             queue wait) against the budget rather than ignoring it. When None
             (the default), the server applies its own backstop budget of
-            debug_utils._DEFAULT_DEBUG_DUMP_DEADLINE_S (1800s) so every
-            API-initiated dump is bounded; see that constant's comment for the
-            derivation. Explicit deadlines pass through verbatim.
+            debug_utils.DEBUG_DUMP_DEFAULT_DEADLINE_S so every
+            API-initiated dump is bounded; see that constant's comment for
+            the derivation. Explicit deadlines pass through verbatim.
 
     Returns:
         Path to the created zip file on the server.
@@ -2043,10 +2043,10 @@ def create_debug_dump(request_ids: Optional[List[str]] = None,
         # sends no deadline -- an unbounded dump holds an API-server worker
         # (and its executor slot) for as long as a single hung collection
         # call persists. 1800s ~ 2x the largest observed near-feasible run
-        # (see debug_utils._DEFAULT_DEBUG_DUMP_DEADLINE_S); callers that need
+        # (see debug_utils.DEBUG_DUMP_DEFAULT_DEADLINE_S); callers that need
         # more can always pass an explicit overall_deadline.
         overall_deadline = (time.time() +
-                            debug_utils._DEFAULT_DEBUG_DUMP_DEADLINE_S)  # pylint: disable=protected-access
+                            debug_utils.DEBUG_DUMP_DEFAULT_DEADLINE_S)
 
     debug_dump_path = debug_utils.create_debug_dump(
         request_ids=request_ids,

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -1028,7 +1028,8 @@ class CreateDebugDumpBody(RequestBody):
     client_info: Optional[Dict[str, Any]] = None
     # Best-effort absolute wall-clock (time.time()) instant to stop the whole
     # collection by. When reached, collection stops early and a partial dump is
-    # returned. None (the default) means no deadline == previous behavior. An
+    # returned. None (the default) means the server applies its own backstop
+    # budget (see core.create_debug_dump), so the dump is always bounded. An
     # absolute deadline (rather than a relative timeout) is used because this
     # request is scheduled out-of-process: it charges executor queue wait
     # before the build starts against the budget rather than ignoring it.

--- a/sky/utils/debug_utils.py
+++ b/sky/utils/debug_utils.py
@@ -303,8 +303,9 @@ DEBUG_DUMP_DIR = '~/.sky/debug_dumps'
 # truncates by design; 1800s gives ~2x headroom over the largest observed
 # near-feasible run while still bounding the previously unbounded no-deadline
 # case (a wedged dump used to hold an API-server worker forever). Explicit
-# caller deadlines always pass through verbatim.
-_DEFAULT_DEBUG_DUMP_DEADLINE_S = 1800.0
+# caller deadlines always pass through verbatim. Public (no leading
+# underscore) because core.create_debug_dump references it cross-module.
+DEBUG_DUMP_DEFAULT_DEADLINE_S = 1800.0
 
 # Env var names whose values should be redacted (show bool presence only).
 # Used for both server_info environment and request body sanitization.
@@ -1178,6 +1179,14 @@ def _dump_server_info(dump_dir: str,
     # and returns not-ok, so we skip enabled_clouds and move on rather than
     # hang the dump. The helper clamps the fixed cap to the remaining overall
     # budget so this probe can't overrun a set deadline.
+    # Which not-ok fate would the helper report if the wait fails: the
+    # overall budget (a skip) or the fixed sky-check cap (a genuine stall)?
+    # Decided here, before submission, mirroring the helper's own
+    # pre-submit attribution -- re-checking the deadline AFTER the wait
+    # would misreport a genuine full-cap stall that also exhausted the
+    # remaining budget as a skip.
+    clamp_binding = (_bounded_timeout(_SKY_CHECK_TIMEOUT, deadline) <
+                     _SKY_CHECK_TIMEOUT)
     try:
         ok, enabled_clouds = _run_with_deadline(
             functools.partial(sky_check.check, quiet=True),
@@ -1187,25 +1196,20 @@ def _dump_server_info(dump_dir: str,
             errors=errors,
             orphans=orphans,
             deadline=deadline,
-            op_desc=('enabled-clouds check; '
-                     'the dump omits the '
-                     'cloud status '
-                     'snapshot'))
+            op_desc=('enabled-clouds check; the dump omits the '
+                     'cloud status snapshot'))
         if ok:
             server_info['enabled_clouds'] = enabled_clouds
+        elif clamp_binding:
+            # The overall budget, not the check, ran out.
+            server_info['cloud_status_error'] = (
+                'sky check skipped: overall debug-dump deadline exceeded; '
+                'enabled_clouds omitted from the dump.')
         else:
-            # The helper's (False, None) covers both a genuine stall and a
-            # budget skip; pick the message from the deadline state so we
-            # never misreport one as the other.
-            if _deadline_exceeded(deadline):
-                server_info['cloud_status_error'] = (
-                    'sky check skipped: overall debug-dump deadline exceeded; '
-                    'enabled_clouds omitted from the dump.')
-            else:
-                server_info['cloud_status_error'] = (
-                    f'sky check timed out after {_SKY_CHECK_TIMEOUT}s (likely '
-                    f'a defunct/unreachable cloud or kube context); skipping '
-                    f'enabled_clouds in the dump.')
+            server_info['cloud_status_error'] = (
+                f'sky check timed out after {_SKY_CHECK_TIMEOUT}s (likely '
+                f'a defunct/unreachable cloud or kube context); skipping '
+                f'enabled_clouds in the dump.')
     except Exception as e:  # pylint: disable=broad-except
         server_info['cloud_status_error'] = str(e)
         if errors is not None:
@@ -2690,7 +2694,10 @@ def _build_debug_dump(
     # the budget can hold them, and a dump that is mathematically certain
     # to truncate should say so up front (the measured in-loop projection
     # in _dump_request_id_info catches mid-section slowdowns this cannot).
-    if budget is not None:
+    # Not fired once the budget is already gone: the section skip records
+    # report that truthfully, and a non-positive remainder would only add
+    # noise like '~Ns vs -0s of budget'.
+    if budget is not None and budget > 0:
         request_count = len(debug_dump_context['request_ids'])
         projected_requests = (request_count * _PROJECTED_SECONDS_PER_REQUEST)
         if projected_requests > budget:
@@ -2987,6 +2994,9 @@ def create_debug_dump(
             # In-archive zip stats (appended best-effort AFTER the zip closes,
             # so it can never fail the dump): the deterministic record of
             # whether the archive is complete or deadline-truncated.
+            # file_count excludes zip_stats.json itself -- this record is
+            # appended after the zip (and the count) is already final, so
+            # the finished archive holds file_count + 1 entries.
             try:
                 zip_stats = {
                     'duration_s': round(time.monotonic() - zip_start, 2),

--- a/sky/utils/debug_utils.py
+++ b/sky/utils/debug_utils.py
@@ -12,6 +12,8 @@ import platform
 import posixpath
 import re
 import shutil
+import sys
+import threading
 import time
 import traceback
 from typing import (Any, Callable, Dict, List, Optional, Set, Tuple, TypedDict,
@@ -85,17 +87,36 @@ def _bounded_timeout(fixed: float, deadline: Optional[float]) -> float:
 
     With no deadline this is just ``fixed`` (unchanged behavior). With a
     deadline it is ``min(fixed, remaining_budget)`` so an operation started
-    late can't overrun the overall budget by its full fixed timeout; when the
-    budget is already gone the op gets a non-positive timeout and fails fast,
-    which its existing best-effort handler records as a partial failure.
+    late can't overrun the overall budget by its full fixed timeout; when
+    the budget is already gone the op gets a 0.0 timeout (floored -- a
+    negative remainder must never leak into a timeout value or an error
+    message) and fails fast, which its existing best-effort handler records
+    as a partial failure.
     """
     remaining = _remaining_budget(deadline)
     if remaining is None:
         return fixed
-    return min(fixed, remaining)
+    return max(0.0, min(fixed, remaining))
 
 
 T = TypeVar('T')
+
+
+def _capture_thread_stack(thread_id: Optional[int]) -> Optional[str]:
+    """Best-effort snapshot of a thread's current stack.
+
+    Returns None if the thread is unknown or the capture fails -- a missing
+    stack must never break the caller that is already handling a timeout.
+    """
+    if thread_id is None:
+        return None
+    try:
+        frame = sys._current_frames().get(thread_id)  # pylint: disable=protected-access
+        if frame is not None:
+            return ''.join(traceback.format_stack(frame))
+    except Exception:  # pylint: disable=broad-except
+        pass
+    return None
 
 
 def _run_with_deadline(
@@ -106,84 +127,184 @@ def _run_with_deadline(
     resource: str,
     errors: Optional[List[Dict[str, str]]] = None,
     orphans: Optional[List[Dict[str, Any]]] = None,
+    deadline: Optional[float] = None,
+    op_desc: Optional[str] = None,
 ) -> Tuple[bool, Optional[T]]:
     """Run ``fn()`` in a worker thread bounded by a wall-clock timeout.
 
-    Returns ``(True, result)`` if ``fn()`` completes within ``timeout``. On
-    timeout a partial-failure record is appended to ``errors`` (mirroring the
-    shared error-record shape) and ``(False, None)`` is returned -- but note
-    the worker is NOT stopped: Python can't kill a thread, and
+    ``timeout`` is the fixed per-op cap; when ``deadline`` (an absolute
+    ``time.monotonic()`` overall-dump budget) is set it is clamped to the
+    remaining budget inside this helper. Returns ``(True, result)`` if
+    ``fn()`` completes in time. On timeout a partial-failure record is
+    appended to ``errors`` and ``(False, None)`` is returned -- but note the
+    worker is NOT stopped: Python can't kill a thread, and
     ``future.result(timeout=)`` only stops us *waiting*, so ``fn`` keeps
-    running in the background until it returns on its own. The abandoned op is
-    appended to ``orphans`` (the per-dump list threaded alongside ``errors``)
-    so _log_timed_out_stragglers can report at dump end which ones are still
-    running (see there for why we don't reap). Any OTHER exception raised by
-    ``fn()`` propagates to the caller, so each call site keeps its own existing
-    non-timeout handling.
+    running in the background until it returns on its own. The abandoned op
+    is appended to ``orphans`` (the per-dump list threaded alongside
+    ``errors``) so _log_timed_out_stragglers can report at dump end which
+    ones are still running (see there for why we don't reap). Any OTHER
+    exception raised by ``fn()`` propagates to the caller, so each call site
+    keeps its own existing non-timeout handling.
 
-    Same executor-deadline pattern as the sky-check probe. We shut the executor
-    down with ``wait=False`` in a ``finally`` -- covering success, timeout, and
-    any other exception, so the executor object is never leaked -- while never
-    re-blocking on a still-running worker (which a ``with`` / the default
-    ``shutdown(wait=True)`` would do on timeout, defeating the whole point).
+    Attribution rules (a timeout record must say WHAT hung and what its
+    loss degrades, and must never misreport budget exhaustion as a stall):
+      * Pre-submit guard: if the overall ``deadline`` has already passed,
+        ``fn`` is never submitted -- the standard budget-skip record is
+        appended (no traceback, no orphan; no worker exists to orphan).
+      * Budget-binding timeout (the deadline clamp, not the fixed cap, cut
+        the wait short): the same standard budget-skip record is appended,
+        plus an orphan entry -- a worker WAS submitted and abandoned, and
+        _log_timed_out_stragglers needs the orphan to report a worker that
+        finished after timing out.
+      * Cap-binding timeout (a genuine stall): the record names the
+        operation (``op_desc``), reports the fixed cap rounded to 0.1s, and
+        carries a best-effort ``worker_stack`` captured from the stuck
+        worker thread via sys._current_frames -- never the waiter's stack,
+        which is byte-identical for every timeout and points at this
+        helper instead of the hung call.
+
+    Same executor-deadline pattern as the sky-check probe. We shut the
+    executor down with ``wait=False`` in a ``finally`` -- covering success,
+    timeout, and any other exception, so the executor object is never
+    leaked -- while never re-blocking on a still-running worker (which a
+    ``with`` / the default ``shutdown(wait=True)`` would do on timeout,
+    defeating the whole point).
     """
+    # Pre-submit guard: this is the ONLY path that omits the orphan entry,
+    # because no worker was ever submitted.
+    if _deadline_exceeded(deadline):
+        msg = 'Skipped: overall debug-dump deadline exceeded.'
+        logger.warning(f'{component}/{resource}: {msg}')
+        if errors is not None:
+            errors.append({
+                'component': component,
+                'resource': resource,
+                'error': msg,
+            })
+        return False, None
+
+    # Which bound will a TimeoutError mean: the overall budget (a skip) or
+    # the fixed per-op cap (a real stall)? Decided here, before submission,
+    # so the handler below can't misattribute.
+    clamp_binding = False
+    if timeout is not None:
+        clamped = _bounded_timeout(timeout, deadline)
+        clamp_binding = clamped < timeout
+        timeout = clamped
+
+    worker_thread_id = None
+
+    def _fn_recording_thread() -> T:
+        nonlocal worker_thread_id
+        worker_thread_id = threading.get_ident()
+        return fn()
+
     executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
     started = time.monotonic()
     try:
-        future = executor.submit(fn)
+        future = executor.submit(_fn_recording_thread)
         try:
             return True, future.result(timeout=timeout)
         except concurrent.futures.TimeoutError:
-            msg = (f'{component}/{resource} timed out after {timeout}s; '
-                   'recorded as a partial failure and skipped so the rest of '
-                   'the dump still completes.')
-            logger.warning(msg)
-            if errors is not None:
-                errors.append({
-                    'component': component,
-                    'resource': resource,
-                    'error': msg,
-                    'traceback': _full_traceback(),
-                })
+            # A worker was submitted and is now abandoned: record the orphan
+            # for BOTH attribution branches (see docstring).
             if orphans is not None:
                 orphans.append({
                     'component': component,
                     'resource': resource,
                     'future': future,
                     'started': started,
+                    'timed_out_at': time.monotonic(),
+                    'thread_id': worker_thread_id,
                 })
+            if clamp_binding:
+                # The overall budget, not the operation, ran out. Same
+                # truthful skip record as every other budget-exceeded path.
+                msg = 'Skipped: overall debug-dump deadline exceeded.'
+                logger.warning(f'{component}/{resource}: {msg}')
+                if errors is not None:
+                    errors.append({
+                        'component': component,
+                        'resource': resource,
+                        'error': msg,
+                    })
+                return False, None
+            desc = f' ({op_desc})' if op_desc else ''
+            msg = (f'{component}/{resource}{desc} timed out after '
+                   f'{timeout:.1f}s; recorded as a partial failure and '
+                   'skipped so the rest of the dump still completes.')
+            logger.warning(msg)
+            if errors is not None:
+                record = {
+                    'component': component,
+                    'resource': resource,
+                    'error': msg,
+                }
+                if op_desc is not None:
+                    record['operation'] = op_desc
+                worker_stack = _capture_thread_stack(worker_thread_id)
+                if worker_stack is not None:
+                    record['worker_stack'] = worker_stack
+                errors.append(record)
             return False, None
     finally:
         executor.shutdown(wait=False)
 
 
 def _log_timed_out_stragglers(orphans: List[Dict[str, Any]]) -> None:
-    """Log any timed-out op in ``orphans`` whose worker thread is STILL running
-    at dump end.
+    """Log the fate of each timed-out op in ``orphans`` at dump end.
 
     Backstop visibility: Python can't kill the thread (see _run_with_deadline),
     so we don't actively reap it here -- it exits when its underlying call
-    (typically a command-runner subprocess) returns. This surfaces what leaked
-    and for how long, so we can decide whether it's worth escalating (targeted
-    timeouts / subprocess isolation). Best-effort: logs and swallows its own
-    errors so it can never break the dump's final steps.
+    (typically a command-runner subprocess) returns. Two fates are worth
+    surfacing:
+      * the worker is STILL running: log how long it has leaked (plus its
+        current stack, best-effort) so we can decide whether it's worth
+        escalating (targeted timeouts / subprocess isolation);
+      * the worker COMPLETED after we gave up on it: its result was silently
+        discarded, so say so -- "data existed but was dropped" must be
+        visible, not inferred from absence.
+    Best-effort: logs and swallows its own errors so it can never break the
+    dump's final steps.
     """
     try:
         now = time.monotonic()
         for op in orphans:
             if op['future'].done():
+                timed_out_at = op.get('timed_out_at', op['started'])
+                logger.warning(
+                    '[debug-dump] worker thread for %s/%s completed %.0fs '
+                    'after timing out; result was discarded (the dump moved '
+                    'on without it).', op['component'], op['resource'],
+                    now - timed_out_at)
                 continue
             logger.warning(
                 '[debug-dump] worker thread for %s/%s still running %.0fs '
                 'after it timed out; not stopped (Python cannot kill a thread) '
                 '-- it will exit when its underlying call returns.',
                 op['component'], op['resource'], now - op['started'])
+            stack = _capture_thread_stack(op.get('thread_id'))
+            if stack:
+                logger.warning(
+                    '[debug-dump] current stack of the still-running worker '
+                    'for %s/%s:\n%s', op['component'], op['resource'], stack)
     except Exception:  # pylint: disable=broad-except
         logger.exception('_log_timed_out_stragglers failed')
 
 
 # Persistent location for debug dumps
 DEBUG_DUMP_DIR = '~/.sky/debug_dumps'
+
+# Server-side backstop budget (seconds) applied by core.create_debug_dump when
+# the caller sends no overall_deadline, so every API-initiated dump is bounded.
+# Derivation: production evidence shows a ~840s caller budget was already
+# infeasible for a server with ~9.5k requests in scope (~80ms/request projects
+# to ~765s for the requests section alone), so anything near that magnitude
+# truncates by design; 1800s gives ~2x headroom over the largest observed
+# near-feasible run while still bounding the previously unbounded no-deadline
+# case (a wedged dump used to hold an API-server worker forever). Explicit
+# caller deadlines always pass through verbatim.
+_DEFAULT_DEBUG_DUMP_DEADLINE_S = 1800.0
 
 # Env var names whose values should be redacted (show bool presence only).
 # Used for both server_info environment and request body sanitization.
@@ -324,14 +445,32 @@ class DebugDumpContext(TypedDict):
     timed_out_ops: List[Dict[str, Any]]
 
 
-def _get_requests_from_clusters(debug_dump_context: DebugDumpContext) -> None:
-    """Get all request IDs associated with the given clusters."""
+def _get_requests_from_clusters(debug_dump_context: DebugDumpContext,
+                                deadline: Optional[float] = None) -> None:
+    """Get all request IDs associated with the given clusters.
+
+    ``deadline`` (absolute monotonic) bounds the per-cluster loop: once the
+    budget is gone we stop expanding and record ONE aggregate skip entry
+    naming how many clusters were left, so a large fleet behind a slow DB
+    can't eat the whole dump budget before the sections run.
+    """
     if not debug_dump_context['cluster_names']:
         return
     logger.debug(
         f'Getting requests for {len(debug_dump_context["cluster_names"])} '
         f'clusters')
-    for cluster_name in debug_dump_context['cluster_names']:
+    cluster_names = list(debug_dump_context['cluster_names'])
+    for index, cluster_name in enumerate(cluster_names):
+        if _deadline_exceeded(deadline):
+            remaining = len(cluster_names) - index
+            debug_dump_context['errors'].append({
+                'component': 'cross_link',
+                'resource': 'requests_from_clusters',
+                'error':
+                    'Skipped: overall debug-dump deadline exceeded. '
+                    f'{remaining} cluster(s) were not expanded into requests.',
+            })
+            return
         try:
             requests = requests_lib.get_request_tasks(
                 requests_lib.RequestTaskFilter(cluster_names=[cluster_name],
@@ -394,11 +533,14 @@ def _get_requests_from_managed_jobs(
                                   job_ids=list(
                                       debug_dump_context['managed_job_ids']),
                                   all_users=True),
-                _bounded_timeout(_MANAGED_JOB_QUEUE_TIMEOUT, deadline),
+                _MANAGED_JOB_QUEUE_TIMEOUT,
                 component='cross_link',
                 resource='managed_job_details',
                 errors=debug_dump_context['errors'],
-                orphans=debug_dump_context['timed_out_ops'])
+                orphans=debug_dump_context['timed_out_ops'],
+                deadline=deadline,
+                op_desc=('managed job details fetch; managed jobs are not '
+                         'matched by name/user during request cross-linking'))
             if ok and result is not None:
                 jobs, _, _, _, _ = result
                 for job in jobs:
@@ -491,23 +633,38 @@ def _get_requests_from_managed_jobs(
         })
 
 
-def _get_clusters_from_requests(debug_dump_context: DebugDumpContext) -> None:
+def _get_clusters_from_requests(debug_dump_context: DebugDumpContext,
+                                deadline: Optional[float] = None) -> None:
     """Get cluster names from the given request IDs.
 
     Skips requests that were themselves added because they reference a
     cluster — that's a same-type re-expansion (cluster -> request ->
     cluster) and would let a cluster that touched many requests drag
     every other cluster touched by those requests into the dump.
+
+    ``deadline`` (absolute monotonic) bounds the per-request loop: once the
+    budget is gone we stop expanding and record ONE aggregate skip entry
+    naming how many requests were left.
     """
     # Requests added by _get_requests_from_clusters must not re-seed
     # cluster_names here. Other origins (user seed, recent context,
     # _get_requests_from_managed_jobs) remain free to expand.
-    request_ids = (debug_dump_context['request_ids'] -
-                   debug_dump_context['request_ids_via_cluster'])
+    request_ids = list(debug_dump_context['request_ids'] -
+                       debug_dump_context['request_ids_via_cluster'])
     if not request_ids:
         return
     logger.debug(f'Getting clusters for {len(request_ids)} requests')
-    for request_id in request_ids:
+    for index, request_id in enumerate(request_ids):
+        if _deadline_exceeded(deadline):
+            remaining = len(request_ids) - index
+            debug_dump_context['errors'].append({
+                'component': 'cross_link',
+                'resource': 'clusters_from_requests',
+                'error':
+                    'Skipped: overall debug-dump deadline exceeded. '
+                    f'{remaining} request(s) were not expanded into clusters.',
+            })
+            return
         try:
             request = requests_lib.get_request(request_id,
                                                fields=['cluster_name'])
@@ -526,8 +683,8 @@ def _get_clusters_from_requests(debug_dump_context: DebugDumpContext) -> None:
             })
 
 
-def _get_managed_jobs_from_requests(
-        debug_dump_context: DebugDumpContext) -> None:
+def _get_managed_jobs_from_requests(debug_dump_context: DebugDumpContext,
+                                    deadline: Optional[float] = None) -> None:
     """Extract managed job IDs from request bodies.
 
     If any request in the context is a managed job request (launch, cancel,
@@ -544,17 +701,32 @@ def _get_managed_jobs_from_requests(
     job — that's a same-type re-expansion (job -> request -> job) which
     would let an over-broad matcher (body.name, body.all_users, body.all)
     drag every sibling job of a batch-style request into the dump.
+
+    ``deadline`` (absolute monotonic) bounds the per-request loop: once the
+    budget is gone we stop expanding and record ONE aggregate skip entry
+    naming how many requests were left.
     """
     # Requests added by _get_requests_from_managed_jobs must not re-seed
     # managed_job_ids here. (With the current cross-link ordering that
     # helper runs after this one, so the subtraction is defensive.)
-    request_ids = (debug_dump_context['request_ids'] -
-                   debug_dump_context['request_ids_via_job'])
+    request_ids = list(debug_dump_context['request_ids'] -
+                       debug_dump_context['request_ids_via_job'])
     if not request_ids:
         return
     logger.debug(f'Getting managed jobs for {len(request_ids)} requests')
 
-    for request_id in request_ids:
+    for index, request_id in enumerate(request_ids):
+        if _deadline_exceeded(deadline):
+            remaining = len(request_ids) - index
+            debug_dump_context['errors'].append({
+                'component': 'cross_link',
+                'resource': 'managed_jobs_from_requests',
+                'error':
+                    'Skipped: overall debug-dump deadline exceeded. '
+                    f'{remaining} request(s) were not expanded into managed '
+                    'jobs.',
+            })
+            return
         try:
             request = requests_lib.get_request(
                 request_id, fields=['name', 'request_body', 'return_value'])
@@ -666,18 +838,23 @@ def _get_managed_jobs_from_clusters(
                                    dead_context))
         return
     try:
-        # Bound the queue_v2 call dump-side (see _MANAGED_JOB_QUEUE_TIMEOUT); on
-        # timeout the helper records it and we skip the expansion, mirroring the
-        # except-and-return degrade below.
+        # Bound the queue_v2 call dump-side (see
+        # _RECENT_MANAGED_JOBS_QUEUE_TIMEOUT); on timeout the helper records
+        # it and we skip the expansion, mirroring the except-and-return
+        # degrade below.
         ok, result = _run_with_deadline(
             functools.partial(managed_jobs_core.queue_v2,
                               refresh=False,
                               all_users=True),
-            _bounded_timeout(_MANAGED_JOB_QUEUE_TIMEOUT, deadline),
+            _RECENT_MANAGED_JOBS_QUEUE_TIMEOUT,
             component='cross_link',
             resource='managed_jobs_from_clusters',
             errors=debug_dump_context['errors'],
-            orphans=debug_dump_context['timed_out_ops'])
+            orphans=debug_dump_context['timed_out_ops'],
+            deadline=deadline,
+            op_desc=('cluster-to-job expansion; jobs running on the '
+                     'explicitly requested clusters are not cross-linked '
+                     'into the dump'))
         if not ok or result is None:
             return
         jobs, _, _, _, _ = result
@@ -700,7 +877,8 @@ def _get_managed_jobs_from_clusters(
 
 
 def _get_job_clusters_from_managed_jobs(
-        debug_dump_context: DebugDumpContext) -> None:
+        debug_dump_context: DebugDumpContext,
+        deadline: Optional[float] = None) -> None:
     """Get the underlying per-job cluster names from managed jobs.
 
     Only meaningful in consolidation mode, where job clusters are recorded
@@ -721,9 +899,26 @@ def _get_job_clusters_from_managed_jobs(
     job_ids = list(debug_dump_context['managed_job_ids'])
     logger.debug(f'Getting job clusters for {len(job_ids)} managed jobs')
     try:
-        jobs, _, _, _, _ = managed_jobs_core.queue_v2(refresh=False,
-                                                      job_ids=job_ids,
-                                                      all_users=True)
+        # Bound the queue_v2 call dump-side like the other queue_v2 call
+        # sites (see _MANAGED_JOB_QUEUE_TIMEOUT); on timeout the helper
+        # records it and we degrade to no job-cluster names, mirroring the
+        # except-and-return below.
+        ok, result = _run_with_deadline(
+            functools.partial(managed_jobs_core.queue_v2,
+                              refresh=False,
+                              job_ids=job_ids,
+                              all_users=True),
+            _MANAGED_JOB_QUEUE_TIMEOUT,
+            component='cross_link',
+            resource='job_clusters_from_managed_jobs',
+            errors=debug_dump_context['errors'],
+            orphans=debug_dump_context['timed_out_ops'],
+            deadline=deadline,
+            op_desc=('job-to-cluster expansion; per-job cluster names are '
+                     'not cross-linked into the dump'))
+        if not ok or result is None:
+            return
+        jobs, _, _, _, _ = result
         job_cluster_names = _managed_job_cluster_names_from_records(jobs)
     except Exception as e:  # pylint: disable=broad-except
         logger.warning(f'Failed to get job clusters for managed jobs: {e}')
@@ -853,17 +1048,23 @@ def _populate_recent_context(
     else:
         try:
             # Bound the queue_v2 call dump-side (see
-            # _MANAGED_JOB_QUEUE_TIMEOUT); on timeout the helper records it and
-            # we skip the recent-jobs scan, mirroring the except degrade below.
+            # _RECENT_MANAGED_JOBS_QUEUE_TIMEOUT); on timeout the helper
+            # records it and we skip the recent-jobs scan, mirroring the
+            # except degrade below.
             ok, result = _run_with_deadline(
                 functools.partial(managed_jobs_core.queue_v2,
                                   refresh=False,
                                   all_users=True),
-                _bounded_timeout(_MANAGED_JOB_QUEUE_TIMEOUT, deadline),
+                _RECENT_MANAGED_JOBS_QUEUE_TIMEOUT,
                 component='recent_context',
                 resource='managed_jobs',
                 errors=debug_dump_context['errors'],
-                orphans=debug_dump_context['timed_out_ops'])
+                orphans=debug_dump_context['timed_out_ops'],
+                deadline=deadline,
+                op_desc=('recent-activity managed jobs scan; only the '
+                         'recent-jobs expansion is lost (jobs referenced by '
+                         'dumped requests are still recovered from their '
+                         'request bodies)'))
             if ok and result is not None:
                 jobs, _, _, _, _ = result
                 for job in jobs:
@@ -975,24 +1176,36 @@ def _dump_server_info(dump_dir: str,
     # the shared executor-deadline helper: run it in a worker thread with a
     # wall-clock deadline. On timeout the helper records a partial-result error
     # and returns not-ok, so we skip enabled_clouds and move on rather than
-    # hang the dump. The timeout is clamped to the remaining overall budget so
-    # this probe can't overrun a set deadline.
-    sky_check_timeout = _bounded_timeout(_SKY_CHECK_TIMEOUT, deadline)
+    # hang the dump. The helper clamps the fixed cap to the remaining overall
+    # budget so this probe can't overrun a set deadline.
     try:
-        ok, enabled_clouds = _run_with_deadline(functools.partial(
-            sky_check.check, quiet=True),
-                                                sky_check_timeout,
-                                                component='server_info',
-                                                resource='cloud_status',
-                                                errors=errors,
-                                                orphans=orphans)
+        ok, enabled_clouds = _run_with_deadline(
+            functools.partial(sky_check.check, quiet=True),
+            _SKY_CHECK_TIMEOUT,
+            component='server_info',
+            resource='cloud_status',
+            errors=errors,
+            orphans=orphans,
+            deadline=deadline,
+            op_desc=('enabled-clouds check; '
+                     'the dump omits the '
+                     'cloud status '
+                     'snapshot'))
         if ok:
             server_info['enabled_clouds'] = enabled_clouds
         else:
-            server_info['cloud_status_error'] = (
-                f'sky check timed out after {sky_check_timeout}s (likely a '
-                f'defunct/unreachable cloud or kube context); skipping '
-                f'enabled_clouds in the dump.')
+            # The helper's (False, None) covers both a genuine stall and a
+            # budget skip; pick the message from the deadline state so we
+            # never misreport one as the other.
+            if _deadline_exceeded(deadline):
+                server_info['cloud_status_error'] = (
+                    'sky check skipped: overall debug-dump deadline exceeded; '
+                    'enabled_clouds omitted from the dump.')
+            else:
+                server_info['cloud_status_error'] = (
+                    f'sky check timed out after {_SKY_CHECK_TIMEOUT}s (likely '
+                    f'a defunct/unreachable cloud or kube context); skipping '
+                    f'enabled_clouds in the dump.')
     except Exception as e:  # pylint: disable=broad-except
         server_info['cloud_status_error'] = str(e)
         if errors is not None:
@@ -1068,11 +1281,14 @@ def _dump_request_id_info(
     """Collect request logs and metadata.
 
     ``deadline`` (absolute monotonic) bounds the section two ways: each
-    per-request log copy is capped by ``_bounded_timeout`` (so a single
-    long-running request's still-streaming log can't dominate), and once the
-    budget is gone we stop starting new requests and skip the rest -- so the
-    dump still zips what it gathered. Per-request wall-clock is written to
-    ``requests/_timings.json``.
+    per-request log copy is capped by the fixed ``_REQUEST_LOG_COPY_TIMEOUT``
+    clamped to the remaining budget inside the helper, and once the budget is
+    gone we stop starting new requests and skip the rest -- so the dump still
+    zips what it gathered. Per-request wall-clock is written to
+    ``requests/_timings.json``. When the measured running-average duration
+    projects the remaining requests past the budget, a one-time
+    ``budget_projection`` warning is logged and recorded in ``errors`` (the
+    measured complement of the static projection at section start).
     """
     if not request_ids:
         logger.debug('No requests to dump')
@@ -1084,6 +1300,7 @@ def _dump_request_id_info(
     os.makedirs(requests_dir, exist_ok=True)
 
     timings: List[Dict[str, Any]] = []
+    overrun_warned = False
     for request_id in request_ids:
         if _deadline_exceeded(deadline):
             if errors is not None:
@@ -1155,17 +1372,22 @@ def _dump_request_id_info(
         # deployments whose request logs are not on the local filesystem
         # can fetch them from wherever they live. Deadline-bounded: a
         # streaming/active request's copy can block for tens of seconds.
+        # The helper's pre-submit guard turns a budget-exhausted copy into
+        # the standard skip record (never a bogus near-zero "timeout").
         try:
             ok, copied = _run_with_deadline(
                 functools.partial(_copy_request_log_file, request_id,
                                   request_dir,
                                   log_provider.RequestLogType.REQUEST,
                                   'request.log'),
-                _bounded_timeout(_REQUEST_LOG_COPY_TIMEOUT, deadline),
+                _REQUEST_LOG_COPY_TIMEOUT,
                 component='requests',
                 resource=f'{request_id}/log',
                 errors=errors,
-                orphans=orphans)
+                orphans=orphans,
+                deadline=deadline,
+                op_desc=('request log copy; the request\'s log is omitted '
+                         'from the dump'))
             if ok and copied:
                 logger.debug(f'Copied request log for {request_id}')
             elif ok:
@@ -1188,11 +1410,14 @@ def _dump_request_id_info(
                                   request_dir,
                                   log_provider.RequestLogType.DEBUG,
                                   'request_debug.log'),
-                _bounded_timeout(_REQUEST_LOG_COPY_TIMEOUT, deadline),
+                _REQUEST_LOG_COPY_TIMEOUT,
                 component='requests',
                 resource=f'{request_id}/request_debug.log',
                 errors=errors,
-                orphans=orphans)
+                orphans=orphans,
+                deadline=deadline,
+                op_desc=('request debug log copy; the request\'s debug log '
+                         'is omitted from the dump'))
             if ok and copied:
                 logger.debug(f'Copied debug log for {request_id}')
         except Exception as e:  # pylint: disable=broad-except
@@ -1210,6 +1435,32 @@ def _dump_request_id_info(
             'request_id': request_id,
             'duration_s': round(time.monotonic() - request_start, 2),
         })
+        # Measured feasibility check (complement of the static projection
+        # at the start of the sections): once the running-average request
+        # duration projects the remaining requests past the budget, warn
+        # exactly once -- this catches a mid-section slowdown (e.g. a DB
+        # going read-only) that the static constant cannot.
+        if (not overrun_warned and deadline is not None and timings):
+            elapsed_sum = sum(t['duration_s'] for t in timings)
+            remaining_requests = len(request_ids) - len(timings)
+            projected = (elapsed_sum / len(timings)) * remaining_requests
+            remaining_budget = _remaining_budget(deadline)
+            if (remaining_requests > 0 and remaining_budget is not None and
+                    projected > remaining_budget):
+                overrun_warned = True
+                msg = (f'debug dump: projected overrun -- requests are '
+                       f'averaging {elapsed_sum / len(timings):.3f}s and the '
+                       f'remaining {remaining_requests} request(s) project '
+                       f'to ~{projected:.0f}s vs {remaining_budget:.0f}s of '
+                       'budget left; the dump will truncate before '
+                       'collecting every request.')
+                logger.warning(msg)
+                if errors is not None:
+                    errors.append({
+                        'component': 'requests',
+                        'resource': 'budget_projection',
+                        'error': msg,
+                    })
 
     try:
         with open(os.path.join(requests_dir, '_timings.json'),
@@ -1262,6 +1513,35 @@ _CONTROLLER_RSYNC_TIMEOUT = 120
 # code. Same magnitude as the controller bounds above; a timeout is recorded as
 # a partial failure and the caller degrades to an empty result.
 _MANAGED_JOB_QUEUE_TIMEOUT = 120
+
+# Tighter cap for the two UNFILTERED all_users queue_v2 calls (the
+# recent-activity scan and the cluster-to-job expansion). These are
+# scope-expansion hints whose data is cheap to recover elsewhere: the
+# request-body scan in _get_managed_jobs_from_requests independently finds
+# every managed job referenced by a dumped request (observed in a large
+# production dump: the 120s unfiltered recent-jobs call returned zero jobs
+# while the request-body scan recovered all ~800 jobs in scope). A slow
+# controller must therefore not cost 120s of budget for a hint. Deliberately
+# within the 15-30s range sanctioned for this call: on a large-but-healthy
+# controller that takes >30s, the expansion is lost (degradation recorded via
+# the helper's op_desc error record) rather than the dump budget being burned.
+_RECENT_MANAGED_JOBS_QUEUE_TIMEOUT = 30
+
+# Fraction of the overall budget (as of the start of the cross-link phase)
+# reserved for context population. The phase runs before any section, so
+# without a sub-budget a couple of slow cross-link calls could silently
+# consume most of the deadline and starve the sections the user actually
+# asked for; 25% keeps the phase generous for healthy servers while capping
+# the damage a hanging controller scan can do before the sections start.
+_CONTEXT_POPULATION_BUDGET_FRACTION = 0.25
+
+# Coarse per-request cost heuristic used for the start-of-sections
+# feasibility projection. Provenance: a single production run of ~9.5k
+# requests averaged ~80ms each in the requests section (~765s total), which
+# was already over that run's remaining budget with no warning emitted. This
+# is a heuristic from one observation, NOT a calibrated constant -- it only
+# decides whether to warn that the run is projected to truncate.
+_PROJECTED_SECONDS_PER_REQUEST = 0.08
 
 
 def _resolve_remote_skylet_log_path(runner: Any,
@@ -1556,12 +1836,13 @@ def _dump_kube_contexts_info(
     Prometheus) sails past the fast-fail gate and stacks several such calls --
     and urllib3 can retry each ~4x -- so the section as a whole can run for
     minutes. We therefore cap the whole parallel batch at
-    ``_bounded_timeout(_KUBE_CONTEXTS_TIMEOUT, deadline)``: with an overall
-    ``deadline`` it shrinks to the remaining budget (so a slow control plane
-    can't blow the dump's hard-kill deadline); without one it's still bounded by
-    the fixed cap. On timeout the batch is abandoned (its worker recorded in
-    ``orphans``) and whatever landed on disk is kept. Best-effort throughout:
-    errors are recorded, never aborts the dump.
+    ``_KUBE_CONTEXTS_TIMEOUT`` clamped to the remaining overall budget inside
+    the deadline helper: with an overall ``deadline`` the cap shrinks to the
+    remaining budget (so a slow control plane can't blow the dump's hard-kill
+    deadline); without one it's still bounded by the fixed cap. On timeout the
+    batch is abandoned (its worker recorded in ``orphans``) and whatever
+    landed on disk is kept. Best-effort throughout: errors are recorded, never
+    aborts the dump.
     """
     try:
         contexts = clouds.Kubernetes.existing_allowed_contexts(silent=True)
@@ -1613,11 +1894,14 @@ def _dump_kube_contexts_info(
     ok, results = _run_with_deadline(
         lambda: subprocess_utils.run_in_parallel(_dump_one, unique_contexts,
                                                  num_threads),
-        _bounded_timeout(_KUBE_CONTEXTS_TIMEOUT, deadline),
+        _KUBE_CONTEXTS_TIMEOUT,
         component='kubernetes_contexts',
         resource='all_contexts',
         errors=errors,
         orphans=orphans,
+        deadline=deadline,
+        op_desc=('per-context Kubernetes resource scrape; only the contexts '
+                 'written before the cutoff are included'),
     )
     if not ok or results is None:
         # Timed out: _run_with_deadline recorded the skip + orphan; per-context
@@ -1986,19 +2270,22 @@ def _dump_managed_job_queue_info(
     Makes a single batched queue_v2 call for all job IDs.
     """
     try:
-        # Bound the queue_v2 call dump-side (see _MANAGED_JOB_QUEUE_TIMEOUT); on
-        # timeout the helper records it and we skip this sub-section, mirroring
-        # the except-and-return degrade below.
+        # Bound the queue_v2 call dump-side (see _MANAGED_JOB_QUEUE_TIMEOUT);
+        # on timeout the helper records it and we skip this sub-section,
+        # mirroring the except-and-return degrade below.
         ok, result = _run_with_deadline(
             functools.partial(managed_jobs_core.queue_v2,
                               refresh=False,
                               job_ids=list(managed_job_ids),
                               all_users=True),
-            _bounded_timeout(_MANAGED_JOB_QUEUE_TIMEOUT, deadline),
+            _MANAGED_JOB_QUEUE_TIMEOUT,
             component='managed_jobs',
             resource='queue_v2_batch',
             errors=errors,
-            orphans=orphans)
+            orphans=orphans,
+            deadline=deadline,
+            op_desc=('managed job queue fetch; managed job state is omitted '
+                     'from the dump'))
         if not ok or result is None:
             return
         all_records, _, _, _, _ = result
@@ -2226,6 +2513,9 @@ def _build_debug_dump(
     summary writes below always run so the partial dump is self-describing.
     ``None`` (the default) keeps the previous behavior exactly.
     """
+    errors = debug_dump_context['errors']
+    orphans = debug_dump_context['timed_out_ops']
+
     # Populate the context and cross-link related resources. Each helper
     # runs exactly once, and the order is load-bearing:
     # 1. Expand clusters -> jobs BEFORE anything else adds cluster names
@@ -2256,23 +2546,88 @@ def _build_debug_dump(
     _kube_context_reachable.cache_clear()
     reachability = _kube_context_reachable
 
+    # The cross-link phase runs BEFORE any section, so without its own
+    # sub-budget it can silently eat a large share of the overall deadline
+    # (a single hanging controller call costs up to the full fixed queue
+    # cap here) and starve every section. Bound it to a fraction of the
+    # budget that remained when the phase started -- checked before EACH
+    # step, including the first (mirroring the section loop below), all in
+    # the main thread. On expiry the remaining steps are skipped with ONE
+    # aggregate record naming the expansions not run, and the phase gets
+    # its own section_timings entry so the pre-section time is accountable
+    # in summary.json. Granularity is per-step / per-loop-iteration: single
+    # in-flight DB calls inside a step are bounded by their own fixed caps
+    # only, which is deliberate (see the per-op bounds above).
     logger.debug('Cross-linking related resources')
-    _get_managed_jobs_from_clusters(debug_dump_context,
-                                    reachability,
-                                    deadline=deadline)
+    phase_start = time.monotonic()
+    context_deadline = None
+    if deadline is not None:
+        # min(overall deadline, phase_start + fraction of what remained
+        # when the phase started). Inlined (not _remaining_budget) because
+        # mypy cannot narrow the Optional through the helper.
+        context_deadline = min(
+            deadline, phase_start + _CONTEXT_POPULATION_BUDGET_FRACTION *
+            (deadline - phase_start))
+    phase_steps: List[Tuple[str, Callable[[], None]]] = [
+        ('managed_jobs_from_clusters', lambda: _get_managed_jobs_from_clusters(
+            debug_dump_context, reachability, deadline=context_deadline)),
+    ]
     if recent_minutes is not None:
-        _populate_recent_context(debug_dump_context,
-                                 recent_minutes,
-                                 reachability,
-                                 deadline=deadline)
-    _get_managed_jobs_from_requests(debug_dump_context)
-    _get_job_clusters_from_managed_jobs(debug_dump_context)
-    _get_requests_from_clusters(debug_dump_context)
-    _get_requests_from_managed_jobs(debug_dump_context,
-                                    reachability,
-                                    deadline=deadline)
-    _get_clusters_from_requests(debug_dump_context)
-    _get_clusters_from_managed_jobs(debug_dump_context)
+        phase_steps.append(
+            ('recent_context',
+             lambda: _populate_recent_context(debug_dump_context,
+                                              recent_minutes,
+                                              reachability,
+                                              deadline=context_deadline)))
+    phase_steps += [
+        ('managed_jobs_from_requests', lambda: _get_managed_jobs_from_requests(
+            debug_dump_context, deadline=context_deadline)),
+        ('job_clusters_from_managed_jobs',
+         lambda: _get_job_clusters_from_managed_jobs(
+             debug_dump_context, deadline=context_deadline)),
+        ('requests_from_clusters', lambda: _get_requests_from_clusters(
+            debug_dump_context, deadline=context_deadline)),
+        ('requests_from_managed_jobs', lambda: _get_requests_from_managed_jobs(
+            debug_dump_context, reachability, deadline=context_deadline)),
+        ('clusters_from_requests', lambda: _get_clusters_from_requests(
+            debug_dump_context, deadline=context_deadline)),
+        ('clusters_from_managed_jobs',
+         lambda: _get_clusters_from_managed_jobs(debug_dump_context)),
+    ]
+    phase_sub_timings: Dict[str, float] = {}
+    phase_expired = False
+    for step_index, (step_name, step) in enumerate(phase_steps):
+        # Checked BEFORE each step (including the first) so a pre-expired
+        # phase records exactly one aggregate skip and never reaches a
+        # helper's own internal guards.
+        if _deadline_exceeded(context_deadline):
+            phase_expired = True
+            not_run = [name for name, _ in phase_steps[step_index:]]
+            msg = ('Skipped: overall debug-dump deadline exceeded. Context-'
+                   'population expansions not run: ' + ', '.join(not_run) +
+                   '. The dump may be missing cross-linked resources; '
+                   'explicitly requested resources are still collected.')
+            logger.warning(msg)
+            errors.append({
+                'component': 'context_population',
+                'resource': 'expansions',
+                'error': msg,
+            })
+            break
+        step_start = time.monotonic()
+        step()
+        phase_sub_timings[step_name] = round(time.monotonic() - step_start, 2)
+
+    # Per-section wall-clock + status, surfaced in summary.json so a reader
+    # can see where the budget went (and which sections were skipped)
+    # without grepping the worker log. The cross-link phase gets the first
+    # entry so the pre-section time is accountable too.
+    section_timings: List[Dict[str, Any]] = [{
+        'section': 'context_population',
+        'status': 'partial_deadline' if phase_expired else 'completed',
+        'duration_s': round(time.monotonic() - phase_start, 2),
+        'sub_timings': phase_sub_timings,
+    }]
 
     # Always include system daemon requests
     debug_dump_context['request_ids'].update(SYSTEM_REQUEST_IDS)
@@ -2292,8 +2647,6 @@ def _build_debug_dump(
     # Kueue quota config) are fetched once per allowed kube context (source of
     # truth: existing_allowed_contexts, so a context with no SkyPilot clusters
     # is still captured).
-    errors = debug_dump_context['errors']
-    orphans = debug_dump_context['timed_out_ops']
     # Section order matters under a deadline: the user-scoped sections (the
     # requests / clusters / jobs the dump was actually filtered to) run first,
     # and the always-on, cluster-wide kubernetes_contexts scrape runs LAST -- so
@@ -2333,10 +2686,26 @@ def _build_debug_dump(
                 f'{len(debug_dump_context["cluster_names"])} clusters, '
                 f'{len(debug_dump_context["managed_job_ids"])} managed jobs); '
                 f'budget={"unbounded" if budget is None else f"{budget:.0f}s"}')
-    # Per-section wall-clock + status, surfaced in summary.json so a reader can
-    # see where the budget went (and which sections were skipped) without
-    # grepping the worker log.
-    section_timings: List[Dict[str, Any]] = []
+    # Static feasibility projection: counts alone say nothing about whether
+    # the budget can hold them, and a dump that is mathematically certain
+    # to truncate should say so up front (the measured in-loop projection
+    # in _dump_request_id_info catches mid-section slowdowns this cannot).
+    if budget is not None:
+        request_count = len(debug_dump_context['request_ids'])
+        projected_requests = (request_count * _PROJECTED_SECONDS_PER_REQUEST)
+        if projected_requests > budget:
+            msg = (f'debug dump: projected overrun -- {request_count} '
+                   f'requests project to ~{projected_requests:.0f}s at '
+                   f'~{_PROJECTED_SECONDS_PER_REQUEST * 1000:.0f}ms/request '
+                   f'vs {budget:.0f}s of budget; the dump will truncate '
+                   'before collecting every request. Consider a larger '
+                   'overall_deadline or a narrower scope.')
+            logger.warning(msg)
+            errors.append({
+                'component': 'requests',
+                'resource': 'budget_projection',
+                'error': msg,
+            })
     for name, dump_section in sections:
         if _deadline_exceeded(deadline):
             logger.warning(f'Skipping debug-dump section {name!r}: overall '
@@ -2510,7 +2879,10 @@ def create_debug_dump(
         # itself. We attach to the root 'sky' logger so that logs from all sky.*
         # modules are captured, not just sky.utils.debug_utils.  Also attach to
         # sky.provision which has propagate=False.  This mirrors
-        # sky_logging.add_debug_log_handler().
+        # sky_logging.add_debug_log_handler(). The handler stays attached
+        # through the zip step below so the 'zipping N bytes' line and the zip
+        # stats land in debug_dump.log too -- they are emitted about the dump
+        # and belong in its own record.
         debug_handler = logging.FileHandler(
             os.path.join(dump_dir, 'debug_dump.log'))
         debug_handler.setFormatter(sky_logging.FORMATTER)
@@ -2534,41 +2906,109 @@ def create_debug_dump(
                               client_info,
                               requested=original_requested,
                               deadline=deadline)
-            # Report any op whose worker thread is still running (before we
-            # detach the handler, so it lands in debug_dump.log too).
+            # Report the fate of every timed-out op (before the handler is
+            # detached, so it lands in debug_dump.log too).
             _log_timed_out_stragglers(debug_dump_context['timed_out_ops'])
+
+            # Log total dump size before zipping
+            total_dump_size = sum(f.stat().st_size
+                                  for f in pathlib.Path(dump_dir).rglob('*')
+                                  if f.is_file())
+
+            # Create zip file in PERSISTENT location (outside temp dir)
+            zip_filename = f'debug_dump_{timestamp}.zip'
+            zip_file_path = dump_base_dir / zip_filename
+            # INFO so the zip step is visible in the worker log: it is the last
+            # thing that runs before the dump is durable, and slow zips eat
+            # into any outer deadline's buffer (see the per-section logging
+            # note above).
+            logger.info(f'debug dump: collection done, zipping '
+                        f'{total_dump_size} bytes to {zip_filename}')
+
+            # The zip walk is deadline-bounded too: a dump that exhausted its
+            # budget collecting must not spend unbudgeted minutes compressing
+            # everything afterwards. We stop adding entries once the deadline
+            # passes -- a truncated-but-valid archive beats no archive at all
+            # (whatever was gathered is still zipped and returned). The
+            # self-describing top-level artifacts are ALWAYS included, by name,
+            # so a partial dump can still explain itself; debug_dump.log is
+            # additionally written as the FINAL entry (after the walk, with the
+            # handler flushed first) so both the 'zipping N bytes' line above
+            # and any mid-walk truncation warning below are deterministic in
+            # the archived copy rather than dependent on os.walk order. Note
+            # the pre-zip rglob stat walk above is not deadline-bounded, and a
+            # single huge file's zf.write cannot be interrupted mid-file --
+            # accepted residuals; the walk-level check still bounds the common
+            # many-files case.
+            exempt_names = {
+                'summary.json', 'errors.json', 'client_info.json',
+                'debug_dump.log'
+            }
+            log_path = os.path.join(dump_dir, 'debug_dump.log')
+            zip_start = time.monotonic()
+            file_count = 0
+            skipped_deadline_files = 0
+            zip_truncated = False
+            with zipfile.ZipFile(zip_file_path, 'w',
+                                 zipfile.ZIP_DEFLATED) as zipf:
+                for root, _, files in os.walk(dump_dir):
+                    for file in files:
+                        if file == 'debug_dump.log':
+                            # Written as the final entry below.
+                            continue
+                        file_path = os.path.join(root, file)
+                        arcname = os.path.relpath(file_path, temp_dir)
+                        if (file not in exempt_names and
+                                _deadline_exceeded(deadline)):
+                            if not zip_truncated:
+                                zip_truncated = True
+                                logger.warning(
+                                    'debug dump: overall deadline exceeded '
+                                    'during zip; truncating the archive '
+                                    f'({file_count} files written so far)')
+                            skipped_deadline_files += 1
+                            continue
+                        zipf.write(file_path, arcname)
+                        file_count += 1
+                # Flush the handler first so the archived copy contains every
+                # line emitted so far, including the truncation warning above.
+                debug_handler.flush()
+                zipf.write(log_path, os.path.relpath(log_path, temp_dir))
+                file_count += 1
+
+            created_msg = (f'debug dump: created {zip_filename} '
+                           f'({file_count} files) '
+                           f'in {time.monotonic() - zip_start:.1f}s')
+            if zip_truncated:
+                created_msg += (f'; truncated at the overall deadline '
+                                f'({skipped_deadline_files} files skipped)')
+            logger.info(created_msg)
+
+            # In-archive zip stats (appended best-effort AFTER the zip closes,
+            # so it can never fail the dump): the deterministic record of
+            # whether the archive is complete or deadline-truncated.
+            try:
+                zip_stats = {
+                    'duration_s': round(time.monotonic() - zip_start, 2),
+                    'file_count': file_count,
+                    'skipped_deadline_files': skipped_deadline_files,
+                    'status':
+                        ('truncated_deadline' if zip_truncated else 'completed'
+                        ),
+                }
+                with zipfile.ZipFile(zip_file_path, 'a') as zipf:
+                    zipf.writestr(
+                        os.path.relpath(
+                            os.path.join(dump_dir, 'zip_stats.json'), temp_dir),
+                        json.dumps(zip_stats, indent=2))
+            except Exception:  # pylint: disable=broad-except
+                logger.debug('Failed to append zip_stats.json to the dump',
+                             exc_info=True)
         finally:
             sky_root_logger.removeHandler(debug_handler)
             provision_logger.removeHandler(debug_handler)
             debug_handler.flush()
             debug_handler.close()
-
-        # Log total dump size before zipping
-        total_dump_size = sum(f.stat().st_size
-                              for f in pathlib.Path(dump_dir).rglob('*')
-                              if f.is_file())
-
-        # Create zip file in PERSISTENT location (outside temp dir)
-        zip_filename = f'debug_dump_{timestamp}.zip'
-        zip_file_path = dump_base_dir / zip_filename
-        # INFO so the zip step is visible in the worker log: it is the last
-        # thing that runs before the dump is durable, and slow zips eat into
-        # any outer deadline's buffer (see the per-section logging note above).
-        logger.info(f'debug dump: collection done, zipping {total_dump_size} '
-                    f'bytes to {zip_filename}')
-
-        zip_start = time.monotonic()
-        file_count = 0
-        with zipfile.ZipFile(zip_file_path, 'w', zipfile.ZIP_DEFLATED) as zipf:
-            for root, _, files in os.walk(dump_dir):
-                for file in files:
-                    file_path = os.path.join(root, file)
-                    arcname = os.path.relpath(file_path, temp_dir)
-                    zipf.write(file_path, arcname)
-                    file_count += 1
-
-        logger.info(f'debug dump: created {zip_filename} ({file_count} files) '
-                    f'in {time.monotonic() - zip_start:.1f}s')
 
     logger.info(f'debug dump: finished in {time.monotonic() - dump_start:.1f}s '
                 f'-> {zip_file_path}')

--- a/tests/unit_tests/test_core.py
+++ b/tests/unit_tests/test_core.py
@@ -1,3 +1,4 @@
+import time
 from unittest import mock
 
 import pytest
@@ -13,6 +14,7 @@ from sky.backends.cloud_vm_ray_backend import CloudVmRayResourceHandle
 from sky.skylet import job_lib
 from sky.utils import common
 from sky.utils import common_utils
+from sky.utils import debug_utils
 from sky.utils import status_lib
 from sky.workspaces import constants as workspace_constants
 
@@ -1027,3 +1029,31 @@ def test_down_graceful_tolerates_missing_command_runners(monkeypatch) -> None:
     backend.teardown.assert_called_once_with(handle,
                                              terminate=True,
                                              purge=False)
+
+
+@mock.patch('sky.core.debug_utils.create_debug_dump',
+            return_value='/tmp/fake_dump.zip')
+def test_create_debug_dump_applies_default_deadline(mock_create) -> None:
+    """With no overall_deadline, the server applies its own backstop budget
+    (debug_utils._DEFAULT_DEBUG_DUMP_DEADLINE_S) so every API-initiated dump
+    is bounded."""
+    before = time.time()
+
+    core.create_debug_dump(cluster_names=['c'])
+    after = time.time()
+
+    passed_deadline = mock_create.call_args.kwargs['overall_deadline']
+    assert passed_deadline is not None
+    # Approximately now + the default backstop.
+    default_s = debug_utils._DEFAULT_DEBUG_DUMP_DEADLINE_S  # pylint: disable=protected-access
+    assert (before + default_s) <= passed_deadline <= (after + default_s)
+
+
+@mock.patch('sky.core.debug_utils.create_debug_dump',
+            return_value='/tmp/fake_dump.zip')
+def test_create_debug_dump_passes_explicit_deadline_through(
+        mock_create) -> None:
+    """An explicit caller deadline is passed through verbatim (CLI users and
+    out-of-process schedulers manage their own budget)."""
+    core.create_debug_dump(cluster_names=['c'], overall_deadline=1234567890.5)
+    assert mock_create.call_args.kwargs['overall_deadline'] == 1234567890.5

--- a/tests/unit_tests/test_core.py
+++ b/tests/unit_tests/test_core.py
@@ -1035,7 +1035,7 @@ def test_down_graceful_tolerates_missing_command_runners(monkeypatch) -> None:
             return_value='/tmp/fake_dump.zip')
 def test_create_debug_dump_applies_default_deadline(mock_create) -> None:
     """With no overall_deadline, the server applies its own backstop budget
-    (debug_utils._DEFAULT_DEBUG_DUMP_DEADLINE_S) so every API-initiated dump
+    (debug_utils.DEBUG_DUMP_DEFAULT_DEADLINE_S) so every API-initiated dump
     is bounded."""
     before = time.time()
 
@@ -1045,7 +1045,7 @@ def test_create_debug_dump_applies_default_deadline(mock_create) -> None:
     passed_deadline = mock_create.call_args.kwargs['overall_deadline']
     assert passed_deadline is not None
     # Approximately now + the default backstop.
-    default_s = debug_utils._DEFAULT_DEBUG_DUMP_DEADLINE_S  # pylint: disable=protected-access
+    default_s = debug_utils.DEBUG_DUMP_DEFAULT_DEADLINE_S
     assert (before + default_s) <= passed_deadline <= (after + default_s)
 
 

--- a/tests/unit_tests/test_sky/utils/test_debug_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_debug_utils.py
@@ -195,6 +195,27 @@ class TestGetRequestsFromClusters:
 
         assert ctx['request_ids'] == {'req-dup'}
 
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_deadline_expires_mid_loop_records_one_aggregate_skip(
+            self, mock_get_tasks):
+        """An expired deadline stops the per-cluster loop with ONE aggregate
+        skip record naming how many clusters were left, instead of grinding
+        the whole budget on per-cluster DB scans."""
+        ctx = _make_context(cluster_names={'c1', 'c2', 'c3'})
+
+        debug_utils._get_requests_from_clusters(ctx,
+                                                deadline=time.monotonic() - 1)
+
+        mock_get_tasks.assert_not_called()
+        assert ctx['request_ids'] == set()
+        assert len(ctx['errors']) == 1
+        record = ctx['errors'][0]
+        assert record['component'] == 'cross_link'
+        assert record['resource'] == 'requests_from_clusters'
+        assert record['error'].startswith(
+            'Skipped: overall debug-dump deadline exceeded.')
+        assert '3 cluster(s)' in record['error']
+
 
 # ---------------------------------------------------------------------------
 # Tests for _get_requests_from_managed_jobs
@@ -519,6 +540,26 @@ class TestGetClustersFromRequests:
 
         assert ctx['cluster_names'] == {'cluster-a', 'cluster-b'}
 
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request')
+    def test_deadline_expires_mid_loop_records_one_aggregate_skip(
+            self, mock_get_request):
+        """An expired deadline stops the per-request loop with ONE aggregate
+        skip record naming how many requests were left."""
+        ctx = _make_context(request_ids={'r1', 'r2'})
+
+        debug_utils._get_clusters_from_requests(ctx,
+                                                deadline=time.monotonic() - 1)
+
+        mock_get_request.assert_not_called()
+        assert ctx['cluster_names'] == set()
+        assert len(ctx['errors']) == 1
+        record = ctx['errors'][0]
+        assert record['component'] == 'cross_link'
+        assert record['resource'] == 'clusters_from_requests'
+        assert record['error'].startswith(
+            'Skipped: overall debug-dump deadline exceeded.')
+        assert '2 request(s)' in record['error']
+
 
 # ---------------------------------------------------------------------------
 # Tests for _get_clusters_from_managed_jobs
@@ -687,6 +728,42 @@ class TestGetManagedJobsFromClusters:
         assert len(errors) == 1
         assert errors[0]['resource'] == 'managed_jobs_from_clusters'
 
+    @mock.patch('sky.utils.debug_utils.managed_jobs_core.queue_v2')
+    def test_queue_timeout_uses_tight_recent_scan_cap(self, mock_queue,
+                                                      monkeypatch):
+        """The unfiltered all_users queue_v2 here is bounded by the tight
+        _RECENT_MANAGED_JOBS_QUEUE_TIMEOUT (not the 120s targeted cap): a
+        slow controller costs at most that much budget, the dump degrades
+        to no cluster-to-job expansion, and the timeout record names the
+        user-relevant consequence."""
+        assert debug_utils._RECENT_MANAGED_JOBS_QUEUE_TIMEOUT <= 30
+        monkeypatch.setattr(debug_utils, '_RECENT_MANAGED_JOBS_QUEUE_TIMEOUT',
+                            0.2)
+        started = threading.Event()
+
+        def _slow_queue(*_args, **_kwargs):
+            started.set()
+            time.sleep(5)  # Longer than the (patched) cap.
+            return ([], 0, {}, 0, [])
+
+        mock_queue.side_effect = _slow_queue
+        errors: List[Dict[str, str]] = []
+        ctx = _make_context(cluster_names={'c1'}, errors=errors)
+        start = time.time()
+
+        debug_utils._get_managed_jobs_from_clusters(ctx, _StubReachability())
+        elapsed = time.time() - start
+
+        assert started.is_set()
+        assert elapsed < 3
+        assert ctx['managed_job_ids'] == set()
+        assert len(errors) == 1
+        record = errors[0]
+        assert record['resource'] == 'managed_jobs_from_clusters'
+        # The record names the operation and what its loss degrades.
+        assert 'operation' in record
+        assert 'cluster-to-job expansion' in record['operation']
+
 
 # ---------------------------------------------------------------------------
 # Tests for _get_job_clusters_from_managed_jobs
@@ -771,6 +848,41 @@ class TestGetJobClustersFromManagedJobs:
         assert ctx['cluster_names'] == set()
         assert len(errors) == 1
         assert errors[0]['resource'] == 'job_clusters_from_managed_jobs'
+
+    @mock.patch('sky.utils.debug_utils.managed_job_utils.is_consolidation_mode')
+    @mock.patch('sky.utils.debug_utils.managed_jobs_core.queue_v2')
+    def test_queue_timeout_degrades_to_no_cluster_names(self, mock_queue,
+                                                        mock_consolidation,
+                                                        monkeypatch):
+        """queue_v2 here is routed through _run_with_deadline like its three
+        sibling call sites: a slow controller is recorded as a partial
+        failure and the helper degrades to no job-cluster names instead of
+        stalling the dump unbounded."""
+        mock_consolidation.return_value = True
+        monkeypatch.setattr(debug_utils, '_MANAGED_JOB_QUEUE_TIMEOUT', 0.2)
+        started = threading.Event()
+
+        def _slow_queue(*_args, **_kwargs):
+            started.set()
+            time.sleep(5)  # Longer than the (patched) bound.
+            return ([], 0, {}, 0, [])
+
+        mock_queue.side_effect = _slow_queue
+        errors: List[Dict[str, str]] = []
+        ctx = _make_context(managed_job_ids={5}, errors=errors)
+        start = time.time()
+
+        debug_utils._get_job_clusters_from_managed_jobs(ctx)
+        elapsed = time.time() - start
+
+        assert started.is_set()
+        assert elapsed < 3
+        assert ctx['cluster_names'] == set()
+        assert len(errors) == 1
+        record = errors[0]
+        assert record['resource'] == 'job_clusters_from_managed_jobs'
+        assert 'timed out after' in record['error']
+        assert 'operation' in record
 
 
 # ---------------------------------------------------------------------------
@@ -932,6 +1044,27 @@ class TestGetManagedJobsFromRequests:
         assert 42 in ctx['managed_job_ids']
         assert 43 in ctx['managed_job_ids']
 
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request')
+    def test_deadline_expires_mid_loop_records_one_aggregate_skip(
+            self, mock_get_request):
+        """An expired deadline stops the per-request loop with ONE aggregate
+        skip record naming how many requests were left."""
+        ctx = _make_context(request_ids={'r1', 'r2', 'r3'})
+
+        debug_utils._get_managed_jobs_from_requests(ctx,
+                                                    deadline=time.monotonic() -
+                                                    1)
+
+        mock_get_request.assert_not_called()
+        assert ctx['managed_job_ids'] == set()
+        assert len(ctx['errors']) == 1
+        record = ctx['errors'][0]
+        assert record['component'] == 'cross_link'
+        assert record['resource'] == 'managed_jobs_from_requests'
+        assert record['error'].startswith(
+            'Skipped: overall debug-dump deadline exceeded.')
+        assert '3 request(s)' in record['error']
+
 
 # ---------------------------------------------------------------------------
 # Tests for _populate_recent_context
@@ -1077,6 +1210,46 @@ class TestPopulateRecentContext:
 
         assert 1 in ctx['managed_job_ids']
         assert 2 not in ctx['managed_job_ids']
+
+    @mock.patch('sky.jobs.server.core.queue_v2')
+    @mock.patch('sky.utils.debug_utils.global_user_state.get_clusters')
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_recent_jobs_scan_uses_tight_cap(self, mock_get_tasks,
+                                             mock_get_clusters, mock_queue_v2,
+                                             monkeypatch):
+        """The unfiltered all_users recent-jobs scan is bounded by the tight
+        _RECENT_MANAGED_JOBS_QUEUE_TIMEOUT, not the 120s targeted cap: this
+        scan is a scope-expansion hint (the request-body scan recovers the
+        jobs independently), so a slow controller must not cost 120s of
+        budget. On timeout the dump records the error and moves on."""
+        assert debug_utils._RECENT_MANAGED_JOBS_QUEUE_TIMEOUT <= 30
+        monkeypatch.setattr(debug_utils, '_RECENT_MANAGED_JOBS_QUEUE_TIMEOUT',
+                            0.2)
+        mock_get_tasks.return_value = []
+        mock_get_clusters.return_value = []
+        started = threading.Event()
+
+        def _slow_queue(*_args, **_kwargs):
+            started.set()
+            time.sleep(5)  # Longer than the (patched) cap.
+            return ([], 0, {}, 0, [])
+
+        mock_queue_v2.side_effect = _slow_queue
+        ctx = _make_context()
+        start = time.time()
+
+        debug_utils._populate_recent_context(ctx,
+                                             minutes=60.0,
+                                             reachability=_StubReachability())
+        elapsed = time.time() - start
+
+        assert started.is_set()
+        assert elapsed < 3
+        assert ctx['managed_job_ids'] == set()
+        assert any(
+            e['component'] == 'recent_context' and
+            e['resource'] == 'managed_jobs' and 'timed out after' in e['error']
+            for e in ctx['errors'])
 
     @mock.patch('sky.jobs.server.core.queue_v2')
     @mock.patch('sky.utils.debug_utils.global_user_state.get_clusters')
@@ -2365,6 +2538,32 @@ class TestSensitiveEnvVarRedaction:
 
     @mock.patch('sky.utils.debug_utils.requests_lib.get_request',
                 return_value=None)
+    def test_dump_server_info_budget_skip_message(self, mock_req, tmp_path):
+        """When the overall deadline (not the sky-check cap) is what ran out,
+        cloud_status_error says the check was SKIPPED for budget -- it never
+        reports a clamped, possibly non-positive 'timed out after Ns'
+        duration, and never misreports a budget skip as a check stall."""
+        del mock_req  # required by mock.patch
+        errors: List[Dict[str, str]] = []
+        with mock.patch('sky.utils.debug_utils.sky_check.check') as mock_check:
+            debug_utils._dump_server_info(str(tmp_path),
+                                          errors=errors,
+                                          deadline=time.monotonic() - 1)
+
+        # The pre-submit guard fired: check was never run, no worker exists.
+        mock_check.assert_not_called()
+        with open(os.path.join(str(tmp_path), 'server_info.json')) as f:
+            info = json.load(f)
+        assert 'enabled_clouds' not in info
+        assert 'skipped: overall debug-dump deadline exceeded' in info[
+            'cloud_status_error']
+        assert 'timed out after' not in info['cloud_status_error']
+        assert any(e['resource'] == 'cloud_status' and
+                   e['error'] == 'Skipped: overall debug-dump deadline '
+                   'exceeded.' for e in errors)
+
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request',
+                return_value=None)
     @mock.patch('sky.utils.debug_utils.sky_check.check',
                 return_value={'default': {
                     'kubernetes': ['compute']
@@ -3150,6 +3349,75 @@ class TestDumpRequestIdInfo:
             call.args[2] for call in provider.copy_log_file.call_args_list
         ]
         assert any(p.name == 'request.log' for p in dest_paths)
+
+    @mock.patch('sky.utils.debug_utils.log_provider.get_log_provider')
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request',
+                return_value=None)
+    def test_deadline_expiring_mid_request_yields_only_skip_records(
+            self, mock_get_request, mock_get_provider, tmp_path):
+        """Regression (double bogus record): a deadline that expires between
+        the loop-top guard and the log copies used to clamp the per-copy
+        timeout to a tiny/negative remainder and record two 'timed out
+        after -0.0015s'-style entries for one request. Now the pre-submit
+        guard and clamp attribution yield only truthful budget-skip records
+        -- and the second copy is never started once the budget is gone."""
+        del mock_get_request  # required by mock.patch
+        provider = mock.MagicMock()
+
+        def _slow_copy(*_args, **_kwargs):
+            time.sleep(0.3)  # Outlasts the whole remaining budget.
+            return True
+
+        provider.copy_log_file.side_effect = _slow_copy
+        mock_get_provider.return_value = provider
+        errors: List[Dict[str, str]] = []
+
+        debug_utils._dump_request_id_info({'req-1'},
+                                          str(tmp_path),
+                                          errors,
+                                          deadline=time.monotonic() + 0.15)
+
+        # First copy: budget-binding timeout -> skip record + orphan.
+        # Second copy: pre-submit guard -> skip record, fn never called.
+        assert provider.copy_log_file.call_count == 1
+        assert len(errors) == 2
+        for record in errors:
+            assert record['error'] == ('Skipped: overall debug-dump deadline '
+                                       'exceeded.')
+        assert not any('timed out after' in e['error'] for e in errors)
+
+    @mock.patch('sky.utils.debug_utils.log_provider.get_log_provider')
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request',
+                return_value=None)
+    def test_measured_overrun_projection_warns_once(self, mock_get_request,
+                                                    mock_get_provider,
+                                                    tmp_path):
+        """The running-average projection inside the requests loop fires
+        exactly once when the measured per-request cost projects the
+        remaining requests past the budget (catching mid-section slowdowns
+        the static constant cannot)."""
+        del mock_get_request  # required by mock.patch
+        provider = mock.MagicMock()
+
+        def _slow_copy(*_args, **_kwargs):
+            time.sleep(0.1)  # Two copies per request -> ~0.2s/request.
+            return True
+
+        provider.copy_log_file.side_effect = _slow_copy
+        mock_get_provider.return_value = provider
+        errors: List[Dict[str, str]] = []
+
+        debug_utils._dump_request_id_info({f'req-{i}' for i in range(5)},
+                                          str(tmp_path),
+                                          errors,
+                                          deadline=time.monotonic() + 0.5)
+
+        projections = [
+            e for e in errors if e['resource'] == 'budget_projection'
+        ]
+        assert len(projections) == 1
+        assert projections[0]['component'] == 'requests'
+        assert 'projected overrun' in projections[0]['error']
 
 
 # ---------------------------------------------------------------------------
@@ -4329,6 +4597,115 @@ class TestRunWithDeadline:
         finally:
             release.set()  # let the orphaned worker exit promptly
 
+    def test_pre_submit_skip_on_expired_deadline(self):
+        """An already-passed overall deadline: fn is never submitted, the
+        standard budget-skip record is appended, and NO orphan is created
+        (no worker was ever submitted)."""
+        called: List[int] = []
+        errors: List[Dict[str, Any]] = []
+        orphans: List[Dict[str, Any]] = []
+
+        def _fn():
+            called.append(1)
+            return 42
+
+        ok, result = debug_utils._run_with_deadline(_fn,
+                                                    timeout=5,
+                                                    component='c',
+                                                    resource='r',
+                                                    errors=errors,
+                                                    orphans=orphans,
+                                                    deadline=time.monotonic() -
+                                                    1)
+
+        assert ok is False
+        assert result is None
+        assert not called
+        assert not orphans
+        assert len(errors) == 1
+        assert errors[0]['error'] == ('Skipped: overall debug-dump deadline '
+                                      'exceeded.')
+        assert 'traceback' not in errors[0]
+
+    def test_clamp_binding_timeout_records_skip_and_orphan(self, monkeypatch):
+        """A budget-binding timeout (the deadline clamp, not the fixed cap,
+        cut the wait short) records the standard skip record AND still
+        creates an orphan: a worker was submitted and abandoned, and the
+        straggler log needs the orphan to report a worker that completes
+        after timing out (pinned semantics)."""
+        release = threading.Event()
+        errors: List[Dict[str, Any]] = []
+        orphans: List[Dict[str, Any]] = []
+        try:
+            ok, result = debug_utils._run_with_deadline(
+                release.wait,
+                timeout=5,  # generous fixed cap; the deadline clamp binds
+                component='comp',
+                resource='res',
+                errors=errors,
+                orphans=orphans,
+                deadline=time.monotonic() + 0.05)
+            assert ok is False
+            assert result is None
+            assert len(errors) == 1
+            assert errors[0]['error'] == ('Skipped: overall debug-dump '
+                                          'deadline exceeded.')
+            assert len(orphans) == 1
+            assert orphans[0]['thread_id'] is not None
+        finally:
+            release.set()  # the abandoned worker now completes
+        orphans[0]['future'].result(timeout=5)
+
+        # The straggler log reports the completed-after-timeout orphan: the
+        # "data existed but was discarded" case is visible.
+        calls: List[tuple] = []
+        monkeypatch.setattr(debug_utils.logger, 'warning',
+                            lambda *a, **k: calls.append(a))
+        debug_utils._log_timed_out_stragglers(orphans)
+        assert len(calls) == 1
+        assert 'completed' in calls[0][0] and 'discarded' in calls[0][0]
+
+    def test_cap_binding_timeout_names_operation_and_stack(self):
+        """A full-cap timeout (genuine stall): the record names the
+        operation, reports the rounded fixed cap, and carries the stuck
+        WORKER's stack -- never the waiter's (which is identical for every
+        timeout and points at the helper itself)."""
+        release = threading.Event()
+
+        def _stuck():  # MARKER_STUCK_WORKER_FN
+            release.wait()  # MARKER_STUCK_WORKER_FRAME
+
+        errors: List[Dict[str, Any]] = []
+        orphans: List[Dict[str, Any]] = []
+        try:
+            ok, result = debug_utils._run_with_deadline(
+                _stuck,
+                timeout=0.1,
+                component='comp',
+                resource='res',
+                errors=errors,
+                orphans=orphans,
+                deadline=time.monotonic() + 100,
+                op_desc=('fetch that '
+                         'hung; its '
+                         'loss '
+                         'degrades '
+                         'the dump'))
+            assert ok is False
+            assert result is None
+            assert len(errors) == 1
+            record = errors[0]
+            assert record['operation'] == ('fetch that hung; its loss '
+                                           'degrades the dump')
+            assert 'timed out after 0.1s' in record['error']
+            assert 'fetch that hung' in record['error']
+            # Never the waiter's frame (future.result lives in the waiter).
+            assert 'future.result' not in record['worker_stack']
+            assert 'MARKER_STUCK_WORKER_FRAME' in record['worker_stack']
+            assert len(orphans) == 1
+        finally:
+            release.set()
+
     def test_non_timeout_exception_propagates(self):
         """A non-timeout error from fn propagates (each call site keeps its own
         handling); the finally still shuts the executor down."""
@@ -4364,9 +4741,11 @@ class TestRunWithDeadline:
         monkeypatch.setattr(debug_utils.logger, 'warning',
                             lambda *a, **k: calls.append(a))
         debug_utils._log_timed_out_stragglers(orphans)
-        # Exactly one warning, for the still-running op; the done one is skipped.
-        assert len(calls) == 1
-        assert 'still' in calls[0] and 'running' in calls[0]
+        # One warning per fate: the still-running op leaks; the done one
+        # completed after timing out and its result was discarded.
+        assert len(calls) == 2
+        assert any('still running' in a[0] for a in calls)
+        assert any('completed' in a[0] and 'discarded' in a[0] for a in calls)
 
 
 class TestOverallDeadlineHelpers:
@@ -4392,6 +4771,12 @@ class TestOverallDeadlineHelpers:
         assert debug_utils._bounded_timeout(120, time.monotonic() + 1000) == 120
         # A tight deadline clamps the fixed timeout down.
         assert debug_utils._bounded_timeout(120, time.monotonic() + 5) <= 5
+
+    def test_bounded_timeout_floors_negative_remainder(self):
+        # An already-elapsed deadline must yield 0.0, never a negative
+        # timeout (a negative value reaches errors.json as a physically
+        # impossible "timed out after -0.0015s" otherwise).
+        assert debug_utils._bounded_timeout(120, time.monotonic() - 5) == 0.0
 
 
 class TestOverallDeadlineDump:
@@ -4420,8 +4805,11 @@ class TestOverallDeadlineDump:
     def _patched_dump(self, tmp_path):
         """Patch all cross-link + section helpers; yield the section mocks."""
         with contextlib.ExitStack() as stack:
-            for fn in self._CROSSLINK_FNS:
+            crosslink_mocks = {
+                fn:
                 stack.enter_context(mock.patch(f'sky.utils.debug_utils.{fn}'))
+                for fn in self._CROSSLINK_FNS
+            }
             section_mocks = {
                 fn:
                 stack.enter_context(mock.patch(f'sky.utils.debug_utils.{fn}'))
@@ -4430,7 +4818,7 @@ class TestOverallDeadlineDump:
             stack.enter_context(
                 mock.patch('sky.utils.debug_utils.DEBUG_DUMP_DIR',
                            str(tmp_path / 'debug_dumps')))
-            yield section_mocks
+            yield crosslink_mocks, section_mocks
 
     @staticmethod
     def _read_errors(zip_path):
@@ -4438,12 +4826,18 @@ class TestOverallDeadlineDump:
             name = next(n for n in zf.namelist() if n.endswith('errors.json'))
             return json.loads(zf.read(name))
 
+    @staticmethod
+    def _read_summary(zip_path):
+        with zipfile.ZipFile(zip_path, 'r') as zf:
+            name = next(n for n in zf.namelist() if n.endswith('summary.json'))
+            return json.loads(zf.read(name))
+
     def test_past_deadline_skips_sections_but_still_zips(self, tmp_path):
         """An already-passed overall_deadline (e.g. the caller spent the whole
         budget queueing) skips every section with its own recorded reason, yet
         still produces a real (partial) zip. Exercises the real wall-clock ->
         monotonic conversion + >=0 clamp, no internal mocking."""
-        with self._patched_dump(tmp_path) as section_mocks:
+        with self._patched_dump(tmp_path) as (_crosslink_mocks, section_mocks):
             result = debug_utils.create_debug_dump(
                 cluster_names=['c'], overall_deadline=time.time() - 1)
 
@@ -4465,10 +4859,23 @@ class TestOverallDeadlineDump:
         assert len(skip_records) == len(self._SECTION_FNS)
         assert all(e['resource'] == 'section' for e in skip_records)
 
+        # The pre-expired cross-link phase yields EXACTLY ONE aggregate
+        # context_population record (its check runs before the first step,
+        # so no helper-level records exist), and no cross-link helper ran.
+        phase_records = [
+            e for e in errors if e['component'] == 'context_population'
+        ]
+        assert len(phase_records) == 1
+        assert phase_records[0]['resource'] == 'expansions'
+        assert phase_records[0]['error'].startswith(
+            'Skipped: overall debug-dump deadline exceeded.')
+        for fn, m in _crosslink_mocks.items():
+            assert not m.called, f'{fn} should have been skipped'
+
     def test_no_deadline_runs_all_sections(self, tmp_path):
         """overall_deadline=None == unchanged behavior: every section runs and
         nothing is skipped."""
-        with self._patched_dump(tmp_path) as section_mocks:
+        with self._patched_dump(tmp_path) as (_crosslink_mocks, section_mocks):
             result = debug_utils.create_debug_dump(cluster_names=['c'],
                                                    overall_deadline=None)
 
@@ -4486,10 +4893,153 @@ class TestOverallDeadlineDump:
     def test_future_deadline_runs_all_sections(self, tmp_path):
         """A generous future overall_deadline must not spuriously skip: every
         section runs when there is budget left."""
-        with self._patched_dump(tmp_path) as section_mocks:
+        with self._patched_dump(tmp_path) as (_crosslink_mocks, section_mocks):
             result = debug_utils.create_debug_dump(
                 cluster_names=['c'], overall_deadline=time.time() + 3600)
 
         assert result.exists()
         for fn, m in section_mocks.items():
             assert m.call_count == 1, f'{fn} should have run exactly once'
+
+    def test_phase_gets_own_section_timing_entry(self, tmp_path):
+        """The pre-section cross-link phase is accountable in summary.json:
+        section_timings[0] is a context_population entry with per-step
+        sub_timings, so pre-section time no longer disappears from the
+        timings sum."""
+        with self._patched_dump(tmp_path) as (_crosslink_mocks, section_mocks):
+            result = debug_utils.create_debug_dump(
+                cluster_names=['c'], overall_deadline=time.time() + 3600)
+
+        summary = self._read_summary(result)
+        timings = summary['section_timings']
+        assert timings[0]['section'] == 'context_population'
+        assert timings[0]['status'] == 'completed'
+        assert 'duration_s' in timings[0]
+        # Every phase step that ran (recent_minutes is None here, so no
+        # recent_context step) is timed individually.
+        assert 'managed_jobs_from_clusters' in timings[0]['sub_timings']
+        assert 'clusters_from_managed_jobs' in timings[0]['sub_timings']
+        # The five sections follow the phase entry.
+        assert [t['section'] for t in timings[1:]] == [
+            'server_info', 'request_ids', 'clusters', 'managed_jobs',
+            'kubernetes_contexts'
+        ]
+
+    def test_phase_sub_budget_expiry_skips_remaining_steps(self, tmp_path):
+        """The cross-link phase runs on its own sub-budget: when it expires
+        mid-phase, the remaining steps are skipped with ONE aggregate record
+        (naming the expansions not run) while the sections still run with
+        whatever budget remains. The check fires between steps -- before the
+        first step too (see test_past_deadline above)."""
+        with self._patched_dump(tmp_path) as (crosslink_mocks, section_mocks):
+            # Shrink the phase sub-budget to ~0.1s (0.001 of the 100s
+            # remaining) and make the first step outlast it.
+            with mock.patch.object(debug_utils,
+                                   '_CONTEXT_POPULATION_BUDGET_FRACTION',
+                                   0.001):
+                crosslink_mocks[
+                    '_get_managed_jobs_from_clusters'].side_effect = (
+                        lambda *a, **kw: time.sleep(0.2))
+                result = debug_utils.create_debug_dump(
+                    cluster_names=['c'], overall_deadline=time.time() + 100)
+
+        # The sections still ran (the phase sub-budget must not eat the
+        # overall one).
+        for fn, m in section_mocks.items():
+            assert m.call_count == 1, f'{fn} should have run exactly once'
+
+        errors = self._read_errors(result)
+        phase_records = [
+            e for e in errors if e['component'] == 'context_population'
+        ]
+        assert len(phase_records) == 1
+        assert phase_records[0]['error'].startswith(
+            'Skipped: overall debug-dump deadline exceeded.')
+        # The record names the expansions that did not run...
+        for step in ('managed_jobs_from_requests', 'requests_from_clusters',
+                     'clusters_from_requests'):
+            assert step in phase_records[0]['error']
+        # ...and those skipped steps never ran (only the first step did).
+        assert crosslink_mocks['_get_managed_jobs_from_clusters'].called
+        assert not crosslink_mocks['_get_managed_jobs_from_requests'].called
+        assert not crosslink_mocks['_get_clusters_from_requests'].called
+
+        summary = self._read_summary(result)
+        assert summary['section_timings'][0]['status'] == 'partial_deadline'
+
+    def test_static_projection_warns_when_infeasible(self, tmp_path):
+        """When the request count projects past the remaining budget, the
+        dump warns at the start of the sections (log + a budget_projection
+        errors record embedded in summary.json) instead of truncating
+        silently."""
+        with self._patched_dump(tmp_path) as (_crosslink_mocks, section_mocks):
+
+            def _fake_prefix_lookup(prefix, fields=None):
+                return [mock.MagicMock(request_id=prefix)]
+
+            with mock.patch(
+                    'sky.utils.debug_utils.requests_lib.'
+                    'get_requests_with_prefix',
+                    side_effect=_fake_prefix_lookup):
+                result = debug_utils.create_debug_dump(
+                    request_ids=[f'req-{i}' for i in range(1000)],
+                    overall_deadline=time.time() + 10)
+
+        errors = self._read_errors(result)
+        projections = [
+            e for e in errors if e['resource'] == 'budget_projection'
+        ]
+        assert len(projections) == 1
+        assert projections[0]['component'] == 'requests'
+        assert 'projected overrun' in projections[0]['error']
+
+    def test_past_deadline_zip_truncates_but_stays_self_describing(
+            self, tmp_path):
+        """A deadline that expires before the zip finishes yields a VALID,
+        truncated archive: the self-describing top-level artifacts are always
+        included by name, debug_dump.log is the final walk entry (so the
+        'zipping N bytes' line and the mid-walk truncation warning are
+        deterministic in the archived copy), and zip_stats.json records the
+        truncation."""
+        with self._patched_dump(tmp_path) as (_crosslink_mocks, section_mocks):
+
+            def _slow_server_info(dump_dir, **_kwargs):
+                # Write a non-exempt collected file, then outlast the
+                # budget so the zip walk starts with the deadline gone.
+                requests_dir = os.path.join(dump_dir, 'requests')
+                os.makedirs(requests_dir, exist_ok=True)
+                with open(os.path.join(requests_dir, 'req-1.log'),
+                          'w',
+                          encoding='utf-8') as f:
+                    f.write('x' * 128)
+                time.sleep(0.3)
+
+            section_mocks['_dump_server_info'].side_effect = (_slow_server_info)
+            result = debug_utils.create_debug_dump(
+                cluster_names=['c'],
+                client_info={'client_version': '0.10.0'},
+                overall_deadline=time.time() + 0.1)
+
+        assert result.exists()
+        assert zipfile.is_zipfile(result)
+        with zipfile.ZipFile(result, 'r') as zf:
+            names = zf.namelist()
+            # The self-describing artifacts are always present, by name.
+            for artifact in ('summary.json', 'errors.json', 'client_info.json',
+                             'debug_dump.log', 'zip_stats.json'):
+                assert any(n.endswith(artifact) for n in names), artifact
+            # The non-exempt collected file was skipped by the deadline.
+            assert not any(n.endswith('req-1.log') for n in names)
+            # debug_dump.log is the final WALK entry (zip_stats.json is
+            # appended after the zip closes, so it is the very last name).
+            assert names[-1].endswith('zip_stats.json')
+            assert names[-2].endswith('debug_dump.log')
+            # The archived log deterministically contains both the
+            # pre-walk 'zipping' line and the mid-walk truncation warning.
+            archived_log = zf.read(names[-2]).decode()
+            assert 'zipping' in archived_log
+            assert 'truncating the archive' in archived_log
+            stats = json.loads(
+                zf.read(next(n for n in names if n.endswith('zip_stats.json'))))
+        assert stats['status'] == 'truncated_deadline'
+        assert stats['skipped_deadline_files'] >= 1

--- a/tests/unit_tests/test_sky/utils/test_debug_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_debug_utils.py
@@ -4686,11 +4686,7 @@ class TestRunWithDeadline:
                 errors=errors,
                 orphans=orphans,
                 deadline=time.monotonic() + 100,
-                op_desc=('fetch that '
-                         'hung; its '
-                         'loss '
-                         'degrades '
-                         'the dump'))
+                op_desc=('fetch that hung; its loss degrades the dump'))
             assert ok is False
             assert result is None
             assert len(errors) == 1
@@ -4720,32 +4716,58 @@ class TestRunWithDeadline:
                                            resource='r')
 
     def test_log_stragglers_warns_running_skips_done(self, monkeypatch):
-        running: concurrent.futures.Future = concurrent.futures.Future()
-        done: concurrent.futures.Future = concurrent.futures.Future()
-        done.set_result(None)
-        orphans = [
-            {
-                'component': 'still',
-                'resource': 'running',
-                'future': running,
-                'started': time.monotonic() - 2,
-            },
-            {
-                'component': 'already',
-                'resource': 'done',
-                'future': done,
-                'started': time.monotonic() - 2,
-            },
-        ]
-        calls = []
-        monkeypatch.setattr(debug_utils.logger, 'warning',
-                            lambda *a, **k: calls.append(a))
-        debug_utils._log_timed_out_stragglers(orphans)
-        # One warning per fate: the still-running op leaks; the done one
-        # completed after timing out and its result was discarded.
-        assert len(calls) == 2
-        assert any('still running' in a[0] for a in calls)
-        assert any('completed' in a[0] and 'discarded' in a[0] for a in calls)
+        """One warning per orphan fate: a still-running op leaks (with its
+        current stack, best-effort), a done one completed after timing out
+        and its result was discarded. The still-running case is exercised
+        with a REAL orphan from _run_with_deadline so the worker's stack
+        genuinely has to reach the log."""
+        release = threading.Event()
+
+        def _stuck():  # MARKER_STRAGGLER_STUCK_FN
+            release.wait()  # MARKER_STRAGGLER_STUCK_FRAME
+
+        real_errors: List[Dict[str, Any]] = []
+        real_orphans: List[Dict[str, Any]] = []
+        try:
+            debug_utils._run_with_deadline(_stuck,
+                                           timeout=0.1,
+                                           component='stuck',
+                                           resource='worker',
+                                           errors=real_errors,
+                                           orphans=real_orphans,
+                                           deadline=time.monotonic() + 100)
+            running: concurrent.futures.Future = concurrent.futures.Future()
+            done: concurrent.futures.Future = concurrent.futures.Future()
+            done.set_result(None)
+            orphans = [
+                {
+                    'component': 'still',
+                    'resource': 'running',
+                    'future': running,
+                    'started': time.monotonic() - 2,
+                },
+                {
+                    'component': 'already',
+                    'resource': 'done',
+                    'future': done,
+                    'started': time.monotonic() - 2,
+                },
+            ] + real_orphans
+            calls = []
+            monkeypatch.setattr(debug_utils.logger, 'warning',
+                                lambda *a, **k: calls.append(a))
+            debug_utils._log_timed_out_stragglers(orphans)
+            # The synthetic still-running orphan has no thread id, so it
+            # gets one warning; the real one also gets its current stack.
+            assert len(calls) == 4
+            assert any('still running' in a[0] for a in calls)
+            assert any(
+                'completed' in a[0] and 'discarded' in a[0] for a in calls)
+            stack_logs = [a for a in calls if 'current stack' in a[0]]
+            assert len(stack_logs) == 1
+            assert 'MARKER_STRAGGLER_STUCK_FRAME' in stack_logs[0][-1]
+        finally:
+            release.set()
 
 
 class TestOverallDeadlineHelpers:
@@ -4993,6 +5015,26 @@ class TestOverallDeadlineDump:
         assert projections[0]['component'] == 'requests'
         assert 'projected overrun' in projections[0]['error']
 
+    def test_past_deadline_emits_no_budget_projection(self, tmp_path):
+        """A dump that reaches the sections with its budget already spent
+        reports that via the section skip records; the static projection
+        stays silent instead of warning against a non-positive remainder
+        ('~Ns vs -0s of budget')."""
+        with self._patched_dump(tmp_path) as (_crosslink_mocks, section_mocks):
+            result = debug_utils.create_debug_dump(
+                request_ids=[f'req-{i}' for i in range(1000)],
+                overall_deadline=time.time() - 1)
+
+        errors = self._read_errors(result)
+        assert not [e for e in errors if e['resource'] == 'budget_projection']
+        # The exhausted budget is still reported -- by the skip records.
+        skip_records = [
+            e for e in errors
+            if e.get('error') == 'Skipped: overall debug-dump deadline '
+            'exceeded.'
+        ]
+        assert skip_records
+
     def test_past_deadline_zip_truncates_but_stays_self_describing(
             self, tmp_path):
         """A deadline that expires before the zip finishes yields a VALID,
@@ -5014,7 +5056,7 @@ class TestOverallDeadlineDump:
                     f.write('x' * 128)
                 time.sleep(0.3)
 
-            section_mocks['_dump_server_info'].side_effect = (_slow_server_info)
+            section_mocks['_dump_server_info'].side_effect = _slow_server_info
             result = debug_utils.create_debug_dump(
                 cluster_names=['c'],
                 client_info={'client_version': '0.10.0'},


### PR DESCRIPTION
## Problem

The debug dump's overall deadline only bounded the five named collection sections. Everything around them ran outside it, which showed up clearly in a dump taken from a production server with many stale unfinished requests:

- **Pre-section phase unbounded (28.5% of the budget before any section ran):** the cross-link/context-population phase spent 239s — including a single 120s unfiltered `queue_v2(all_users=True)` call that returned **zero** jobs (all ~800 in-scope jobs were recovered by the request-body scan instead) — and the phase had no `section_timings` entry, so the timings sum understated the runtime by ~4 minutes.
- **TOCTOU nonsense timeouts:** the deadline clamp could hand `future.result()` a tiny or negative timeout, producing permanent records like `log timed out after 0.021s` and `request_debug.log timed out after -0.0015s` — one deadline-exhausted request generated two bogus records, one with a physically impossible duration, indistinguishable from a real copy stall.
- **Waiter-stack tracebacks:** every timeout entry carried the byte-identical stack of the *waiting* thread, pointing at the dump helper rather than the hung operation; and a worker that finished after being abandoned had its result silently discarded with no trace.
- **Zip step invisible:** after the budget was exhausted, the walk DEFLATE-compressed the whole multi-GB dump with no deadline check and with the log handler already detached, so the zip phase appeared in no artifact.
- **No OSS default and no feasibility feedback:** OSS `sky debug-dump` ran with no deadline at all, and the dump logged request counts and budget side by side without ever comparing them, even when the scope was mathematically infeasible.

## What this PR does

- `_run_with_deadline`: a pre-submit guard (never start a worker once the budget is gone — this is the only path that omits an orphan), deterministic attribution (a budget-binding timeout records the standard `Skipped: overall debug-dump deadline exceeded.` record; only a full-cap timeout is reported as a stall, now with an `operation` description and a best-effort `worker_stack` captured from the stuck worker thread via `sys._current_frames` — never the waiter's stack), and orphan entries carrying the worker thread id. The sky-check summary message in `server_info.json` branches on the same pre-submit decision instead of re-checking the deadline after the wait. `_bounded_timeout` floors the clamp at 0.0 so negative timeouts can no longer exist.
- `_log_timed_out_stragglers` also reports workers that completed after timing out (`result was discarded`) and logs a still-running worker's current stack.
- The context-population phase runs on its own sub-budget (25% of the budget remaining at phase start, checked before each step including the first, and at every per-item DB loop top), records one aggregate skip entry on expiry, and gets its own `section_timings[0]` entry with per-step sub-timings.
- The two unfiltered `all_users` `queue_v2` scans are capped at 30s (down from 120s) — they are scope-expansion hints whose data the request-body scan recovers independently. Note this is a deliberate degradation on large-but-healthy controllers that take >30s: the cluster→job expansion is lost, recorded with its user-relevant consequence.
- `_get_job_clusters_from_managed_jobs` routes its `queue_v2` call through the deadline helper like its three siblings (it was the only unbounded call site).
- The zip walk checks the deadline between files, always includes the self-describing artifacts (`summary.json`, `errors.json`, `client_info.json` when present, `debug_dump.log`) by name, writes `debug_dump.log` as the final entry (handler flushed first, so the zipping line and any truncation warning are deterministic in the archived copy), and appends a `zip_stats.json` record (duration / file count / skipped files / status). The debug handler stays attached through the zip.
- `core.create_debug_dump` applies a 1800s backstop deadline when the caller sends none, so every API-initiated dump is bounded (a wedged dump previously held an API-server worker indefinitely); explicit deadlines pass through verbatim, and `debug_utils`' documented `None` == unchanged-behavior contract is preserved. The 1800s value is derived from evidence: a ~840s caller budget was already infeasible for ~9.5k in-scope requests (~80ms/request projects to ~765s for the requests section alone), so 1800s gives ~2x headroom over the largest observed near-feasible run while bounding the previously unbounded case.
- Two complementary feasibility warnings when the workload cannot fit the budget: a static projection at the start of the sections (~0.08s/request, a coarse heuristic derived from one production observation) and a once-only measured running-average projection inside the requests loop — both logged prominently and recorded as `budget_projection` entries in errors.json (embedded in summary.json). The static projection stays silent once the budget is already gone -- the skip records report that.

## Known residuals (deliberate, follow-up-able)

- A single multi-GB `zf.write` inside the zip walk remains uninterruptible mid-file (per-file check granularity only; mid-file chunked streaming is left as a follow-up).
- Single in-flight DB calls inside the context-population phase (the request/cluster scans, the body-fetch query, individual `get_request` calls) are bounded only by their fixed per-op caps and loop-top checks, not per-call.
- The pre-zip `rglob` stat walk remains outside the deadline.
- At the `kubernetes_contexts` site, the captured `worker_stack` is the `run_in_parallel` pool-wait frame of the executor worker, not the individual stuck context thread — best-effort, still more useful than the waiter stack.

No new user-facing configuration knobs — only internal constants; rollback is revert.

## Tested

- `tests/unit_tests/test_sky/utils/test_debug_utils.py` — new tests for the pre-submit skip, clamp-vs-stall attribution (pinned orphan semantics), worker-stack capture, the `_bounded_timeout` floor, the per-request double-record regression, both feasibility warnings, the phase sub-budget and its `section_timings` entry, the 30s recent-jobs cap, the `queue_v2` sibling bounding, loop-top aggregate skips, the sky-check budget-skip phrasing, and zip truncation with a self-describing partial (18 new tests + updates; the only failures in the file are pre-existing environment-dependent kube tests that also fail on unmodified master in this devspace).
- `tests/unit_tests/test_core.py -k create_debug_dump` — the 1800s default and verbatim pass-through.
- End-to-end against a locally started API server: `sky debug-dump --recent-minutes 5` completes and downloads; section logs show `(1800s budget left)`; `summary.json`'s `section_timings[0]` is `context_population` with sub-timings; errors.json contains no negative/tiny timeout records; the archived `debug_dump.log` is the final walk entry and contains the zipping line; `zip_stats.json` is present.

Note: this touches `sky/utils/debug_utils.py` in the same regions as other in-flight debug-dump changes, so expect (textual) conflicts with those — they should be resolved by re-reading the newer version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
