### PR TITLE
refactor: utilize ReadReplica instead or a url

### DIFF
--- a/sky/serve/controller.py
+++ b/sky/serve/controller.py
@@ -124,33 +124,29 @@ class SkyServeController:
             logger.info(f'Received {len(timestamps)} inflight requests.')
             self._autoscaler.collect_request_information(request_aggregator)
 
-            # Get replica information for instance-aware load balancing
-            replica_infos = serve_state.get_replica_infos(self._service_name)
-            ready_replica_urls = self._replica_manager.get_active_replica_urls()
+            # Get replica information for load balancing. Keep the stable
+            # replica ID together with the current URL so the load balancer
+            # can use the URL for routing and the ID for accounting.
+            active_replica_infos = (
+                self._replica_manager.get_active_replica_infos())
+            replica_info = []
+            for info in active_replica_infos:
+                url = info.url
+                assert url is not None, info
 
-            # Use URL-to-info mapping to avoid duplication
-            replica_info = {}
-            for info in replica_infos:
-                if info.url in ready_replica_urls:
-                    # Get GPU type from handle.launched_resources.accelerators
-                    gpu_type = 'unknown'
-                    handle = info.handle()
-                    if handle is not None:
-                        accelerators = handle.launched_resources.accelerators
-                        if accelerators and len(accelerators) > 0:
-                            # Get the first accelerator type
-                            gpu_type = list(accelerators.keys())[0]
+                # Get GPU type from handle.launched_resources.accelerators.
+                gpu_type = 'unknown'
+                handle = info.handle()
+                if handle is not None:
+                    accelerators = handle.launched_resources.accelerators
+                    if accelerators:
+                        gpu_type = list(accelerators.keys())[0]
 
-                    replica_info[info.url] = {'gpu_type': gpu_type}
-
-            # Check that all ready replica URLs are included in replica_info
-            missing_urls = set(ready_replica_urls) - set(replica_info.keys())
-            if missing_urls:
-                logger.warning(f'Ready replica URLs missing from replica_info: '
-                               f'{missing_urls}')
-                # fallback: add missing URLs with unknown GPU type
-                for url in missing_urls:
-                    replica_info[url] = {'gpu_type': 'unknown'}
+                replica_info.append({
+                    'replica_id': info.replica_id,
+                    'url': url,
+                    'gpu_type': gpu_type,
+                })
 
             return responses.JSONResponse(
                 content={'replica_info': replica_info}, status_code=200)

--- a/sky/serve/load_balancer.py
+++ b/sky/serve/load_balancer.py
@@ -87,8 +87,7 @@ class SkyServeLoadBalancer:
             load_balancing_policy_name)
 
         # Set accelerator QPS for instance-aware policies
-        if (target_qps_per_replica and
-                isinstance(target_qps_per_replica, dict) and
+        if (isinstance(target_qps_per_replica, dict) and
                 isinstance(self._load_balancing_policy,
                            lb_policies.InstanceAwareLeastLoadPolicy)):
             self._load_balancing_policy.set_target_qps_per_accelerator(
@@ -117,8 +116,7 @@ class SkyServeLoadBalancer:
 
     async def _sync_with_controller_once(self) -> List[asyncio.Task]:
         close_client_tasks = []
-        ready_replica_urls = []
-        replica_info = {}
+        ready_replicas = []
 
         async with aiohttp.ClientSession() as session:
             try:
@@ -135,28 +133,34 @@ class SkyServeLoadBalancer:
                     self._request_aggregator.clear()
                     response.raise_for_status()
                     response_json = await response.json()
-                    replica_info = response_json.get('replica_info', {})
-                    ready_replica_urls = list(replica_info.keys())
+                    replica_infos = response_json.get('replica_info', [])
+                    if not isinstance(replica_infos, list):
+                        raise ValueError(
+                            'Expected replica_info to be a list of replica '
+                            f'descriptors, got {type(replica_infos).__name__}.')
+                    ready_replicas = [
+                        lb_policies.ReadyReplica(
+                            replica_id=replica_info['replica_id'],
+                            url=replica_info['url'],
+                            gpu_type=replica_info.get('gpu_type', 'unknown'))
+                        for replica_info in replica_infos
+                    ]
             except (aiohttp.ClientError, asyncio.TimeoutError) as e:
                 logger.error(f'An error occurred when syncing with '
                              f'the controller: {e}'
                              f'\nTraceback: {traceback.format_exc()}')
             else:
-                logger.info(f'Available Replica URLs: {ready_replica_urls}')
+                logger.info('Available replicas: %s', ready_replicas)
                 with self._client_pool_lock:
                     self._load_balancing_policy.set_ready_replicas(
-                        ready_replica_urls)
-                    # Set replica info for instance-aware policies
-                    if isinstance(self._load_balancing_policy,
-                                  lb_policies.InstanceAwareLeastLoadPolicy):
-                        self._load_balancing_policy.set_replica_info(
-                            replica_info)
-                    for replica_url in ready_replica_urls:
-                        if replica_url not in self._client_pool:
-                            self._client_pool[replica_url] = httpx.AsyncClient(
-                                base_url=replica_url)
-                    urls_to_close = set(
-                        self._client_pool.keys()) - set(ready_replica_urls)
+                        ready_replicas)
+                    for replica in ready_replicas:
+                        if replica.url not in self._client_pool:
+                            self._client_pool[replica.url] = httpx.AsyncClient(
+                                base_url=replica.url)
+                    urls_to_close = set(self._client_pool.keys()) - {
+                        replica.url for replica in ready_replicas
+                    }
                     client_to_close = []
                     for replica_url in urls_to_close:
                         client_to_close.append(
@@ -190,7 +194,7 @@ class SkyServeLoadBalancer:
                              f'\nTraceback: {traceback.format_exc()}')
 
     async def _proxy_request_to(
-        self, url: str, request: fastapi.Request
+        self, replica: lb_policies.ReadyReplica, request: fastapi.Request
     ) -> Union[fastapi.responses.Response, Exception]:
         """Proxy the request to the specified URL.
 
@@ -198,20 +202,20 @@ class SkyServeLoadBalancer:
             The response from the endpoint replica. Return the exception
             encountered if anything goes wrong.
         """
-        logger.info(f'Proxy request to {url}')
+        logger.info(f'Proxy request to {replica.url}')
         release_load: Optional[Callable[[], None]] = None
         try:
             release_load = self._load_balancing_policy.begin_request(
-                url, request)
+                replica, request)
             # We defer the get of the client here on purpose, for case when the
             # replica is ready in `_proxy_with_retries` but refreshed before
             # entering this function. In that case we will return an error here
             # and retry to find next ready replica. We also need to wait for the
             # update of the client pool to finish before getting the client.
             with self._client_pool_lock:
-                client = self._client_pool.get(url, None)
+                client = self._client_pool.get(replica.url, None)
             if client is None:
-                return RuntimeError(f'Client for {url} not found.')
+                return RuntimeError(f'Client for {replica.url} not found.')
             worker_url = httpx.URL(path=request.url.path,
                                    query=request.url.query.encode('utf-8'))
             proxy_request = client.build_request(
@@ -228,7 +232,7 @@ class SkyServeLoadBalancer:
                     await proxy_response.aclose()
                 except Exception:  # pylint: disable=broad-except
                     logger.exception(
-                        f'Error closing proxied response to {url}.')
+                        f'Error closing proxied response to {replica.url}.')
                 finally:
                     release_load()
 
@@ -242,7 +246,7 @@ class SkyServeLoadBalancer:
             release_load = None
             return response
         except (httpx.RequestError, httpx.HTTPStatusError) as e:
-            logger.error(f'Error when proxy request to {url}: '
+            logger.error(f'Error when proxy request to {replica.url}: '
                          f'{common_utils.format_exception(e)}'
                          f'\nTraceback: {traceback.format_exc()}')
             return e
@@ -266,9 +270,9 @@ class SkyServeLoadBalancer:
         while True:
             retry_cnt += 1
             with self._client_pool_lock:
-                ready_replica_url = self._load_balancing_policy.select_replica(
+                ready_replica = self._load_balancing_policy.select_replica(
                     request)
-            if ready_replica_url is None:
+            if ready_replica is None:
                 response_or_exception = fastapi.HTTPException(
                     # 503 means that the server is currently
                     # unable to handle the incoming requests.
@@ -278,7 +282,7 @@ class SkyServeLoadBalancer:
                     'to check the replica status.')
             else:
                 response_or_exception = await self._proxy_request_to(
-                    ready_replica_url, request)
+                    ready_replica, request)
             if not isinstance(response_or_exception, Exception):
                 return response_or_exception
             # When the user aborts the request during streaming, the request

--- a/sky/serve/load_balancer.py
+++ b/sky/serve/load_balancer.py
@@ -93,7 +93,7 @@ class SkyServeLoadBalancer:
             self._load_balancing_policy.set_target_qps_per_accelerator(
                 target_qps_per_replica)
 
-        logger.info('Starting load balancer with policy '
+        logger.info(f'Starting load balancer with policy '
                     f'{load_balancing_policy_name}.')
         self._request_aggregator: serve_utils.RequestsAggregator = (
             serve_utils.RequestTimestamp())
@@ -146,11 +146,11 @@ class SkyServeLoadBalancer:
                         for replica_info in replica_infos
                     ]
             except (aiohttp.ClientError, asyncio.TimeoutError) as e:
-                logger.error(f'An error occurred when syncing with '
-                             f'the controller: {e}'
-                             f'\nTraceback: {traceback.format_exc()}')
+                logger.error(f'An error occurred when syncing with the '
+                             f'controller: {e}\nTraceback: '
+                             f'{traceback.format_exc()}')
             else:
-                logger.info('Available replicas: %s', ready_replicas)
+                logger.info(f'Available replicas: {ready_replicas}')
                 with self._client_pool_lock:
                     self._load_balancing_policy.set_ready_replicas(
                         ready_replicas)
@@ -189,9 +189,9 @@ class SkyServeLoadBalancer:
                 # Await those tasks after the interval to avoid blocking.
                 await asyncio.gather(*close_client_tasks)
             except Exception as e:  # pylint: disable=broad-except
-                logger.error(f'An error occurred when syncing with '
-                             f'the controller: {e}'
-                             f'\nTraceback: {traceback.format_exc()}')
+                logger.error(f'An error occurred when syncing with the '
+                             f'controller: {e}\nTraceback: '
+                             f'{traceback.format_exc()}')
 
     async def _proxy_request_to(
         self, replica: lb_policies.ReadyReplica, request: fastapi.Request
@@ -247,8 +247,8 @@ class SkyServeLoadBalancer:
             return response
         except (httpx.RequestError, httpx.HTTPStatusError) as e:
             logger.error(f'Error when proxy request to {replica.url}: '
-                         f'{common_utils.format_exception(e)}'
-                         f'\nTraceback: {traceback.format_exc()}')
+                         f'{common_utils.format_exception(e)}\nTraceback: '
+                         f'{traceback.format_exc()}')
             return e
         finally:
             # If proxying failed before release ownership was transferred to
@@ -329,7 +329,7 @@ class SkyServeLoadBalancer:
 
         protocol = 'https' if self._tls_credential is not None else 'http'
 
-        logger.info('SkyServe Load Balancer started on '
+        logger.info(f'SkyServe Load Balancer started on '
                     f'{protocol}://0.0.0.0:{self._load_balancer_port}. '
                     f'PID: {os.getpid()}')
 

--- a/sky/serve/load_balancing_policies.py
+++ b/sky/serve/load_balancing_policies.py
@@ -84,7 +84,7 @@ class LoadBalancingPolicy:
                 f'Selected replica {replica.replica_id} at {replica.url} '
                 f'for request {_request_repr(request)}')
         else:
-            logger.warning('No replica selected for request '
+            logger.warning(f'No replica selected for request '
                            f'{_request_repr(request)}')
         return replica
 
@@ -275,19 +275,18 @@ class InstanceAwareLeastLoadPolicy(LeastLoadPolicy,
         target_qps = self._get_target_qps_for_accelerator(accelerator_type)
         if target_qps <= 0:
             logger.warning(
-                'Non-positive target QPS (%s) for accelerator type %s; '
-                'using default value 1.0 to avoid division by zero.',
-                target_qps, accelerator_type)
+                f'Non-positive target QPS ({target_qps}) for accelerator type '
+                f'{accelerator_type}; using default value 1.0 to avoid '
+                'division by zero.')
             target_qps = 1.0
 
         # Load is normalized by target QPS
         normalized_load = current_load / target_qps
 
         logger.debug(
-            'InstanceAwareLeastLoadPolicy: Replica %s - GPU type: %s, '
-            'current load: %s, target QPS: %s, normalized load: %s',
-            replica.replica_id, accelerator_type, current_load, target_qps,
-            normalized_load)
+            f'InstanceAwareLeastLoadPolicy: Replica {replica.replica_id} - '
+            f'GPU type: {accelerator_type}, current load: {current_load}, '
+            f'target QPS: {target_qps}, normalized load: {normalized_load}')
 
         return normalized_load
 
@@ -329,8 +328,8 @@ class InstanceAwareLeastLoadPolicy(LeastLoadPolicy,
                 replica for replica, load in replica_loads if load == min_load
             ]
             selected_replica = self._select_tied_replica(tied_replicas)
-            logger.debug('Available replicas and loads: %s', replica_loads)
-            logger.debug('Selected replica: %s', selected_replica)
+            logger.debug(f'Available replicas and loads: {replica_loads}')
+            logger.debug(f'Selected replica: {selected_replica}')
             return selected_replica
 
     # set_ready_replicas, begin_request, pre_execute_hook, and

--- a/sky/serve/load_balancing_policies.py
+++ b/sky/serve/load_balancing_policies.py
@@ -1,9 +1,10 @@
 """LoadBalancingPolicy: Policy to select endpoint."""
 import collections
+import dataclasses
 import random
 import threading
 import typing
-from typing import Any, Callable, Dict, List, Optional
+from typing import Callable, Dict, List, Optional
 
 from sky import sky_logging
 
@@ -11,6 +12,23 @@ if typing.TYPE_CHECKING:
     import fastapi
 
 logger = sky_logging.init_logger(__name__)
+
+
+@dataclasses.dataclass(frozen=True)
+class ReadyReplica:
+    """A ready replica's stable identity and current routing information.
+
+    ``replica_id`` is scoped to a service and is used as the load-accounting
+    key. Each load balancer currently handles a single service.
+    """
+
+    # TODO(jgsweets): Include service_name in the identity and accounting key if
+    # a load balancer ever handles multiple services.
+
+    replica_id: int
+    url: str
+    gpu_type: str = 'unknown'
+
 
 # Define a registry for load balancing policies
 LB_POLICIES = {}
@@ -29,7 +47,7 @@ class LoadBalancingPolicy:
     """Abstract class for load balancing policies."""
 
     def __init__(self) -> None:
-        self.ready_replicas: List[str] = []
+        self.ready_replicas: List[ReadyReplica] = []
 
     def __init_subclass__(cls, name: str, default: bool = False):
         LB_POLICIES[name] = cls
@@ -55,14 +73,16 @@ class LoadBalancingPolicy:
             raise ValueError(f'Unknown load balancing policy: {policy_name}')
         return LB_POLICIES[policy_name]()
 
-    def set_ready_replicas(self, ready_replicas: List[str]) -> None:
+    def set_ready_replicas(self, ready_replicas: List[ReadyReplica]) -> None:
         raise NotImplementedError
 
-    def select_replica(self, request: 'fastapi.Request') -> Optional[str]:
+    def select_replica(self,
+                       request: 'fastapi.Request') -> Optional[ReadyReplica]:
         replica = self._select_replica(request)
         if replica is not None:
-            logger.info(f'Selected replica {replica} '
-                        f'for request {_request_repr(request)}')
+            logger.info(
+                f'Selected replica {replica.replica_id} at {replica.url} '
+                f'for request {_request_repr(request)}')
         else:
             logger.warning('No replica selected for request '
                            f'{_request_repr(request)}')
@@ -70,21 +90,24 @@ class LoadBalancingPolicy:
 
     # TODO(tian): We should have an abstract class for Request to
     # compatible with all frameworks.
-    def _select_replica(self, request: 'fastapi.Request') -> Optional[str]:
+    def _select_replica(self,
+                        request: 'fastapi.Request') -> Optional[ReadyReplica]:
         raise NotImplementedError
 
-    def begin_request(self, replica_url: str,
+    def begin_request(self, replica: ReadyReplica,
                       request: 'fastapi.Request') -> Callable[[], None]:
         """Begin request accounting and return a release callback."""
-        del replica_url, request
+        del replica, request
         return lambda: None
 
-    def pre_execute_hook(self, replica_url: str,
+    def pre_execute_hook(self, replica: ReadyReplica,
                          request: 'fastapi.Request') -> None:
+        del replica, request
         pass
 
-    def post_execute_hook(self, replica_url: str,
+    def post_execute_hook(self, replica: ReadyReplica,
                           request: 'fastapi.Request') -> None:
+        del replica, request
         pass
 
 
@@ -95,9 +118,10 @@ class RoundRobinPolicy(LoadBalancingPolicy, name='round_robin'):
         super().__init__()
         self.index = 0
 
-    def set_ready_replicas(self, ready_replicas: List[str]) -> None:
+    def set_ready_replicas(self, ready_replicas: List[ReadyReplica]) -> None:
         if set(self.ready_replicas) == set(ready_replicas):
             return
+        ready_replicas = list(ready_replicas)
         # If the autoscaler keeps scaling up and down the replicas,
         # we need this shuffle to not let the first replica have the
         # most of the load.
@@ -105,13 +129,14 @@ class RoundRobinPolicy(LoadBalancingPolicy, name='round_robin'):
         self.ready_replicas = ready_replicas
         self.index = 0
 
-    def _select_replica(self, request: 'fastapi.Request') -> Optional[str]:
+    def _select_replica(self,
+                        request: 'fastapi.Request') -> Optional[ReadyReplica]:
         del request  # Unused.
         if not self.ready_replicas:
             return None
-        ready_replica_url = self.ready_replicas[self.index]
+        ready_replica = self.ready_replicas[self.index]
         self.index = (self.index + 1) % len(self.ready_replicas)
-        return ready_replica_url
+        return ready_replica
 
 
 class LeastLoadPolicy(LoadBalancingPolicy, name='least_load', default=True):
@@ -119,44 +144,45 @@ class LeastLoadPolicy(LoadBalancingPolicy, name='least_load', default=True):
 
     def __init__(self) -> None:
         super().__init__()
-        self.load_map: Dict[str, int] = collections.defaultdict(int)
+        self.load_map: Dict[int, int] = collections.defaultdict(int)
         self.lock = threading.Lock()
         self._tie_breaker_index = 0
 
-    def set_ready_replicas(self, ready_replicas: List[str]) -> None:
+    def set_ready_replicas(self, ready_replicas: List[ReadyReplica]) -> None:
         ready_replica_set = set(ready_replicas)
         if set(self.ready_replicas) == ready_replica_set:
             return
+        ready_replicas = list(ready_replicas)
+        ready_replica_ids = {replica.replica_id for replica in ready_replicas}
         with self.lock:
             self.ready_replicas = ready_replicas
-            for r in list(self.load_map.keys()):
-                # Delete retired replicas immediately. A late completion is
-                # ignored by post_execute_hook() instead of recreating the
-                # entry. This favors avoiding phantom load if a URL is reused
-                # over preserving accounting across a readiness flap. A URL
-                # that re-enters before an old request finishes can still be
-                # affected by that late completion; stable replica identity
-                # would be needed to eliminate that ambiguity.
-                if r not in ready_replica_set:
-                    del self.load_map[r]
+            # Retain retired replica IDs with in-flight requests so their
+            # completions can decrement the same identity. Remove idle
+            # retired IDs immediately.
+            for replica_id in list(self.load_map.keys()):
+                if (replica_id not in ready_replica_ids and
+                        self.load_map[replica_id] == 0):
+                    del self.load_map[replica_id]
             for replica in ready_replicas:
-                self.load_map[replica] = self.load_map.get(replica, 0)
+                self.load_map[replica.replica_id] = self.load_map.get(
+                    replica.replica_id, 0)
 
-    def _select_replica(self, request: 'fastapi.Request') -> Optional[str]:
+    def _select_replica(self,
+                        request: 'fastapi.Request') -> Optional[ReadyReplica]:
         del request  # Unused.
         if not self.ready_replicas:
             return None
         with self.lock:
             min_load = min(
-                self.load_map.get(replica, 0)
+                self.load_map.get(replica.replica_id, 0)
                 for replica in self.ready_replicas)
             tied_replicas = [
                 replica for replica in self.ready_replicas
-                if self.load_map.get(replica, 0) == min_load
+                if self.load_map.get(replica.replica_id, 0) == min_load
             ]
             return self._select_tied_replica(tied_replicas)
 
-    def begin_request(self, replica_url: str,
+    def begin_request(self, replica: ReadyReplica,
                       request: 'fastapi.Request') -> Callable[[], None]:
         load_released = False
 
@@ -165,16 +191,17 @@ class LeastLoadPolicy(LoadBalancingPolicy, name='least_load', default=True):
             if load_released:
                 return
             load_released = True
-            self.post_execute_hook(replica_url, request)
+            self.post_execute_hook(replica, request)
 
         # Keep this as the last operation before returning the release
         # callback. It increments load_map; a potentially-raising operation
         # after it would leak the increment before the callback is handed to
         # the caller.
-        self.pre_execute_hook(replica_url, request)
+        self.pre_execute_hook(replica, request)
         return release_load
 
-    def _select_tied_replica(self, replicas: List[str]) -> str:
+    def _select_tied_replica(self,
+                             replicas: List[ReadyReplica]) -> ReadyReplica:
         """Select among tied replicas without favoring the first one.
 
         The cursor is relative to all ready replicas, so changes to the set
@@ -192,26 +219,30 @@ class LeastLoadPolicy(LoadBalancingPolicy, name='least_load', default=True):
                 return replica
         raise RuntimeError('No tied replica found among ready replicas.')
 
-    def pre_execute_hook(self, replica_url: str,
+    def pre_execute_hook(self, replica: ReadyReplica,
                          request: 'fastapi.Request') -> None:
         del request  # Unused.
         with self.lock:
-            self.load_map[replica_url] += 1
+            self.load_map[replica.replica_id] += 1
 
-    def post_execute_hook(self, replica_url: str,
+    def post_execute_hook(self, replica: ReadyReplica,
                           request: 'fastapi.Request') -> None:
         del request  # Unused.
         with self.lock:
-            current_load = self.load_map.get(replica_url)
+            current_load = self.load_map.get(replica.replica_id)
             if current_load is None:
-                # Do not recreate an entry for a completion from a retired
-                # replica.
+                # The replica may have retired before this request completed.
                 return
             current_load = max(0, current_load - 1)
-            if current_load == 0 and replica_url not in self.ready_replicas:
-                del self.load_map[replica_url]
+            ready_replica_ids = {
+                ready_replica.replica_id
+                for ready_replica in self.ready_replicas
+            }
+            if (current_load == 0 and
+                    replica.replica_id not in ready_replica_ids):
+                del self.load_map[replica.replica_id]
             else:
-                self.load_map[replica_url] = current_load
+                self.load_map[replica.replica_id] = current_load
 
 
 class InstanceAwareLeastLoadPolicy(LeastLoadPolicy,
@@ -225,20 +256,8 @@ class InstanceAwareLeastLoadPolicy(LeastLoadPolicy,
 
     def __init__(self) -> None:
         super().__init__()
-        self.replica_info: Dict[str, Dict[str, Any]] = {}  # replica_url -> info
         self.target_qps_per_accelerator: Dict[str, float] = {
         }  # accelerator_type -> target_qps
-
-    def set_replica_info(self, replica_info: Dict[str, Dict[str, Any]]) -> None:
-        """Set replica information including accelerator types.
-
-        Args:
-            replica_info: Dict mapping replica URL to replica information
-                         e.g., {'http://url1': {'gpu_type': 'A100'}}
-        """
-        with self.lock:
-            self.replica_info = replica_info
-            logger.debug('Set replica info: %s', self.replica_info)
 
     def set_target_qps_per_accelerator(
             self, target_qps_per_accelerator: Dict[str, float]) -> None:
@@ -246,13 +265,11 @@ class InstanceAwareLeastLoadPolicy(LeastLoadPolicy,
         with self.lock:
             self.target_qps_per_accelerator = target_qps_per_accelerator
 
-    def _get_normalized_load(self, replica_url: str) -> float:
+    def _get_normalized_load(self, replica: ReadyReplica) -> float:
         """Get normalized load for a replica based on its accelerator type."""
-        current_load = self.load_map.get(replica_url, 0)
+        current_load = self.load_map.get(replica.replica_id, 0)
 
-        # Get accelerator type for this replica
-        replica_data = self.replica_info.get(replica_url, {})
-        accelerator_type = replica_data.get('gpu_type', 'unknown')
+        accelerator_type = replica.gpu_type
 
         # Get target QPS for this accelerator type with flexible matching
         target_qps = self._get_target_qps_for_accelerator(accelerator_type)
@@ -269,7 +286,7 @@ class InstanceAwareLeastLoadPolicy(LeastLoadPolicy,
         logger.debug(
             'InstanceAwareLeastLoadPolicy: Replica %s - GPU type: %s, '
             'current load: %s, target QPS: %s, normalized load: %s',
-            replica_url, accelerator_type, current_load, target_qps,
+            replica.replica_id, accelerator_type, current_load, target_qps,
             normalized_load)
 
         return normalized_load
@@ -294,7 +311,8 @@ class InstanceAwareLeastLoadPolicy(LeastLoadPolicy,
             f'Using default value 1.0 as fallback.')
         return 1.0
 
-    def _select_replica(self, request: 'fastapi.Request') -> Optional[str]:
+    def _select_replica(self,
+                        request: 'fastapi.Request') -> Optional[ReadyReplica]:
         del request  # Unused.
         if not self.ready_replicas:
             return None

--- a/sky/serve/replica_managers.py
+++ b/sky/serve/replica_managers.py
@@ -756,8 +756,8 @@ class ReplicaManager:
                        update_mode: serve_utils.UpdateMode) -> None:
         raise NotImplementedError
 
-    def get_active_replica_urls(self) -> List[str]:
-        """Get the urls of the active replicas."""
+    def get_active_replica_infos(self) -> List[ReplicaInfo]:
+        """Get the active replica information."""
         raise NotImplementedError
 
 
@@ -1507,19 +1507,18 @@ class SkyPilotReplicaManager(ReplicaManager):
             # TODO(MaoZiming): Probe cloud for early preemption warning.
             time.sleep(self._get_endpoint_probe_interval_seconds())
 
-    def get_active_replica_urls(self) -> List[str]:
-        """Get the urls of all active replicas."""
+    def get_active_replica_infos(self) -> List[ReplicaInfo]:
+        """Get the information of all active replicas."""
         record = serve_state.get_service_from_name(self._service_name)
         assert record is not None, (f'{self._service_name} not found on '
                                     'controller records.')
-        ready_replica_urls = []
         active_versions = set(record['active_versions'])
+        active_replica_infos = []
         for info in serve_state.get_replica_infos(self._service_name):
             if (info.status == serve_state.ReplicaStatus.READY and
                     info.version in active_versions):
-                assert info.url is not None, info
-                ready_replica_urls.append(info.url)
-        return ready_replica_urls
+                active_replica_infos.append(info)
+        return active_replica_infos
 
     ###########################################
     # SkyServe Update and replica versioning. #

--- a/tests/unit_tests/test_sky/test_load_balancer.py
+++ b/tests/unit_tests/test_sky/test_load_balancer.py
@@ -19,11 +19,72 @@ def _make_request():
     return request
 
 
+def _make_replica(replica_id=1, url='http://replica', gpu_type='unknown'):
+    return load_balancing_policies.ReadyReplica(replica_id, url, gpu_type)
+
+
 def _make_load_balancer():
     return load_balancer.SkyServeLoadBalancer(
         controller_url='http://controller',
         load_balancer_port=30001,
         load_balancing_policy_name='least_load')
+
+
+@pytest.mark.asyncio
+async def test_sync_builds_ready_replica_descriptors(monkeypatch):
+    lb = _make_load_balancer()
+    response = mock.MagicMock()
+    response.raise_for_status = mock.Mock()
+    response.json = mock.AsyncMock(
+        return_value={
+            'replica_info': [{
+                'replica_id': 1,
+                'url': 'http://replica-1',
+                'gpu_type': 'A100',
+            }, {
+                'replica_id': 2,
+                'url': 'http://replica-2',
+            }]
+        })
+    response_context = mock.MagicMock()
+    response_context.__aenter__.return_value = response
+    session = mock.MagicMock()
+    session.post.return_value = response_context
+    session_context = mock.MagicMock()
+    session_context.__aenter__.return_value = session
+    monkeypatch.setattr(load_balancer.aiohttp, 'ClientSession',
+                        mock.Mock(return_value=session_context))
+
+    close_client_tasks = await lb._sync_with_controller_once()
+
+    assert close_client_tasks == []
+    assert lb._load_balancing_policy.ready_replicas == [
+        _make_replica(1, 'http://replica-1', 'A100'),
+        _make_replica(2, 'http://replica-2'),
+    ]
+    assert set(lb._client_pool) == {
+        'http://replica-1',
+        'http://replica-2',
+    }
+
+
+@pytest.mark.asyncio
+async def test_sync_rejects_non_list_replica_info(monkeypatch):
+    lb = _make_load_balancer()
+    response = mock.MagicMock()
+    response.raise_for_status = mock.Mock()
+    response.json = mock.AsyncMock(return_value={'replica_info': {}})
+    response_context = mock.MagicMock()
+    response_context.__aenter__.return_value = response
+    session = mock.MagicMock()
+    session.post.return_value = response_context
+    session_context = mock.MagicMock()
+    session_context.__aenter__.return_value = session
+    monkeypatch.setattr(load_balancer.aiohttp, 'ClientSession',
+                        mock.Mock(return_value=session_context))
+
+    with pytest.raises(ValueError, match='Expected replica_info to be a list'):
+        await lb._sync_with_controller_once()
 
 
 async def _run_response_with_client_disconnect(response, spec_version):
@@ -90,39 +151,39 @@ def _configure_multi_replica_clients(lb, replica_urls, failing_url):
 @pytest.mark.asyncio
 async def test_proxy_error_releases_least_load_accounting():
     lb = _make_load_balancer()
-    replica_url = 'http://replica'
+    replica = _make_replica()
     policy = lb._load_balancing_policy
-    policy.set_ready_replicas([replica_url])
+    policy.set_ready_replicas([replica])
     client = mock.MagicMock()
     client.build_request.return_value = mock.sentinel.proxy_request
     client.send = mock.AsyncMock(side_effect=httpx.ReadTimeout('timed out'))
-    lb._client_pool[replica_url] = client
+    lb._client_pool[replica.url] = client
 
-    result = await lb._proxy_request_to(replica_url, _make_request())
+    result = await lb._proxy_request_to(replica, _make_request())
 
     assert isinstance(result, httpx.ReadTimeout)
-    assert policy.load_map.get(replica_url) == 0
+    assert policy.load_map.get(replica.replica_id) == 0
 
 
 @pytest.mark.asyncio
 async def test_begin_request_error_preserves_least_load_accounting():
     lb = _make_load_balancer()
-    replica_url = 'http://replica'
+    replica = _make_replica()
     request = _make_request()
     policy = lb._load_balancing_policy
-    policy.set_ready_replicas([replica_url])
-    policy.pre_execute_hook(replica_url, request)
+    policy.set_ready_replicas([replica])
+    policy.pre_execute_hook(replica, request)
 
-    def raise_begin_request(replica_url_arg, request_arg):
-        del replica_url_arg, request_arg
+    def raise_begin_request(replica_arg, request_arg):
+        del replica_arg, request_arg
         raise RuntimeError('begin request failed')
 
     policy.begin_request = raise_begin_request
 
     with pytest.raises(RuntimeError, match='begin request failed'):
-        await lb._proxy_request_to(replica_url, request)
+        await lb._proxy_request_to(replica, request)
 
-    assert policy.load_map.get(replica_url) == 1
+    assert policy.load_map.get(replica.replica_id) == 1
 
 
 @pytest.mark.parametrize('spec_version', ['2.3', '2.4'])
@@ -130,7 +191,7 @@ async def test_begin_request_error_preserves_least_load_accounting():
 async def test_streaming_response_releases_least_load_accounting_on_close(
         spec_version):
     lb = _make_load_balancer()
-    replica_url = 'http://replica'
+    replica = _make_replica()
     client = mock.MagicMock()
     client.build_request.return_value = mock.sentinel.proxy_request
 
@@ -139,12 +200,12 @@ async def test_streaming_response_releases_least_load_accounting_on_close(
 
     proxy_response = _make_streaming_response(response_body())
     client.send = mock.AsyncMock(return_value=proxy_response)
-    lb._client_pool[replica_url] = client
-    lb._load_balancing_policy.set_ready_replicas([replica_url])
+    lb._client_pool[replica.url] = client
+    lb._load_balancing_policy.set_ready_replicas([replica])
 
-    response = await lb._proxy_request_to(replica_url, _make_request())
+    response = await lb._proxy_request_to(replica, _make_request())
 
-    assert lb._load_balancing_policy.load_map.get(replica_url) == 1
+    assert lb._load_balancing_policy.load_map.get(replica.replica_id) == 1
     messages = []
 
     receive_event = asyncio.Event()
@@ -162,7 +223,7 @@ async def test_streaming_response_releases_least_load_accounting_on_close(
         }
     }, receive, send)
 
-    assert lb._load_balancing_policy.load_map.get(replica_url) == 0
+    assert lb._load_balancing_policy.load_map.get(replica.replica_id) == 0
     assert any(message.get('body') == b'response' for message in messages)
     proxy_response.aclose.assert_awaited_once()
 
@@ -172,7 +233,7 @@ async def test_streaming_response_releases_least_load_accounting_on_close(
 async def test_streaming_response_error_releases_least_load_accounting(
         spec_version):
     lb = _make_load_balancer()
-    replica_url = 'http://replica'
+    replica = _make_replica()
     client = mock.MagicMock()
     client.build_request.return_value = mock.sentinel.proxy_request
 
@@ -183,10 +244,10 @@ async def test_streaming_response_error_releases_least_load_accounting(
     proxy_response = _make_streaming_response(
         response_body(), aclose_side_effect=RuntimeError('aclose failed'))
     client.send = mock.AsyncMock(return_value=proxy_response)
-    lb._client_pool[replica_url] = client
-    lb._load_balancing_policy.set_ready_replicas([replica_url])
+    lb._client_pool[replica.url] = client
+    lb._load_balancing_policy.set_ready_replicas([replica])
 
-    response = await lb._proxy_request_to(replica_url, _make_request())
+    response = await lb._proxy_request_to(replica, _make_request())
 
     receive_event = asyncio.Event()
 
@@ -203,7 +264,7 @@ async def test_streaming_response_error_releases_least_load_accounting(
                 'spec_version': spec_version
             }
         }, receive, send)
-    assert lb._load_balancing_policy.load_map.get(replica_url) == 0
+    assert lb._load_balancing_policy.load_map.get(replica.replica_id) == 0
     proxy_response.aclose.assert_awaited_once()
 
 
@@ -212,7 +273,7 @@ async def test_streaming_response_error_releases_least_load_accounting(
 async def test_client_disconnect_before_streaming_releases_load_accounting(
         spec_version):
     lb = _make_load_balancer()
-    replica_url = 'http://replica'
+    replica = _make_replica()
     client = mock.MagicMock()
     client.build_request.return_value = mock.sentinel.proxy_request
 
@@ -222,14 +283,14 @@ async def test_client_disconnect_before_streaming_releases_load_accounting(
 
     proxy_response = _make_streaming_response(response_body())
     client.send = mock.AsyncMock(return_value=proxy_response)
-    lb._client_pool[replica_url] = client
-    lb._load_balancing_policy.set_ready_replicas([replica_url])
+    lb._client_pool[replica.url] = client
+    lb._load_balancing_policy.set_ready_replicas([replica])
 
-    response = await lb._proxy_request_to(replica_url, _make_request())
+    response = await lb._proxy_request_to(replica, _make_request())
 
     await _run_response_with_client_disconnect(response, spec_version)
 
-    assert lb._load_balancing_policy.load_map.get(replica_url) == 0
+    assert lb._load_balancing_policy.load_map.get(replica.replica_id) == 0
     proxy_response.aclose.assert_awaited_once()
 
 
@@ -238,17 +299,18 @@ async def test_client_disconnect_before_streaming_releases_load_accounting(
 async def test_proxy_retries_spread_load_after_failure_and_disconnect(
         spec_version, monkeypatch):
     lb = _make_load_balancer()
-    replica_urls = [
-        'http://failing-replica',
-        'http://healthy-replica-1',
-        'http://healthy-replica-2',
+    replicas = [
+        _make_replica(1, 'http://failing-replica'),
+        _make_replica(2, 'http://healthy-replica-1'),
+        _make_replica(3, 'http://healthy-replica-2'),
     ]
+    replica_urls = [replica.url for replica in replicas]
     failing_url = replica_urls[0]
     _, healthy_responses = _configure_multi_replica_clients(
         lb, replica_urls, failing_url)
 
     policy = lb._load_balancing_policy
-    policy.set_ready_replicas(replica_urls)
+    policy.set_ready_replicas(replicas)
     request = _make_request()
     request.is_disconnected = mock.AsyncMock(return_value=False)
     monkeypatch.setattr(load_balancer.asyncio, 'sleep', mock.AsyncMock())
@@ -259,8 +321,8 @@ async def test_proxy_retries_spread_load_after_failure_and_disconnect(
         response = await lb._proxy_with_retries(request)
         await _run_response_with_client_disconnect(response, spec_version)
         assert all(
-            policy.load_map.get(replica_url) == 0
-            for replica_url in replica_urls)
+            policy.load_map.get(replica.replica_id) == 0
+            for replica in replicas)
 
     assert [
         lb._client_pool[replica_url].send.await_count
@@ -275,16 +337,17 @@ async def test_proxy_retries_spread_load_after_failure_and_disconnect(
 async def test_proxy_stops_retrying_after_client_disconnect_without_leaking_load(
         spec_version):
     lb = _make_load_balancer()
-    replica_urls = [
-        'http://failing-replica',
-        'http://healthy-replica-1',
-        'http://healthy-replica-2',
+    replicas = [
+        _make_replica(1, 'http://failing-replica'),
+        _make_replica(2, 'http://healthy-replica-1'),
+        _make_replica(3, 'http://healthy-replica-2'),
     ]
+    replica_urls = [replica.url for replica in replicas]
     clients, healthy_responses = _configure_multi_replica_clients(
         lb, replica_urls, replica_urls[0])
 
     policy = lb._load_balancing_policy
-    policy.set_ready_replicas(replica_urls)
+    policy.set_ready_replicas(replicas)
     request = _make_request()
     request.is_disconnected = mock.AsyncMock(return_value=True)
 
@@ -295,8 +358,8 @@ async def test_proxy_stops_retrying_after_client_disconnect_without_leaking_load
         if result.status_code != 499:
             await _run_response_with_client_disconnect(result, spec_version)
         assert all(
-            policy.load_map.get(replica_url) == 0
-            for replica_url in replica_urls)
+            policy.load_map.get(replica.replica_id) == 0
+            for replica in replicas)
 
     assert result_statuses == [499, 200, 200, 499]
     assert request.is_disconnected.await_count == 2
@@ -310,34 +373,70 @@ async def test_proxy_stops_retrying_after_client_disconnect_without_leaking_load
 @pytest.mark.asyncio
 async def test_missing_client_releases_least_load_accounting():
     lb = _make_load_balancer()
-    replica_url = 'http://replica'
+    replica = _make_replica()
     policy = lb._load_balancing_policy
-    policy.set_ready_replicas([replica_url])
+    policy.set_ready_replicas([replica])
 
-    result = await lb._proxy_request_to(replica_url, _make_request())
+    result = await lb._proxy_request_to(replica, _make_request())
 
     assert isinstance(result, RuntimeError)
-    assert policy.load_map.get(replica_url) == 0
+    assert policy.load_map.get(replica.replica_id) == 0
 
 
 def test_late_completion_does_not_recreate_retired_replica_load():
     policy = load_balancing_policies.LeastLoadPolicy()
-    replica_url = 'http://replica'
+    replica = _make_replica()
     request = _make_request()
 
-    policy.set_ready_replicas([replica_url])
-    policy.pre_execute_hook(replica_url, request)
+    policy.set_ready_replicas([replica])
+    policy.pre_execute_hook(replica, request)
     policy.set_ready_replicas([])
-    assert replica_url not in policy.load_map
+    assert replica.replica_id in policy.load_map
 
-    policy.post_execute_hook(replica_url, request)
+    policy.post_execute_hook(replica, request)
 
-    assert replica_url not in policy.load_map
+    assert replica.replica_id not in policy.load_map
+
+
+def test_late_completion_does_not_decrement_reused_url_replica():
+    policy = load_balancing_policies.LeastLoadPolicy()
+    old_replica = _make_replica(1, 'http://replica')
+    new_replica = _make_replica(2, 'http://replica')
+    request = _make_request()
+
+    policy.set_ready_replicas([old_replica])
+    policy.pre_execute_hook(old_replica, request)
+    policy.set_ready_replicas([new_replica])
+    policy.pre_execute_hook(new_replica, request)
+
+    policy.post_execute_hook(old_replica, request)
+
+    assert old_replica.replica_id not in policy.load_map
+    assert policy.load_map[new_replica.replica_id] == 1
+
+
+def test_endpoint_change_preserves_replica_load_accounting():
+    policy = load_balancing_policies.LeastLoadPolicy()
+    old_replica = _make_replica(1, 'http://old-replica')
+    new_replica = _make_replica(1, 'http://new-replica')
+    request = _make_request()
+
+    policy.set_ready_replicas([old_replica])
+    policy.pre_execute_hook(old_replica, request)
+    policy.set_ready_replicas([new_replica])
+
+    assert policy.load_map[new_replica.replica_id] == 1
+    policy.post_execute_hook(old_replica, request)
+    assert policy.load_map[new_replica.replica_id] == 0
 
 
 def test_least_load_rotates_equal_load_ties():
     policy = load_balancing_policies.LeastLoadPolicy()
-    replicas = ['http://replica-1', 'http://replica-2', 'http://replica-3']
+    replicas = [
+        _make_replica(1, 'http://replica-1'),
+        _make_replica(2, 'http://replica-2'),
+        _make_replica(3, 'http://replica-3'),
+    ]
     policy.set_ready_replicas(replicas)
 
     selected_replicas = [policy._select_replica(None) for _ in range(6)]
@@ -347,7 +446,10 @@ def test_least_load_rotates_equal_load_ties():
 
 def test_instance_aware_least_load_rotates_equal_load_ties():
     policy = load_balancing_policies.InstanceAwareLeastLoadPolicy()
-    replicas = ['http://replica-1', 'http://replica-2']
+    replicas = [
+        _make_replica(1, 'http://replica-1', 'A100'),
+        _make_replica(2, 'http://replica-2', 'A100'),
+    ]
     policy.set_ready_replicas(replicas)
 
     selected_replicas = [policy._select_replica(None) for _ in range(4)]


### PR DESCRIPTION
This PR refactors ready replicas to utilize id instead of url via an immutable descriptor class.



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
closes: https://github.com/skypilot-org/skypilot/issues/10671