### PR TITLE
[Vast] Register the SSH key with the instance, not just authorized_keys

### DIFF
--- a/sky/provision/vast/utils.py
+++ b/sky/provision/vast/utils.py
@@ -241,7 +241,37 @@ def launch(name: str,
     new_instance = vast.vast().show_instance(
         id=new_instance_contract['new_contract'])
 
+    if ssh_public_key:
+        _register_ssh_key(new_instance['id'], ssh_public_key)
+
     return new_instance['id']
+
+
+def _register_ssh_key(instance_id: int, ssh_public_key: str) -> None:
+    """Registers the key with Vast, which owns the instance's authorized set.
+
+    Appending to ``authorized_keys`` from ``onstart_cmd`` only holds until Vast
+    refreshes the instance, after which every new connection is refused while
+    the job keeps running: the cluster looks healthy over the control
+    connection opened at setup and is unreachable to everything else.
+
+    ``setup_vast_authentication`` is meant to cover this by registering the key
+    on the account, but Vast answers ``team_ssh_keys_not_supported`` (HTTP 400)
+    for team-scoped API keys and that path gives up silently. Attaching per
+    instance is accepted for those keys.
+    """
+    try:
+        result = vast.vast().attach_ssh(instance_id=int(instance_id),
+                                        ssh_key=ssh_public_key.strip())
+    except Exception as e:  # pylint: disable=broad-except
+        logger.warning(
+            f'Vast rejected the SSH key registration for instance '
+            f'{instance_id}: {e}. The cluster will come up, but Vast may stop '
+            'accepting the key later, leaving a running job unreachable.')
+        return
+    if isinstance(result, dict) and not result.get('success', True):
+        logger.warning(f'Vast did not register the SSH key for instance '
+                       f'{instance_id}: {result.get("msg")}')
 
 
 def start(instance_id: str) -> None:

--- a/tests/unit_tests/test_vast.py
+++ b/tests/unit_tests/test_vast.py
@@ -1,0 +1,39 @@
+"""Unit tests for the Vast provisioner."""
+from sky.provision.vast import utils
+
+
+def test_register_ssh_key_attaches_to_the_instance(monkeypatch):
+    """The key must be registered with Vast, not only appended by onstart.
+
+    Vast owns the instance's authorized set and drops what it did not register,
+    which strands a running cluster with `Permission denied (publickey)`.
+    """
+    calls = []
+
+    class _Client:
+
+        def attach_ssh(self, instance_id, ssh_key):
+            calls.append((instance_id, ssh_key))
+            return {'success': True}
+
+    monkeypatch.setattr(utils.vast, 'vast', lambda: _Client())
+    utils._register_ssh_key(42, '  ssh-rsa AAAA  ')
+    assert calls == [(42, 'ssh-rsa AAAA')]
+
+
+def test_register_ssh_key_warns_instead_of_raising(monkeypatch, caplog):
+    """A launch that works now must not abort, but the failure must be visible.
+
+    Registering on the account already fails silently for team API keys;
+    repeating that here would hide the same outage.
+    """
+
+    class _Client:
+
+        def attach_ssh(self, instance_id, ssh_key):
+            raise RuntimeError('boom')
+
+    monkeypatch.setattr(utils.vast, 'vast', lambda: _Client())
+    with caplog.at_level('WARNING'):
+        utils._register_ssh_key(42, 'ssh-rsa AAAA')
+    assert 'boom' in caplog.text


### PR DESCRIPTION
Appending the public key to `~/.ssh/authorized_keys` from `onstart_cmd` only holds until Vast refreshes the instance's authorized set, which it owns. After a few hours every new connection is refused with `Permission denied (publickey)` while the job keeps running.

The failure is quiet, which is what makes it expensive. The multiplexed control connection opened at setup survives, so the skylet keeps polling through it and `sky status` reports `UP` / "runtime healthy", while `sky queue`, `sky logs` and `sky exec` all fail. I saw four clusters do this, between 9 and 18 hours in; one had been unreachable for most of a day before anyone noticed, and its GPU sat at 0%.

## Why the existing path does not cover it

`setup_vast_authentication` is supposed to register the key on the account. Vast refuses that for team-scoped API keys:

```
POST /api/v0/ssh/ -> 400
{"success": false, "error": "team_ssh_keys_not_supported",
 "msg": "Team SSH keys are not supported. SSH keys can only be created in personal context."}
```

#9631 wrapped that call so the 400 no longer aborts provisioning — which is right — but it skips on a `logger.debug`, on the stated premise that "SSH access does not actually depend on this step" because of the `onstart_cmd` injection. That premise does not survive Vast refreshing the instance, and on a team account the key is then registered nowhere at all.

## What this does

Attach the key to the instance after creation. That endpoint *is* accepted for team-scoped keys:

```
POST /api/v0/instances/<id>/ssh/ -> 200 {"msg": "SSH key added to instance."}
```

## Testing

- Against a team account, three already-stranded clusters regained SSH **10-12 seconds** after the call, with nothing else changed — no restart, no touching the container.
- Re-attaching an existing key returns `{"success": false, "msg": "SSH key already associated with instance."}` rather than raising, so the call is safe to repeat.
- Two unit tests: the key reaches `attach_ssh` stripped, and a failure warns instead of raising.

Best-effort with a warning rather than fatal: the cluster does come up either way, and the warning is the point — a silent skip is exactly what hid this for us.

Happy to make it fatal instead, or to gate it behind a config key, if you would rather not add an API call to every launch.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10730" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->