### PR TITLE
[Test] Retry on host port conflicts when starting the remote-server container

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -902,10 +902,8 @@ def setup_docker_container(request):
         # Use create_and_setup_new_container to create and start the container
         docker_utils.create_and_setup_new_container(
             target_container_name=docker_utils.get_container_name(),
-            api_server_host_port=docker_utils.get_api_server_host_port(),
-            api_server_container_port=46580,
-            metrics_host_port=docker_utils.get_metrics_host_port(),
-            metrics_container_port=9090,
+            api_server_container_port=docker_utils.API_SERVER_CONTAINER_PORT,
+            metrics_container_port=docker_utils.METRICS_CONTAINER_PORT,
             username=default_user)
 
         logger.info(f'Container {docker_utils.get_container_name()} started')

--- a/tests/smoke_tests/docker/docker_utils.py
+++ b/tests/smoke_tests/docker/docker_utils.py
@@ -2,9 +2,35 @@ import hashlib
 import logging
 import os
 import subprocess
+from typing import Dict, List, Optional, Tuple
 
 IMAGE_NAME = 'sky-remote-test-image'
 CONTAINER_NAME_PREFIX = 'sky-remote-test'
+
+# Ports the API server and the metrics server listen on inside the container.
+API_SERVER_CONTAINER_PORT = 46580
+METRICS_CONTAINER_PORT = 9090
+
+# Host ports are picked deterministically from [40000, 50000).
+_HOST_PORT_RANGE_START = 40000
+_HOST_PORT_RANGE_SIZE = 10000
+# How many candidate host ports to try before giving up.
+_MAX_HOST_PORT_ATTEMPTS = 10
+
+# Docker's wording when it cannot bind a published host port.
+_PORT_UNAVAILABLE_MARKERS = (
+    'port is already allocated',
+    'address already in use',
+)
+
+# Cache of (container name, container port) -> published host port. Looking the
+# port up shells out to `docker port`, and callers ask for it once per generated
+# test command.
+_published_host_ports: Dict[Tuple[str, int], int] = {}
+
+
+class PortUnavailableError(Exception):
+    """Docker could not bind one of the requested host ports."""
 
 
 def is_inside_docker() -> bool:
@@ -28,19 +54,69 @@ def get_container_name() -> str:
     return container_name
 
 
-def get_api_server_host_port() -> int:
-    """Get the host port that will be listened by the test container."""
-    container_name = get_container_name()
+def _candidate_host_port(container_name: str, attempt: int) -> int:
+    """Get the `attempt`-th candidate host port for `container_name`.
+
+    The port is derived from the container name so that every process in a test
+    session agrees on it without coordinating. The range overlaps the kernel's
+    ephemeral port range, though, so a candidate may already be taken by an
+    unrelated process on the host -- a `kind` cluster publishing its API server,
+    or just a transient outbound connection. `attempt` walks to the next
+    candidate when that happens; attempt 0 keeps the historical port.
+    """
+    key = container_name if attempt == 0 else f'{container_name}:{attempt}'
     # Create a deterministic hash using MD5
-    md5_hash = hashlib.md5(container_name.encode('utf-8')).hexdigest()
-    # Convert first 8 chars of hash to integer and map to port range 40000-50000
-    port = 40000 + (int(md5_hash[:8], 16) % 10000)
-    return port
+    md5_hash = hashlib.md5(key.encode('utf-8')).hexdigest()
+    # Convert first 8 chars of hash to integer and map to the port range.
+    return _HOST_PORT_RANGE_START + (int(md5_hash[:8], 16) %
+                                     _HOST_PORT_RANGE_SIZE)
+
+
+def _published_host_port(container_name: str,
+                         container_port: int) -> Optional[int]:
+    """Get the host port Docker actually published for `container_port`.
+
+    Returns None if the container does not exist or is not publishing the port.
+    """
+    cached = _published_host_ports.get((container_name, container_port))
+    if cached is not None:
+        return cached
+    try:
+        output = subprocess.check_output(
+            ['docker', 'port', container_name, f'{container_port}/tcp'],
+            stderr=subprocess.DEVNULL).decode()
+    except (subprocess.CalledProcessError, OSError):
+        return None
+    # Output looks like '0.0.0.0:43649\n[::]:43649\n'.
+    for binding in output.split():
+        _, _, port = binding.rpartition(':')
+        if port.isdigit():
+            _published_host_ports[(container_name, container_port)] = int(port)
+            return int(port)
+    return None
+
+
+def get_api_server_host_port() -> int:
+    """Get the host port that will be listened by the test container.
+
+    Prefers the port Docker actually published, so that every process -- the
+    pytest-xdist workers included -- agrees on it even when container creation
+    had to fall back to a different candidate port.
+    """
+    container_name = get_container_name()
+    published = _published_host_port(container_name, API_SERVER_CONTAINER_PORT)
+    if published is not None:
+        return published
+    return _candidate_host_port(container_name, 0)
 
 
 def get_metrics_host_port() -> int:
     """Get the host port that will be mapped to the metrics server inside the test container."""
-    return get_api_server_host_port() + 1
+    container_name = get_container_name()
+    published = _published_host_port(container_name, METRICS_CONTAINER_PORT)
+    if published is not None:
+        return published
+    return _candidate_host_port(container_name, 0) + 1
 
 
 def get_api_server_endpoint_inside_docker() -> str:
@@ -56,19 +132,71 @@ def get_metrics_endpoint_inside_docker() -> str:
     return f'http://{host}:{metrics_port}'
 
 
+def _run_container(target_container_name: str, api_server_host_port: int,
+                   api_server_container_port: int, metrics_host_port: int,
+                   metrics_container_port: int, username: str,
+                   volumes: List[str]) -> None:
+    """Start the test container, publishing the given host ports.
+
+    Raises:
+        PortUnavailableError: one of the host ports is already taken.
+        subprocess.CalledProcessError: `docker run` failed for any other reason.
+    """
+    if is_inside_docker():
+        # Files are copied in afterwards rather than mounted, because the paths
+        # are inside this container rather than on the host.
+        run_cmd = [
+            'docker', 'run', '-d', '--cpus=4', '--name', target_container_name,
+            '-p', f'{api_server_host_port}:{api_server_container_port}', '-p',
+            f'{metrics_host_port}:{metrics_container_port}',
+            '--add-host=host.docker.internal:host-gateway', '-e',
+            f'USERNAME={username}', '-e', 'LAUNCHED_BY_DOCKER_CONTAINER=1',
+            '-e', 'SKYPILOT_DISABLE_USAGE_COLLECTION=1', '-e',
+            'SKY_API_SERVER_METRICS_ENABLED=true', IMAGE_NAME
+        ]
+    else:
+        run_cmd = [
+            'docker', 'run', '-d', '--name', target_container_name,
+            *[f'-v={v}' for v in volumes], '-e', f'USERNAME={username}', '-e',
+            'SKYPILOT_DISABLE_USAGE_COLLECTION=1', '-e',
+            'SKY_API_SERVER_METRICS_ENABLED=true', '-p',
+            f'{api_server_host_port}:{api_server_container_port}', '-p',
+            f'{metrics_host_port}:{metrics_container_port}', IMAGE_NAME
+        ]
+
+    proc = subprocess.run(run_cmd, capture_output=True, text=True, check=False)
+    if proc.returncode == 0:
+        return
+
+    # A `docker run -d` that fails while publishing ports still leaves the
+    # named container behind in `created` state, which would turn the next
+    # attempt into a name conflict.
+    subprocess.run(['docker', 'rm', '-f', target_container_name],
+                   capture_output=True,
+                   check=False)
+
+    stderr = proc.stderr or ''
+    if any(marker in stderr.lower() for marker in _PORT_UNAVAILABLE_MARKERS):
+        raise PortUnavailableError(stderr.strip())
+    raise subprocess.CalledProcessError(proc.returncode,
+                                        run_cmd,
+                                        output=proc.stdout,
+                                        stderr=stderr)
+
+
 def create_and_setup_new_container(target_container_name: str,
-                                   api_server_host_port: int,
                                    api_server_container_port: int,
-                                   metrics_host_port: int,
                                    metrics_container_port: int,
                                    username: str) -> str:
     """Create a new Docker container and copy files/directories from current container.
 
+    The host ports are derived from the container name. They may collide with
+    an unrelated process on the host, in which case the next candidate pair is
+    tried; `get_api_server_host_port` reads the resulting port back from Docker.
+
     Args:
         target_container_name: Name for the new container
-        api_server_host_port: Port on host machine to bind
         api_server_container_port: Port in container to expose
-        metrics_host_port: Port on host machine to bind
         metrics_container_port: Port in container to expose
         username: Username in the container
 
@@ -94,22 +222,46 @@ def create_and_setup_new_container(target_container_name: str,
         os.path.join(workspace_path, 'tests/smoke_tests/docker'): f'/success_mount_directory',
     }
 
+    # Prepare volume mounts with read-write mode. Only used when running on the
+    # host; inside Docker the files are copied in after the container starts.
+    volumes = []
+    if not is_inside_docker():
+        for src_path, dst_path in src_dst_paths.items():
+            if os.path.exists(src_path):
+                volumes.append(f"{src_path}:{dst_path}")
+            else:
+                logger.warning(
+                    f"Path {src_path} does not exist, skipping mount")
+
+    for attempt in range(_MAX_HOST_PORT_ATTEMPTS):
+        api_server_host_port = _candidate_host_port(target_container_name,
+                                                    attempt)
+        metrics_host_port = api_server_host_port + 1
+        try:
+            _run_container(target_container_name, api_server_host_port,
+                           api_server_container_port, metrics_host_port,
+                           metrics_container_port, username, volumes)
+            break
+        except PortUnavailableError as e:
+            # The port range overlaps the kernel's ephemeral range, so an
+            # unrelated process on the host may be sitting on the port we
+            # picked. Move on to the next candidate instead of failing the
+            # whole session.
+            logger.warning(
+                f'Host ports {api_server_host_port}/{metrics_host_port} are '
+                f'unavailable for container {target_container_name} ({e}); '
+                f'trying the next candidate ports.')
+    else:
+        raise RuntimeError(
+            f'Could not find free host ports for container '
+            f'{target_container_name} after {_MAX_HOST_PORT_ATTEMPTS} '
+            f'attempts.')
+
+    logger.info(f'Container {target_container_name} published API server on '
+                f'host port {api_server_host_port} and metrics on '
+                f'{metrics_host_port}')
+
     if is_inside_docker():
-        # Run the new container directly
-        run_cmd = (f'docker run -d '
-                   f'--cpus=4 '
-                   f'--name {target_container_name} '
-                   f'-p {api_server_host_port}:{api_server_container_port} '
-                   f'-p {metrics_host_port}:{metrics_container_port} '
-                   f'--add-host=host.docker.internal:host-gateway '
-                   f'-e USERNAME={username} '
-                   f'-e LAUNCHED_BY_DOCKER_CONTAINER=1 '
-                   f'-e SKYPILOT_DISABLE_USAGE_COLLECTION=1 '
-                   f'-e SKY_API_SERVER_METRICS_ENABLED=true '
-                   f'{IMAGE_NAME}')
-
-        subprocess.check_call(run_cmd, shell=True)
-
         # Copy directories and files from current container to the new one
         for src_path, dst_path in src_dst_paths.items():
             if os.path.exists(src_path):
@@ -132,34 +284,6 @@ def create_and_setup_new_container(target_container_name: str,
                 subprocess.check_call(copy_cmd, shell=True)
             else:
                 logger.warning(f"Path {src_path} does not exist, skipping copy")
-    else:
-        # Prepare volume mounts with read-write mode
-        volumes = []
-        for src_path, dst_path in src_dst_paths.items():
-            if os.path.exists(src_path):
-                volumes.append(f"{src_path}:{dst_path}")
-            else:
-                logger.warning(
-                    f"Path {src_path} does not exist, skipping mount")
-
-        # Run the container directly
-        docker_cmd = [
-            'docker',
-            'run',
-            '-d',
-            '--name',
-            target_container_name,
-        ]
-
-        docker_cmd.extend([
-            *[f'-v={v}' for v in volumes], '-e', f'USERNAME={username}', '-e',
-            'SKYPILOT_DISABLE_USAGE_COLLECTION=1', '-e',
-            'SKY_API_SERVER_METRICS_ENABLED=true', '-p',
-            f'{api_server_host_port}:{api_server_container_port}', '-p',
-            f'{metrics_host_port}:{metrics_container_port}', IMAGE_NAME
-        ])
-
-        subprocess.check_call(docker_cmd)
 
     # Get and return the new container ID
     new_container_id = subprocess.check_output(


### PR DESCRIPTION
## Summary

The `--remote-server` smoke tests publish the test API server on a host port derived from the container name:

```python
port = 40000 + (int(md5(container_name)[:8], 16) % 10000)
```

That range sits inside the kernel's default ephemeral port range (`net.ipv4.ip_local_port_range` = `32768 60999`), so the port can already be held by an unrelated process on the host. When it is, `docker run` fails and the session-scoped `setup_docker_container` fixture errors out **before any test body runs**:

```
docker: Error response from daemon: driver failed programming external connectivity
on endpoint sky-remote-test-<name>: Bind for 0.0.0.0:43649 failed: port is already allocated
E   subprocess.CalledProcessError: Command 'docker run -d --cpus=4 --name sky-remote-test-<name>
    -p 43649:46580 -p 43650:9090 ... sky-remote-test-image' returned non-zero exit status 125
```

Two ways it shows up:

- **Transient** — an outbound connection happens to hold the port; one job fails and passes on retry.
- **Permanent** — a `kind` cluster publishes its API server on a random ephemeral host port that lands on the hashed one. A `kind` control plane lives as long as the host, so from then on *every* `--remote-server` run on that host fails, for *any* test, until the host is recycled. Any host that also runs `kind` is exposed to this.

The failure is in a session fixture, so it presents as a wide, unrelated-looking set of test failures rather than as one broken test.

## Changes

- Try the next deterministic candidate port when Docker reports a port as unavailable, instead of failing the session. Attempt 0 keeps the historical port, so the common case is byte-for-byte unchanged.
- `get_api_server_host_port()` / `get_metrics_host_port()` now read the port Docker actually published (`docker port <name> <port>/tcp`), so every process — the pytest-xdist workers included — agrees on the port without coordinating, even after a fallback. The lookup is cached.
- Remove the container that a failed `docker run -d` leaves behind in `created` state, which would otherwise turn the retry into a name conflict.
- `create_and_setup_new_container()` now derives the host ports itself, so the host port arguments are gone; the two container ports are module constants.

## Test plan

Reproduced on a host where a `kind` control plane was publishing `0.0.0.0:43649->6443/tcp` — exactly the port hashed for the container name in play — and ran the same call before and after the change.

**Before (this file at `master`)** — fails, which is the CI symptom:

```
master computes host port 43649 for sky-remote-test-<name>
docker: Error response from daemon: ... Bind for 0.0.0.0:43649 failed: port is already allocated
master FAILED as expected: CalledProcessError: Command '[... '-p', '43649:46580', '-p', '43650:9090', 'sky-remote-test-image']'
    returned non-zero exit status 125
```

**After (this PR)** — falls back and comes up:

```
[1] attempt-0 port: 43649
[2] who holds 43649: kind-cluster-2-control-plane 0.0.0.0:43649->6443/tcp
[3] attempt-1 fallback port would be: 42216
[4] creating container with the patched code ...
Host ports 43649/43650 are unavailable for container sky-remote-test-<name>
    (... Bind for 0.0.0.0:43649 failed: port is already allocated.); trying the next candidate ports.
[5] created: a20d12926882
[6] state=running bindings={"46580/tcp":[{"HostPort":"42216"}],"9090/tcp":[{"HostPort":"42217"}]}
[7] _published_host_port() -> 42216

PASS: collision on 43649 -> fell back to 42216, and the port is readable back from docker.
```

To reproduce the collision yourself, occupy the hashed port before running the fixture:

```bash
PORT=$(python3 -c "import hashlib
name = 'sky-remote-test'  # or 'sky-remote-test-\$CONTAINER_NAME' inside Docker
print(40000 + int(hashlib.md5(name.encode()).hexdigest()[:8], 16) % 10000)")
docker run -d --name port-squatter -p "$PORT":80 nginx:alpine
pytest tests/smoke_tests/test_basic.py::test_minimal --remote-server --kubernetes
docker rm -f port-squatter
```

Also verifying no regression on the normal (no-collision) path with a smoke-test run of the tests that were taken out by this in the last nightly.

## Notes

Attempt 0 is unchanged, so this does not renumber ports for anyone. The retry only engages on Docker's two port-binding error strings; any other `docker run` failure still raises as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018JekVSCumAMWgWMiXjqz9u

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10724" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->