### PR TITLE
[Core] Quarantine orphaned debug-dump writes, reconcile errors.json, and de-bloat the dump's records

### DIFF
--- a/sky/server/requests/log_provider.py
+++ b/sky/server/requests/log_provider.py
@@ -3,6 +3,7 @@ import abc
 import enum
 import pathlib
 import shutil
+import threading
 from typing import AsyncGenerator, Optional
 
 from sky import sky_logging
@@ -20,6 +21,12 @@ class RequestLogType(enum.Enum):
     # The request debug log, written to DEBUG_LOG_DIR/<request_id>.log
     # when SKYPILOT_SERVER_ENABLE_REQUEST_DEBUG_LOGGING is enabled.
     DEBUG = 'debug'
+
+
+# Chunk size for the default local copy in LogProvider.copy_log_file:
+# large enough to keep a local copy effectively instant, small enough
+# that an abandoned copy notices the stop event at its next read.
+_LOG_COPY_CHUNK_BYTES = 1024 * 1024
 
 
 def local_log_path(request_id: str, log_type: RequestLogType) -> pathlib.Path:
@@ -72,21 +79,57 @@ class LogProvider(abc.ABC):
         del request_id, log_path, plain_logs, tail, follow, polling_interval
         yield ''
 
-    def copy_log_file(self, request_id: str, log_type: RequestLogType,
-                      dest_path: pathlib.Path) -> bool:
+    def copy_log_file(self,
+                      request_id: str,
+                      log_type: RequestLogType,
+                      dest_path: pathlib.Path,
+                      stop_event: Optional[threading.Event] = None) -> bool:
         """Copy a request's log file to dest_path (e.g. for a debug dump).
 
-        The default implementation copies from the local filesystem.
-        Providers backed by other log stores may override this to fetch
-        the log from wherever it lives.
+        The default implementation copies from the local filesystem in
+        bounded chunks. Providers backed by other log stores may override
+        this to fetch the log from wherever it lives; note that overrides
+        written before ``stop_event`` was added keep the old 3-argument
+        signature and will not receive the keyword.
+
+        Args:
+            stop_event: Optional cooperative-cancel signal. When set, the
+                caller has abandoned the copy: return False promptly --
+                checking the event before starting and between reads --
+                without creating or keeping the destination file. ``None``
+                (the default) keeps the copy uninterruptible.
 
         Returns:
             True if the log file was found and copied, False otherwise.
         """
         src_path = local_log_path(request_id, log_type)
+        if stop_event is not None and stop_event.is_set():
+            return False
         if not src_path.exists():
             return False
-        shutil.copy2(src_path, dest_path)
+        stopped = False
+        with open(src_path, 'rb') as src, open(dest_path, 'wb') as dest:
+            while True:
+                if stop_event is not None and stop_event.is_set():
+                    stopped = True
+                    break
+                chunk = src.read(_LOG_COPY_CHUNK_BYTES)
+                if not chunk:
+                    break
+                dest.write(chunk)
+        if stopped:
+            # Abandoned mid-copy: discard the partial output. The unlink
+            # is guarded so an error on a stalled filesystem cannot mask
+            # the stop contract.
+            try:
+                dest_path.unlink()
+            except OSError:
+                pass
+            return False
+        # copy2 = copyfile + copystat; the chunked copy above replaces
+        # copyfile, copystat preserves the metadata (notably mtime) the
+        # debug dump's forensic value relies on.
+        shutil.copystat(src_path, dest_path)
         return True
 
     def discard_log(self, request_id: str) -> None:

--- a/sky/utils/debug_utils.py
+++ b/sky/utils/debug_utils.py
@@ -1436,7 +1436,10 @@ def _dump_request_id_info(
     ``attempted = info_written + not_in_db + db_errors`` (each of those
     buckets implies a request_info.json artifact, full or stub), plus
     per-log-type coverage counts, so every gap between the summary counts
-    and the on-disk artifacts is explainable from the dump alone.
+    and the on-disk artifacts is explainable from the dump alone. The
+    ``skipped_request_ids`` list is the one exception: the caller moves it
+    into ids_manifest.json (summary.json keeps only the
+    ``skipped_deadline`` count) so the summary stays scannable.
     """
     outcomes = _empty_request_outcomes()
     if not request_ids:
@@ -2881,11 +2884,16 @@ def _build_debug_dump(
 
     request_logs = _log_coverage('request_log')
     request_debug_logs = _log_coverage('request_debug_log')
+    # The full skipped-ID list lives only in ids_manifest.json: popping it
+    # here keeps it out of the outcomes dict that summary.json embeds below
+    # (skipped_deadline already carries the count), so the summary stays
+    # scannable even when thousands of requests were skipped.
+    skipped_request_ids = request_outcomes.pop('skipped_request_ids', [])
     ids_manifest: Dict[str, Any] = {
         'request_ids': sorted(debug_dump_context['request_ids']),
         'cluster_names': sorted(debug_dump_context['cluster_names']),
         'managed_job_ids': sorted(debug_dump_context['managed_job_ids']),
-        'skipped_request_ids': request_outcomes.get('skipped_request_ids', []),
+        'skipped_request_ids': skipped_request_ids,
     }
     ids_manifest_path = os.path.join(dump_dir, 'ids_manifest.json')
     with open(ids_manifest_path, 'w', encoding='utf-8') as f:

--- a/sky/utils/debug_utils.py
+++ b/sky/utils/debug_utils.py
@@ -4,6 +4,7 @@ import concurrent.futures
 import datetime
 import functools
 import hashlib
+import inspect
 import json
 import logging
 import os
@@ -12,10 +13,11 @@ import platform
 import posixpath
 import re
 import shutil
+import threading
 import time
 import traceback
-from typing import (Any, Callable, Dict, List, Optional, Set, Tuple, TypedDict,
-                    TypeVar)
+from typing import (Any, Callable, Dict, Iterator, List, Optional, Set, Tuple,
+                    TypedDict, TypeVar)
 import zipfile
 
 import sky
@@ -104,69 +106,281 @@ def _run_with_deadline(
     *,
     component: str,
     resource: str,
-    errors: Optional[List[Dict[str, str]]] = None,
+    errors: Optional[List[Dict[str, Any]]] = None,
     orphans: Optional[List[Dict[str, Any]]] = None,
+    stop_event: Optional[threading.Event] = None,
+    executor: Optional[concurrent.futures.ThreadPoolExecutor] = None,
+    executor_slots: Optional[threading.Semaphore] = None,
+    orphan_extras: Optional[Dict[str, Any]] = None,
 ) -> Tuple[bool, Optional[T]]:
     """Run ``fn()`` in a worker thread bounded by a wall-clock timeout.
+
+    Invariant: no op is recorded as timed out unless a real attempt was
+    started. Plainly queueing behind already-abandoned workers on a
+    shared executor would violate that (the op would sit unstarted until
+    its own timeout), so a caller-provided executor is guarded with a
+    free-slot semaphore and a saturated pool falls back to a fresh
+    single-worker executor below.
 
     Returns ``(True, result)`` if ``fn()`` completes within ``timeout``. On
     timeout a partial-failure record is appended to ``errors`` (mirroring the
     shared error-record shape) and ``(False, None)`` is returned -- but note
-    the worker is NOT stopped: Python can't kill a thread, and
-    ``future.result(timeout=)`` only stops us *waiting*, so ``fn`` keeps
-    running in the background until it returns on its own. The abandoned op is
-    appended to ``orphans`` (the per-dump list threaded alongside ``errors``)
-    so _log_timed_out_stragglers can report at dump end which ones are still
-    running (see there for why we don't reap). Any OTHER exception raised by
-    ``fn()`` propagates to the caller, so each call site keeps its own existing
-    non-timeout handling.
+    the worker is NOT killed: Python can't kill a thread, and
+    ``future.result(timeout=)`` only stops us *waiting``, so ``fn`` keeps
+    running in the background until it returns on its own. The timeout path
+    first sets ``stop_event`` (when given, so a cooperating op such as the
+    chunked log copy terminates at its next checkpoint) and cancels the
+    future (a no-op for a running future; it prevents queued-not-started
+    work from running late). The abandoned op is appended to ``orphans``
+    (the per-dump list threaded alongside ``errors``) with a direct
+    ``error_entry`` reference to the record just appended, so
+    _reconcile_timed_out_ops can rewrite it in place, plus any merged
+    ``orphan_extras`` (e.g. a late-publish closure for staged log copies).
+    Any OTHER exception raised by ``fn()`` propagates to the caller, so each
+    call site keeps its own existing non-timeout handling.
 
-    Same executor-deadline pattern as the sky-check probe. We shut the executor
-    down with ``wait=False`` in a ``finally`` -- covering success, timeout, and
-    any other exception, so the executor object is never leaked -- while never
-    re-blocking on a still-running worker (which a ``with`` / the default
-    ``shutdown(wait=True)`` would do on timeout, defeating the whole point).
+    Executor discipline: an executor created here is shut down with
+    ``wait=False`` in a ``finally`` -- covering success, timeout, and any
+    other exception, so it is never leaked -- while never re-blocking on a
+    still-running worker (which a ``with`` / the default ``shutdown(wait=True)``
+    would do on timeout, defeating the whole point). A caller-provided
+    ``executor`` is NEVER shut down by this call. When ``executor_slots`` is
+    given alongside it, the submission is guarded by a non-blocking acquire
+    released via a done-callback (fires on completion, exception, AND
+    cancellation) and on a submit failure; on acquire failure (all shared
+    workers held by orphans) a fresh single-worker executor is created so
+    the op still gets a real attempt with real timeout semantics.
     """
-    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
     started = time.monotonic()
+    # Executor we created for this call (shut down in the finally);
+    # a caller-provided executor is never shut down here.
+    own_executor: Optional[concurrent.futures.ThreadPoolExecutor] = None
     try:
-        future = executor.submit(fn)
+        if executor is not None and executor_slots is not None and not (
+                executor_slots.acquire(blocking=False)):
+            # All shared workers are held by abandoned timed-out copies;
+            # fall back to a fresh executor so this op still gets a real
+            # attempt (see the invariant in the docstring).
+            executor = None
+        if executor is None:
+            own_executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+            future = own_executor.submit(fn)
+        elif executor_slots is not None:
+            try:
+                future = executor.submit(fn)
+            except Exception:  # pylint: disable=broad-except
+                # submit failed after taking a slot (e.g. the shared
+                # executor was shut down concurrently): give the slot
+                # back and fall back to a fresh executor.
+                executor_slots.release()
+                own_executor = concurrent.futures.ThreadPoolExecutor(
+                    max_workers=1)
+                future = own_executor.submit(fn)
+            else:
+                future.add_done_callback(lambda _f: executor_slots.release())
+        else:
+            future = executor.submit(fn)
         try:
             return True, future.result(timeout=timeout)
         except concurrent.futures.TimeoutError:
+            # Signal the worker first (if the op cooperates via
+            # stop_event) so an abandoned copy stops at its next
+            # checkpoint; then cancel, which only matters for work that
+            # never started.
+            if stop_event is not None:
+                stop_event.set()
+            future.cancel()
             msg = (f'{component}/{resource} timed out after {timeout}s; '
                    'recorded as a partial failure and skipped so the rest of '
                    'the dump still completes.')
             logger.warning(msg)
+            error_entry = None
             if errors is not None:
-                errors.append({
+                error_entry = {
                     'component': component,
                     'resource': resource,
                     'error': msg,
                     'traceback': _full_traceback(),
-                })
+                }
+                errors.append(error_entry)
             if orphans is not None:
-                orphans.append({
+                orphan_record = {
                     'component': component,
                     'resource': resource,
                     'future': future,
                     'started': started,
-                })
+                    # Direct reference to the error record just appended
+                    # (None when ``errors`` is), so reconciliation rewrites
+                    # it in place with no matching heuristics.
+                    'error_entry': error_entry,
+                }
+                if orphan_extras:
+                    orphan_record.update(orphan_extras)
+                orphans.append(orphan_record)
             return False, None
     finally:
-        executor.shutdown(wait=False)
+        if own_executor is not None:
+            own_executor.shutdown(wait=False)
+
+
+# Fixed grace period given to timed-out ops' worker threads to finish
+# before the dump's error records are finalized. Deliberately NOT clamped
+# to the remaining dump budget: orphans exist exactly when the budget is
+# already exhausted, so clamping would zero the grace and make
+# reconciliation dead code (the zip step already runs past the deadline).
+# Read at call time (not bound as a default arg) so tests can monkeypatch
+# the constant.
+_ORPHAN_GRACE_S = 5.0
+
+
+def _reconcile_done_orphan(orphan: Dict[str, Any]) -> None:
+    """Fold one finished orphan's outcome back into its error record.
+
+    Assumes the caller already verified the future is done and not
+    cancelled. Mutates ``orphan['error_entry']`` in place.
+    """
+    future: concurrent.futures.Future = orphan['future']
+    error_entry = orphan.get('error_entry')
+    component, resource = orphan.get('component'), orphan.get('resource')
+    try:
+        result = future.result()
+    except Exception:  # pylint: disable=broad-except
+        tb = _full_traceback()
+        logger.warning(
+            '[debug-dump] worker for %s/%s, timed out earlier, '
+            'later raised:\n%s', component, resource, tb)
+        if error_entry is not None:
+            error_entry['error'] += (' The worker raised an exception after '
+                                     'the timeout (see late_traceback).')
+            error_entry['late_traceback'] = tb
+        return
+    if not result:
+        # Falsy outcome (e.g. a copy that returned False): the existing
+        # timed-out record is already accurate -- nothing was published.
+        return
+    publish = orphan.get('publish')
+    if publish is not None:
+        try:
+            published = publish()
+        except Exception:  # pylint: disable=broad-except
+            logger.exception(
+                '[debug-dump] failed to publish the late '
+                'completion of %s/%s', component, resource)
+            published = False
+        if published:
+            note = ('The worker completed after the timeout; its output is '
+                    'included in the dump.')
+        else:
+            note = ('The worker completed after the timeout; its output '
+                    'could not be published.')
+    else:
+        # _run_with_deadline returned (False, None) to the caller, so no
+        # caller captured the result -- this wording is accurate for every
+        # section and does not imply data exists.
+        note = ('The worker completed after the timeout; its result was '
+                'not captured.')
+    if error_entry is not None:
+        error_entry['error'] += f' {note}'
+
+
+def _quarantine_orphan(orphan: Dict[str, Any]) -> None:
+    """Mark a still-running orphan so its output stays out of the archive.
+
+    The error record is left unchanged (it accurately says the op timed
+    out, and the worker-side publish gate means nothing lands at a final
+    name); a logging done-callback is attached so the eventual post-grace
+    outcome is at least visible in the log.
+    """
+    orphan['excluded_from_archive'] = True
+    future: concurrent.futures.Future = orphan['future']
+    component, resource = orphan.get('component'), orphan.get('resource')
+
+    def _log_outcome(fut: concurrent.futures.Future) -> None:
+        try:
+            if fut.cancelled():
+                return
+            exc = fut.exception()
+            if exc is not None:
+                logger.warning(
+                    '[debug-dump] worker for %s/%s, timed out and '
+                    'excluded from the archive, later raised: %s', component,
+                    resource, exc)
+            else:
+                logger.warning(
+                    '[debug-dump] worker for %s/%s, timed out and '
+                    'excluded from the archive, later completed; '
+                    'its output was not published.', component, resource)
+        except Exception:  # pylint: disable=broad-except
+            pass
+
+    future.add_done_callback(_log_outcome)
+
+
+def _reconcile_timed_out_ops(orphans: List[Dict[str, Any]],
+                             grace_s: Optional[float] = None) -> None:
+    """Reconcile timed-out ops' eventual outcomes into their error records.
+
+    Runs after collection but before errors.json is written, so the
+    serialized error file can never contradict the archive: within the
+    grace period, an orphan that completed successfully is published (for
+    staged log copies) and its error record annotated; an orphan that
+    raised gets a ``late_traceback``; an orphan still running at the end
+    of the grace keeps its accurate timed-out record, is marked
+    ``excluded_from_archive`` (its final output path, if any, is pruned
+    from the zip walk), and gets a logging done-callback.
+
+    Best-effort and per-orphan: one bad orphan cannot abort reconciliation
+    of the rest. The records live in ``timed_out_ops`` and are mutated in
+    place.
+    """
+    if grace_s is None:
+        # Read at call time (not a default-arg binding) so tests can
+        # monkeypatch _ORPHAN_GRACE_S.
+        grace_s = _ORPHAN_GRACE_S
+    pending: List[Dict[str, Any]] = []
+    for orphan in orphans:
+        future = orphan.get('future')
+        if future is None:
+            continue
+        try:
+            if future.cancelled():
+                # A cancelled op never ran; .result() would raise
+                # CancelledError and be misread as a late failure.
+                continue
+            if future.done():
+                _reconcile_done_orphan(orphan)
+            else:
+                pending.append(orphan)
+        except Exception:  # pylint: disable=broad-except
+            logger.exception('[debug-dump] failed to reconcile timed-out '
+                             f'op {orphan.get("resource")!r}')
+    if not pending:
+        return
+    concurrent.futures.wait([o['future'] for o in pending], timeout=grace_s)
+    for orphan in pending:
+        try:
+            if orphan['future'].done():
+                _reconcile_done_orphan(orphan)
+            else:
+                _quarantine_orphan(orphan)
+        except Exception:  # pylint: disable=broad-except
+            logger.exception('[debug-dump] failed to reconcile timed-out '
+                             f'op {orphan.get("resource")!r}')
 
 
 def _log_timed_out_stragglers(orphans: List[Dict[str, Any]]) -> None:
-    """Log any timed-out op in ``orphans`` whose worker thread is STILL running
-    at dump end.
+    """Log any timed-out op in ``orphans`` whose worker thread is STILL
+    running at dump end (i.e. past the reconciliation grace period).
 
-    Backstop visibility: Python can't kill the thread (see _run_with_deadline),
-    so we don't actively reap it here -- it exits when its underlying call
-    (typically a command-runner subprocess) returns. This surfaces what leaked
-    and for how long, so we can decide whether it's worth escalating (targeted
-    timeouts / subprocess isolation). Best-effort: logs and swallows its own
-    errors so it can never break the dump's final steps.
+    Backstop visibility: Python can't kill the thread (see
+    _run_with_deadline), so we don't actively reap it here -- it exits when
+    its underlying call (typically a command-runner subprocess, or a
+    stop-aware log copy at its next chunk) returns. Quarantined orphans
+    already have a logging done-callback attached by
+    _reconcile_timed_out_ops; this reports them one last time, with how
+    long they have leaked, so we can decide whether it's worth escalating.
+    Best-effort: logs and swallows its own errors so it can never break
+    the dump's final steps.
     """
     try:
         now = time.monotonic()
@@ -317,10 +531,10 @@ class DebugDumpContext(TypedDict):
     # into the dump.
     request_ids_via_job: Set[str]
     request_ids_via_cluster: Set[str]
-    errors: List[Dict[str, str]]
+    errors: List[Dict[str, Any]]
     # Per-dump accumulator (sibling of ``errors``) of deadline-timed-out ops
     # whose worker thread was abandoned; see _run_with_deadline /
-    # _log_timed_out_stragglers.
+    # _reconcile_timed_out_ops / _log_timed_out_stragglers.
     timed_out_ops: List[Dict[str, Any]]
 
 
@@ -1038,19 +1252,6 @@ def _sanitize_request_body(request) -> Optional[Dict[str, Any]]:
     return data
 
 
-def _copy_request_log_file(request_id: str, request_dir: str,
-                           log_type: log_provider.RequestLogType,
-                           filename: str) -> bool:
-    """Copy one request's log via the LogProvider (bounded by the caller).
-
-    Standalone (not a per-iteration closure) so the deadline wrapper can call it
-    via functools.partial without capturing the loop variable.
-    """
-    return log_provider.get_log_provider().copy_log_file(
-        request_id, log_type,
-        pathlib.Path(request_dir) / filename)
-
-
 # Per-log-copy cap. A copy is normally instant, but copy_log_file on a
 # long-running/streaming request (e.g. a status-refresh daemon whose log is
 # still being appended) can block for tens of seconds before returning -- so one
@@ -1058,13 +1259,169 @@ def _copy_request_log_file(request_id: str, request_dir: str,
 # section. Clamped further by the overall deadline via _bounded_timeout.
 _REQUEST_LOG_COPY_TIMEOUT = 30
 
+# Directory (under each request's dump dir) where log copies are staged
+# before reaching their final name. A copy is published only via an
+# idempotent os.replace after the provider copy completed and the copy was
+# not abandoned, so the archive never contains a partial file and an
+# orphaned copy that completes late lands in a path the zip walk prunes.
+_LOG_STAGING_DIRNAME = '.staging'
+
+# Workers in the shared per-section log-copy executor (one for the whole
+# requests section instead of two per request, which added up to tens of
+# thousands of create/destroy cycles on a large dump). The requests loop is
+# sequential, so this bounds concurrency only via accumulated timed-out
+# copies, each holding a worker until its underlying call returns; a
+# saturated pool falls back to a fresh executor per op (see
+# _run_with_deadline).
+_REQUEST_LOG_EXECUTOR_WORKERS = 8
+
+
+@functools.lru_cache(maxsize=None)
+def _provider_accepts_stop_event(provider: 'log_provider.LogProvider') -> bool:
+    """True if the provider's copy_log_file accepts a stop_event kwarg.
+
+    Cached on the provider object (production providers are singletons,
+    so the cache holds ~one entry); providers that predate the parameter
+    keep the old 3-argument signature and must not be passed the kwarg.
+    inspect.signature raises for some callables; treat that as not
+    capable.
+    """
+    try:
+        sig = inspect.signature(provider.copy_log_file)
+    except (ValueError, TypeError):
+        return False
+    if any(p.kind == inspect.Parameter.VAR_KEYWORD
+           for p in sig.parameters.values()):
+        return True
+    return 'stop_event' in sig.parameters
+
+
+def _provider_copy_log_file(request_id: str,
+                            log_type: log_provider.RequestLogType,
+                            dest_path: str,
+                            stop_event: Optional[threading.Event]) -> bool:
+    """Copy a log via the LogProvider, forwarding stop_event when supported."""
+    provider = log_provider.get_log_provider()
+    dest = pathlib.Path(dest_path)
+    if _provider_accepts_stop_event(provider):
+        return provider.copy_log_file(request_id,
+                                      log_type,
+                                      dest,
+                                      stop_event=stop_event)
+    return provider.copy_log_file(request_id, log_type, dest)
+
+
+def _publish_staged_log(request_dir: str, filename: str) -> bool:
+    """Move a staged log copy to its final name (idempotent).
+
+    Returns True when the final file is in place -- including when the
+    copy was already published (the worker won the check-then-act race
+    against its own stop event), which keeps late reconciliation from
+    reporting a published file as missing.
+    """
+    final_path = os.path.join(request_dir, filename)
+    staged_path = os.path.join(request_dir, _LOG_STAGING_DIRNAME, filename)
+    if os.path.exists(final_path) and not os.path.exists(staged_path):
+        return True
+    try:
+        os.replace(staged_path, final_path)
+        return True
+    except OSError as e:
+        logger.warning(f'Failed to publish staged log {staged_path} -> '
+                       f'{final_path}: {e}')
+        return False
+
+
+def _copy_request_log_file(
+        request_id: str,
+        request_dir: str,
+        log_type: log_provider.RequestLogType,
+        filename: str,
+        stop_event: Optional[threading.Event] = None) -> bool:
+    """Copy one request's log via the LogProvider into a staging dir.
+
+    Standalone (not a per-iteration closure) so the deadline wrapper can call it
+    via functools.partial without capturing the loop variable.
+
+    The copy lands in ``request_dir/.staging/<filename>`` (creating the
+    request dir lazily, so no empty request dir is ever left behind) and
+    reaches its final name only via _publish_staged_log after the provider
+    copy completed and the copy was not abandoned. An abandoned copy that
+    finishes anyway leaves its complete file in .staging for
+    _reconcile_timed_out_ops to publish late (worker-side gate).
+    """
+    staging_dir = os.path.join(request_dir, _LOG_STAGING_DIRNAME)
+    os.makedirs(staging_dir, exist_ok=True)
+    staged_path = os.path.join(staging_dir, filename)
+    if not _provider_copy_log_file(request_id, log_type, staged_path,
+                                   stop_event):
+        try:
+            os.unlink(staged_path)
+        except OSError:
+            pass
+        return False
+    if stop_event is not None and stop_event.is_set():
+        # Abandoned after the copy finished: leave the complete file in
+        # .staging for the reconciler to publish.
+        return True
+    return _publish_staged_log(request_dir, filename)
+
+
+def _empty_request_outcomes() -> Dict[str, Any]:
+    """Zeroed outcomes for the requests section (empty or fully skipped)."""
+    return {
+        'in_scope': 0,
+        'attempted': 0,
+        'skipped_deadline': 0,
+        'not_in_db': 0,
+        'db_errors': 0,
+        'info_written': 0,
+        'skipped_request_ids': [],
+        'request_log': {
+            'found': 0,
+            'not_found': 0,
+            'timed_out': 0
+        },
+        'request_debug_log': {
+            'found': 0,
+            'not_found': 0,
+            'timed_out': 0
+        },
+    }
+
+
+def _write_stub_request_info(request_dir: str,
+                             request_id: str,
+                             error: str,
+                             logs: Optional[Dict[str, str]] = None) -> None:
+    """Write a minimal request_info.json for an un-dumpable request.
+
+    Every attempted request leaves an artifact the zip contains, so the
+    collected ID list can be reconciled from the dump alone. The request
+    dir is created lazily here (never upfront), so a request that is
+    skipped, or fails before any write, leaves no empty directory the zip
+    would silently drop. Written after the log copies (like the full
+    request_info.json) so the stub can carry the per-log outcomes too.
+    """
+    stub: Dict[str, Any] = {'request_id': request_id, 'error': error}
+    if logs is not None:
+        stub['logs'] = logs
+    try:
+        os.makedirs(request_dir, exist_ok=True)
+        stub_path = os.path.join(request_dir, 'request_info.json')
+        with open(stub_path, 'w', encoding='utf-8') as f:
+            json.dump(stub, f, indent=2)
+    except OSError as e:
+        logger.warning(
+            f'Failed to write stub request info for {request_id}: {e}')
+
 
 def _dump_request_id_info(
         request_ids: Set[str],
         dump_dir: str,
-        errors: Optional[List[Dict[str, str]]] = None,
+        errors: Optional[List[Dict[str, Any]]] = None,
         deadline: Optional[float] = None,
-        orphans: Optional[List[Dict[str, Any]]] = None) -> None:
+        orphans: Optional[List[Dict[str, Any]]] = None) -> Dict[str, Any]:
     """Collect request logs and metadata.
 
     ``deadline`` (absolute monotonic) bounds the section two ways: each
@@ -1073,142 +1430,249 @@ def _dump_request_id_info(
     budget is gone we stop starting new requests and skip the rest -- so the
     dump still zips what it gathered. Per-request wall-clock is written to
     ``requests/_timings.json``.
+
+    Returns an outcomes dict surfaced in summary.json's
+    ``section_outcomes``: ``in_scope = attempted + skipped_deadline`` and
+    ``attempted = info_written + not_in_db + db_errors`` (each of those
+    buckets implies a request_info.json artifact, full or stub), plus
+    per-log-type coverage counts, so every gap between the summary counts
+    and the on-disk artifacts is explainable from the dump alone.
     """
+    outcomes = _empty_request_outcomes()
     if not request_ids:
         logger.debug('No requests to dump')
-        return
+        return outcomes
     logger.debug(f'Entering _dump_request_id_info for '
                  f'{len(request_ids)} requests')
+    outcomes['in_scope'] = len(request_ids)
 
     requests_dir = os.path.join(dump_dir, 'requests')
     os.makedirs(requests_dir, exist_ok=True)
 
-    timings: List[Dict[str, Any]] = []
-    for request_id in request_ids:
-        if _deadline_exceeded(deadline):
-            if errors is not None:
-                errors.append({
-                    'component': 'requests',
-                    'resource': request_id,
-                    'error': 'Skipped: overall debug-dump deadline exceeded.',
-                })
-            continue
-        request_start = time.monotonic()
-        request_dir = os.path.join(requests_dir, request_id)
-        os.makedirs(request_dir, exist_ok=True)
+    # One shared bounded executor (plus its matching free-slot semaphore)
+    # for the whole section instead of two per request, which added up to
+    # tens of thousands of executor create/destroy cycles on a large
+    # dump. The loop below is sequential, so the semaphore only saturates
+    # via accumulated timed-out copies (each holding a worker until its
+    # underlying call returns); _run_with_deadline then falls back to a
+    # fresh executor per op.
+    executor = concurrent.futures.ThreadPoolExecutor(
+        max_workers=_REQUEST_LOG_EXECUTOR_WORKERS,
+        thread_name_prefix='debug-dump-log-copy')
+    executor_slots = threading.Semaphore(_REQUEST_LOG_EXECUTOR_WORKERS)
 
-        # Get request metadata from DB
-        try:
-            request = requests_lib.get_request(request_id)
-            if request is not None:
-                request_info: Dict[str, Any] = {
-                    'request_id': request.request_id,
-                    'name': request.name,
-                    'status': request.status.value if request.status else None,
-                    'created_at': request.created_at,
-                    'created_at_human': debug_dump_helpers.epoch_to_human(
-                        request.created_at),
-                    'finished_at': request.finished_at,
-                    'finished_at_human': debug_dump_helpers.epoch_to_human(
-                        request.finished_at),
-                    'cluster_name': request.cluster_name,
-                    'user_id': request.user_id,
-                    'status_msg': request.status_msg,
-                    'schedule_type': (request.schedule_type.value
-                                      if request.schedule_type else None),
-                    'request_body': _sanitize_request_body(request),
-                }
+    def _copy_one_log(log_type: log_provider.RequestLogType, filename: str,
+                      resource: str, log_key: str) -> str:
+        """Deadline-bounded copy of one log type via the LogProvider.
 
-                # Include error info if present
-                try:
-                    error = request.get_error()
-                    if error:
-                        request_info['error'] = {
-                            'type': error.get('type'),
-                            'message': error.get('message'),
-                        }
-                except Exception:  # pylint: disable=broad-except
-                    pass
-
-                request_info_path = os.path.join(request_dir,
-                                                 'request_info.json')
-                with open(request_info_path, 'w', encoding='utf-8') as f:
-                    json.dump(request_info, f, indent=2, default=str)
-                logger.debug(
-                    f'Dumped request {request_id} '
-                    f'(name={request.name}, '
-                    f'status='
-                    f'{request.status.value if request.status else None})')
-            else:
-                logger.debug(f'Request {request_id} not found in DB')
-        except Exception as e:  # pylint: disable=broad-except
-            logger.warning(f'Failed to get info for request {request_id}: {e}')
-            if errors is not None:
-                errors.append({
-                    'component': 'requests',
-                    'resource': request_id,
-                    'error': str(e),
-                    'traceback': _full_traceback()
-                })
-
-        # Copy request log file. Routed through the LogProvider so that
-        # deployments whose request logs are not on the local filesystem
-        # can fetch them from wherever they live. Deadline-bounded: a
-        # streaming/active request's copy can block for tens of seconds.
+        Returns the outcome ('found' / 'not_found' / 'copy_timed_out')
+        and bumps the matching coverage counter. Routed through the
+        LogProvider so that deployments whose request logs are not on the
+        local filesystem can fetch them from wherever they live.
+        Deadline-bounded: a streaming/active request's copy can block for
+        tens of seconds.
+        """
+        stop_event = threading.Event()
         try:
             ok, copied = _run_with_deadline(
                 functools.partial(_copy_request_log_file, request_id,
-                                  request_dir,
-                                  log_provider.RequestLogType.REQUEST,
-                                  'request.log'),
+                                  request_dir, log_type, filename, stop_event),
                 _bounded_timeout(_REQUEST_LOG_COPY_TIMEOUT, deadline),
                 component='requests',
-                resource=f'{request_id}/log',
+                resource=resource,
                 errors=errors,
-                orphans=orphans)
+                orphans=orphans,
+                stop_event=stop_event,
+                executor=executor,
+                executor_slots=executor_slots,
+                orphan_extras={
+                    # Lets the reconciler publish a late completion and
+                    # the zip walk exclude an unresolved orphan's final
+                    # path.
+                    'publish': functools.partial(_publish_staged_log,
+                                                 request_dir, filename),
+                    'final_path': os.path.join(request_dir, filename),
+                })
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning(f'Failed to copy {filename} for {request_id}: {e}')
+            if errors is not None:
+                errors.append({
+                    'component': 'requests',
+                    'resource': resource,
+                    'error': str(e),
+                    'traceback': _full_traceback()
+                })
+            outcome = 'not_found'
+        else:
             if ok and copied:
-                logger.debug(f'Copied request log for {request_id}')
+                logger.debug(f'Copied {filename} for {request_id}')
+                outcome = 'found'
             elif ok:
                 logger.debug(f'Request log not found for {request_id}')
-        except Exception as e:  # pylint: disable=broad-except
-            logger.warning(f'Failed to copy log for request {request_id}: {e}')
-            if errors is not None:
-                errors.append({
-                    'component': 'requests',
-                    'resource': f'{request_id}/log',
-                    'error': str(e),
-                    'traceback': _full_traceback()
-                })
+                outcome = 'not_found'
+            else:
+                # Timed out. Whether the abandoned worker eventually
+                # delivered the log is folded into errors.json by
+                # _reconcile_timed_out_ops; final resolution lives there,
+                # not in this counter.
+                outcome = 'copy_timed_out'
+        # Counter keys use 'timed_out'; the per-request 'logs' outcome in
+        # request_info.json uses the more explicit 'copy_timed_out'.
+        counter_key = 'timed_out' if outcome == 'copy_timed_out' else outcome
+        outcomes[log_key][counter_key] += 1
+        return outcome
 
-        # Copy debug log file (only exists when
-        # ENABLE_REQUEST_DEBUG_LOGGING is enabled). Deadline-bounded too.
-        try:
-            ok, copied = _run_with_deadline(
-                functools.partial(_copy_request_log_file, request_id,
-                                  request_dir,
-                                  log_provider.RequestLogType.DEBUG,
-                                  'request_debug.log'),
-                _bounded_timeout(_REQUEST_LOG_COPY_TIMEOUT, deadline),
-                component='requests',
-                resource=f'{request_id}/request_debug.log',
-                errors=errors,
-                orphans=orphans)
-            if ok and copied:
-                logger.debug(f'Copied debug log for {request_id}')
-        except Exception as e:  # pylint: disable=broad-except
-            logger.warning(
-                f'Failed to copy debug log for request {request_id}: {e}')
-            if errors is not None:
-                errors.append({
-                    'component': 'requests',
-                    'resource': f'{request_id}/request_debug.log',
-                    'error': str(e),
-                    'traceback': _full_traceback()
-                })
+    # Deadline-exhaustion bookkeeping: ONE aggregate error record at the
+    # end instead of one identical record per skipped request (which, on
+    # a large dump, buried the few entries with real diagnostic content).
+    skipped_request_ids: List[str] = []
+    budget_exhausted_at: Optional[str] = None
+    skip_warned = False
 
-        timings.append({
-            'request_id': request_id,
-            'duration_s': round(time.monotonic() - request_start, 2),
+    timings: List[Dict[str, Any]] = []
+    # Sorted (raw set order is hash-randomized per process) so the
+    # aggregate skip record's first_skipped_id is the first request in
+    # processing order that hit the exhausted budget -- and the dump is
+    # deterministic.
+    try:
+        for request_id in sorted(request_ids):
+            if _deadline_exceeded(deadline):
+                if not skip_warned:
+                    remaining = (len(request_ids) - len(skipped_request_ids) -
+                                 outcomes['attempted'])
+                    logger.warning(
+                        'Overall debug-dump deadline exceeded; skipping '
+                        'remaining requests, starting with '
+                        f'{request_id} ({remaining} left).')
+                    skip_warned = True
+                    budget_exhausted_at = datetime.datetime.now().isoformat()
+                skipped_request_ids.append(request_id)
+                continue
+            request_start = time.monotonic()
+            request_dir = os.path.join(requests_dir, request_id)
+            outcomes['attempted'] += 1
+
+            request_info: Optional[Dict[str, Any]] = None
+            # Set when the request could not be read from the DB; a stub
+            # request_info.json is written for it after the log copies.
+            stub_error: Optional[str] = None
+            # Get request metadata from DB
+            try:
+                request = requests_lib.get_request(request_id)
+                if request is not None:
+                    request_info = {
+                        'request_id': request.request_id,
+                        'name': request.name,
+                        'status': request.status.value
+                                  if request.status else None,
+                        'created_at': request.created_at,
+                        'created_at_human': debug_dump_helpers.epoch_to_human(
+                            request.created_at),
+                        'finished_at': request.finished_at,
+                        'finished_at_human': debug_dump_helpers.epoch_to_human(
+                            request.finished_at),
+                        'cluster_name': request.cluster_name,
+                        'user_id': request.user_id,
+                        'status_msg': request.status_msg,
+                        'schedule_type': (request.schedule_type.value
+                                          if request.schedule_type else None),
+                        'request_body': _sanitize_request_body(request),
+                    }
+
+                    # Include error info if present
+                    try:
+                        error = request.get_error()
+                        if error:
+                            request_info['error'] = {
+                                'type': error.get('type'),
+                                'message': error.get('message'),
+                            }
+                    except Exception:  # pylint: disable=broad-except
+                        pass
+                else:
+                    logger.debug(f'Request {request_id} not found in DB')
+                    outcomes['not_in_db'] += 1
+                    stub_error = ('Request not found in database (row may '
+                                  'have been garbage-collected); no data '
+                                  'collected.')
+                    if errors is not None:
+                        errors.append({
+                            'component': 'requests',
+                            'resource': request_id,
+                            'error': stub_error,
+                        })
+            except Exception as e:  # pylint: disable=broad-except
+                logger.warning(
+                    f'Failed to get info for request {request_id}: {e}')
+                outcomes['db_errors'] += 1
+                stub_error = str(e)
+                if errors is not None:
+                    errors.append({
+                        'component': 'requests',
+                        'resource': request_id,
+                        'error': str(e),
+                        'traceback': _full_traceback()
+                    })
+
+            log_outcomes = {
+                'request_log': _copy_one_log(
+                    log_provider.RequestLogType.REQUEST, 'request.log',
+                    f'{request_id}/log', 'request_log'),
+                'request_debug_log': _copy_one_log(
+                    log_provider.RequestLogType.DEBUG, 'request_debug.log',
+                    f'{request_id}/request_debug.log', 'request_debug_log'),
+            }
+
+            # Written after the log copies (independent data) and carrying
+            # the per-log outcomes, so a reader of request_info.json knows
+            # which logs to expect next to it.
+            if request_info is not None:
+                request_info['logs'] = log_outcomes
+                try:
+                    request_info_path = os.path.join(request_dir,
+                                                     'request_info.json')
+                    with open(request_info_path, 'w', encoding='utf-8') as f:
+                        json.dump(request_info, f, indent=2, default=str)
+                    outcomes['info_written'] += 1
+                    logger.debug(f'Dumped request {request_id} '
+                                 f'(name={request_info["name"]}, '
+                                 f'status={request_info["status"]})')
+                except OSError as e:
+                    logger.warning(
+                        f'Failed to write request info for {request_id}: {e}')
+                    if errors is not None:
+                        errors.append({
+                            'component': 'requests',
+                            'resource': request_id,
+                            'error': str(e),
+                            'traceback': _full_traceback()
+                        })
+            elif stub_error is not None:
+                # Un-dumpable request: still leave an artifact (with the
+                # log outcomes) so the collected ID list reconciles.
+                _write_stub_request_info(request_dir, request_id, stub_error,
+                                         log_outcomes)
+
+            timings.append({
+                'request_id': request_id,
+                'duration_s': round(time.monotonic() - request_start, 2),
+            })
+    finally:
+        executor.shutdown(wait=False)
+
+    outcomes['skipped_deadline'] = len(skipped_request_ids)
+    outcomes['skipped_request_ids'] = skipped_request_ids
+    if skipped_request_ids and errors is not None:
+        errors.append({
+            'component': 'requests',
+            'resource': 'requests_deadline_skips',
+            'error': ('Skipped: overall debug-dump deadline exceeded. '
+                      f'{len(skipped_request_ids)} requests were skipped '
+                      'after the budget ran out; the full sorted list is '
+                      'in ids_manifest.json.'),
+            'skipped_count': len(skipped_request_ids),
+            'first_skipped_id': skipped_request_ids[0],
+            'budget_exhausted_at': budget_exhausted_at,
         })
 
     try:
@@ -1219,6 +1683,7 @@ def _dump_request_id_info(
     except OSError as e:
         logger.debug(f'Failed to write request timings: {e}')
     logger.debug('Exiting _dump_request_id_info')
+    return outcomes
 
 
 # Short connection timeout for the skylet-log-path resolution command. The
@@ -2302,7 +2767,7 @@ def _build_debug_dump(
     # deadline-aware (its internal calls are bounded and it's skipped once the
     # budget is gone), so the build always reaches the zip step with a coherent
     # partial instead of being hard-killed mid-section.
-    sections: List[Tuple[str, Callable[[], None]]] = [
+    sections: List[Tuple[str, Callable[[], Any]]] = [
         ('server_info', lambda: _dump_server_info(
             dump_dir, errors=errors, deadline=deadline, orphans=orphans)),
         ('request_ids',
@@ -2337,6 +2802,13 @@ def _build_debug_dump(
     # see where the budget went (and which sections were skipped) without
     # grepping the worker log.
     section_timings: List[Dict[str, Any]] = []
+    # Structured per-section outcomes (only the sections that return one,
+    # e.g. the requests section's outcome counters). Deliberately an
+    # isinstance check rather than a truthiness check: section functions
+    # are frequently replaced by test doubles whose return values are not
+    # JSON-serializable, and summary.json's json.dump below has no
+    # default=str -- any junk return is simply not captured.
+    section_outcomes: Dict[str, Any] = {}
     for name, dump_section in sections:
         if _deadline_exceeded(deadline):
             logger.warning(f'Skipping debug-dump section {name!r}: overall '
@@ -2362,14 +2834,22 @@ def _build_debug_dump(
         remaining = _remaining_budget(deadline)
         logger.info(f'debug dump: section {name!r} start' + (
             '' if remaining is None else f' ({remaining:.0f}s budget left)'))
-        dump_section()
+        ret = dump_section()
         duration = time.monotonic() - section_start
         logger.info(f'debug dump: section {name!r} done in {duration:.1f}s')
+        if isinstance(ret, dict):
+            section_outcomes[name] = ret
         section_timings.append({
             'section': name,
             'status': 'completed',
             'duration_s': round(duration, 2),
         })
+
+    # Fold the eventual outcome of every timed-out op (completed late,
+    # raised late, or still running) into its error record BEFORE
+    # errors.json is written, so the serialized error file matches the
+    # tree at zip time and can never contradict the archive.
+    _reconcile_timed_out_ops(orphans)
 
     # Write client info if provided
     if client_info:
@@ -2385,6 +2865,32 @@ def _build_debug_dump(
     with open(errors_path, 'w', encoding='utf-8') as f:
         json.dump(errors, f, indent=2, default=str)
 
+    # ID lists (and the requests skipped for a dead budget) live in their
+    # own manifest so summary.json stays scannable; summary.json points at
+    # both files instead of inlining their contents.
+    request_outcomes = section_outcomes.get('request_ids', {})
+
+    def _log_coverage(log_key: str) -> Dict[str, int]:
+        counts = request_outcomes.get(log_key, {})
+        # missing = not_found + copy_timed_out: a timed-out copy whose
+        # worker later delivered the log is annotated in errors.json, but
+        # the log only counts as present when the copy returned in time.
+        found = counts.get('found', 0)
+        missing = counts.get('not_found', 0) + counts.get('timed_out', 0)
+        return {'found': found, 'missing': missing}
+
+    request_logs = _log_coverage('request_log')
+    request_debug_logs = _log_coverage('request_debug_log')
+    ids_manifest: Dict[str, Any] = {
+        'request_ids': sorted(debug_dump_context['request_ids']),
+        'cluster_names': sorted(debug_dump_context['cluster_names']),
+        'managed_job_ids': sorted(debug_dump_context['managed_job_ids']),
+        'skipped_request_ids': request_outcomes.get('skipped_request_ids', []),
+    }
+    ids_manifest_path = os.path.join(dump_dir, 'ids_manifest.json')
+    with open(ids_manifest_path, 'w', encoding='utf-8') as f:
+        json.dump(ids_manifest, f, indent=2)
+
     # Write summary file
     summary: Dict[str, Any] = {
         'requested': requested,
@@ -2392,16 +2898,40 @@ def _build_debug_dump(
             'request_count': len(debug_dump_context['request_ids']),
             'cluster_count': len(debug_dump_context['cluster_names']),
             'managed_job_count': len(debug_dump_context['managed_job_ids']),
-            'request_ids': sorted(debug_dump_context['request_ids']),
-            'cluster_names': sorted(debug_dump_context['cluster_names']),
-            'managed_job_ids': sorted(debug_dump_context['managed_job_ids']),
+            'request_logs_found': request_logs['found'],
+            'request_logs_missing': request_logs['missing'],
+            'request_debug_logs_found': request_debug_logs['found'],
+            'request_debug_logs_missing': request_debug_logs['missing'],
         },
         'section_timings': section_timings,
-        'errors': errors,
+        'section_outcomes': section_outcomes,
+        'errors_count': len(errors),
+        'errors_file': 'errors.json',
+        'ids_manifest_file': 'ids_manifest.json',
     }
     summary_path = os.path.join(dump_dir, 'summary.json')
     with open(summary_path, 'w', encoding='utf-8') as f:
         json.dump(summary, f, indent=2)
+
+
+def _iter_dump_files(dump_dir: str, excluded_paths: Set[str]) -> Iterator[str]:
+    """Iterate the dump's files for the pre-zip size sum and the zip walk.
+
+    Prunes staging directories (a log copy reaches its final name only
+    via an atomic rename after completing, so anything still in .staging
+    is partial or quarantined) and any file whose absolute path is in
+    ``excluded_paths`` -- the final paths of orphans the reconciler could
+    not resolve, computed once before the walk (a fixed set, so a file
+    landing at an excluded path after the set was built still cannot
+    enter the archive or the size total).
+    """
+    for root, dirs, files in os.walk(dump_dir):
+        dirs[:] = [d for d in dirs if d != _LOG_STAGING_DIRNAME]
+        for file in files:
+            file_path = os.path.join(root, file)
+            if os.path.abspath(file_path) in excluded_paths:
+                continue
+            yield file_path
 
 
 def create_debug_dump(
@@ -2543,10 +3073,21 @@ def create_debug_dump(
             debug_handler.flush()
             debug_handler.close()
 
+        # Fixed set (computed once, before the walk) of the final paths of
+        # orphans the reconciler could not resolve: their output must stay
+        # out of the archive even if a worker lands a file at the final
+        # name between the reconciliation and the zip (e.g. a stalled
+        # rename that finally completes). See _iter_dump_files.
+        excluded_paths = {
+            os.path.abspath(op['final_path'])
+            for op in debug_dump_context['timed_out_ops']
+            if op.get('excluded_from_archive') and op.get('final_path')
+        }
+
         # Log total dump size before zipping
-        total_dump_size = sum(f.stat().st_size
-                              for f in pathlib.Path(dump_dir).rglob('*')
-                              if f.is_file())
+        total_dump_size = sum(
+            os.stat(file_path).st_size
+            for file_path in _iter_dump_files(dump_dir, excluded_paths))
 
         # Create zip file in PERSISTENT location (outside temp dir)
         zip_filename = f'debug_dump_{timestamp}.zip'
@@ -2560,12 +3101,10 @@ def create_debug_dump(
         zip_start = time.monotonic()
         file_count = 0
         with zipfile.ZipFile(zip_file_path, 'w', zipfile.ZIP_DEFLATED) as zipf:
-            for root, _, files in os.walk(dump_dir):
-                for file in files:
-                    file_path = os.path.join(root, file)
-                    arcname = os.path.relpath(file_path, temp_dir)
-                    zipf.write(file_path, arcname)
-                    file_count += 1
+            for file_path in _iter_dump_files(dump_dir, excluded_paths):
+                arcname = os.path.relpath(file_path, temp_dir)
+                zipf.write(file_path, arcname)
+                file_count += 1
 
         logger.info(f'debug dump: created {zip_filename} ({file_count} files) '
                     f'in {time.monotonic() - zip_start:.1f}s')

--- a/tests/smoke_tests/test_cli.py
+++ b/tests/smoke_tests/test_cli.py
@@ -371,12 +371,14 @@ def test_debug_dump_cluster(generic_cloud: str):
             'assert \\\"name\\\" in d; '
             'assert \\\"status\\\" in d; '
             '"',
-            # Verify summary shows the cluster was collected
+            # Verify the cluster was collected (ID lists live in
+            # ids_manifest.json; counts live in summary.json)
             'cd /tmp/test_debug_dump_cluster/debug_dump_* && '
-            's=$(cat summary.json) && echo "$s" && '
+            's=$(cat ids_manifest.json) && echo "$s" && '
             'echo "$s" | python3 -c "'
-            'import sys, json; d = json.load(sys.stdin); '
-            f'assert \\\"{name}\\\" in d[\\\"collected\\\"][\\\"cluster_names\\\"]; '
+            'import sys, json; m = json.load(sys.stdin); '
+            f'assert \\\"{name}\\\" in m[\\\"cluster_names\\\"]; '
+            'd = json.load(open(\\\"summary.json\\\")); '
             'assert d[\\\"collected\\\"][\\\"cluster_count\\\"] >= 1; '
             # Cross-linked requests from the launch should be present
             'assert d[\\\"collected\\\"][\\\"request_count\\\"] > 0; '

--- a/tests/unit_tests/test_sky/server/requests/test_log_provider.py
+++ b/tests/unit_tests/test_sky/server/requests/test_log_provider.py
@@ -1,5 +1,7 @@
 """Tests for sky.server.requests.log_provider."""
+import builtins
 import pathlib
+import threading
 from unittest import mock
 
 import pytest
@@ -70,3 +72,120 @@ class TestCopyLogFile:
         # The request log prefix is under ~, so with HOME patched it must
         # resolve inside tmp_path.
         assert str(src).startswith(str(tmp_path))
+
+
+class TestCopyLogStopEvent:
+    """stop_event makes the default local copy cooperatively cancellable."""
+
+    def _write_src(self, tmp_path, size_bytes=64):
+        src_dir = tmp_path / 'request_logs'
+        src_dir.mkdir(exist_ok=True)
+        src = src_dir / 'req-1.log'
+        src.write_bytes(b'x' * size_bytes)
+        return src
+
+    @staticmethod
+    def _open_that_stops_on_first_write(stop_event):
+        """Patch target for builtins.open: the destination's first write
+        flips the stop event, so the copy is deterministically abandoned
+        mid-flight (after the destination file was created). File objects
+        do not allow attribute overrides, hence the wrapper class."""
+        real_open = builtins.open
+
+        def _open(file, *args, **kwargs):
+            f = real_open(file, *args, **kwargs)
+            if getattr(f, 'mode', '') == 'wb':
+
+                class _StopOnWrite:
+                    """Wraps the dest file; the first write flips the stop
+                    event (the copy is abandoned mid-flight)."""
+
+                    def __init__(self, inner):
+                        self._inner = inner
+
+                    def write(self, data):
+                        stop_event.set()
+                        return self._inner.write(data)
+
+                    def __enter__(self):
+                        return self
+
+                    def __exit__(self, *exc):
+                        return self._inner.__exit__(*exc)
+
+                return _StopOnWrite(f)
+            return f
+
+        return _open
+
+    def test_stop_preset_returns_false_no_dest(self, tmp_path):
+        src = self._write_src(tmp_path)
+        dest = tmp_path / 'request.log'
+        stop_event = threading.Event()
+        stop_event.set()  # caller already abandoned the copy
+        with mock.patch.object(log_provider, 'local_log_path',
+                               return_value=src):
+            provider = log_provider.LocalLogProvider()
+            copied = provider.copy_log_file('req-1',
+                                            log_provider.RequestLogType.REQUEST,
+                                            dest,
+                                            stop_event=stop_event)
+        assert not copied
+        assert not dest.exists()
+
+    def test_stop_mid_copy_unlinks_partial_dest(self, tmp_path):
+        src = self._write_src(tmp_path)
+        dest = tmp_path / 'request.log'
+        stop_event = threading.Event()
+        with mock.patch(
+                'builtins.open',
+                side_effect=self._open_that_stops_on_first_write(
+                    stop_event)), \
+             mock.patch.object(log_provider,
+                               'local_log_path',
+                               return_value=src):
+            provider = log_provider.LocalLogProvider()
+            copied = provider.copy_log_file('req-1',
+                                            log_provider.RequestLogType.REQUEST,
+                                            dest,
+                                            stop_event=stop_event)
+        assert not copied
+        assert not dest.exists()
+
+    def test_stop_path_unlink_error_does_not_propagate(self, tmp_path):
+        src = self._write_src(tmp_path)
+        dest = tmp_path / 'request.log'
+        stop_event = threading.Event()
+        with mock.patch(
+                'builtins.open',
+                side_effect=self._open_that_stops_on_first_write(
+                    stop_event)), \
+             mock.patch.object(pathlib.Path,
+                               'unlink',
+                               side_effect=OSError('stalled fs')), \
+             mock.patch.object(log_provider,
+                               'local_log_path',
+                               return_value=src):
+            provider = log_provider.LocalLogProvider()
+            # The guarded unlink must not mask the stop contract.
+            copied = provider.copy_log_file('req-1',
+                                            log_provider.RequestLogType.REQUEST,
+                                            dest,
+                                            stop_event=stop_event)
+        assert not copied
+
+    def test_multichunk_copy_is_byte_identical_with_mtime(
+            self, tmp_path, monkeypatch):
+        monkeypatch.setattr(log_provider, '_LOG_COPY_CHUNK_BYTES', 16)
+        src = self._write_src(tmp_path, size_bytes=100)
+        dest = tmp_path / 'request.log'
+        with mock.patch.object(log_provider, 'local_log_path',
+                               return_value=src):
+            provider = log_provider.LocalLogProvider()
+            copied = provider.copy_log_file('req-1',
+                                            log_provider.RequestLogType.REQUEST,
+                                            dest)
+        assert copied
+        assert dest.read_bytes() == src.read_bytes()
+        # copystat parity with the old copy2 behavior (mtime included).
+        assert dest.stat().st_mtime == src.stat().st_mtime

--- a/tests/unit_tests/test_sky/utils/test_debug_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_debug_utils.py
@@ -1428,16 +1428,30 @@ class TestCreateDebugDump:
             summary_files = [n for n in names if n.endswith('summary.json')]
             assert len(summary_files) == 1
 
-            # Verify summary content
+            # Verify summary content. The full error records and ID lists
+            # live in errors.json / ids_manifest.json; summary.json only
+            # carries a count and file pointers.
             summary_data = json.loads(zf.read(summary_files[0]))
             assert 'requested' in summary_data
             assert 'collected' in summary_data
-            assert 'errors' in summary_data
+            assert 'errors' not in summary_data
+            assert summary_data['errors_file'] == 'errors.json'
+            assert isinstance(summary_data['errors_count'], int)
             assert 'warnings' not in summary_data
             assert 'req-1' in summary_data['requested']['request_ids']
 
             errors_files = [n for n in names if n.endswith('errors.json')]
             assert len(errors_files) == 1
+
+            manifest_files = [
+                n for n in names if n.endswith('ids_manifest.json')
+            ]
+            assert len(manifest_files) == 1
+            manifest = json.loads(zf.read(manifest_files[0]))
+            assert 'request_ids' in manifest
+            assert 'cluster_names' in manifest
+            assert 'managed_job_ids' in manifest
+            assert 'skipped_request_ids' in manifest
 
             # debug_dump.log should be present (from the file handler)
             log_files = [n for n in names if n.endswith('debug_dump.log')]
@@ -1734,11 +1748,11 @@ class TestRequestIdPrefixResolution:
             result = debug_utils.create_debug_dump(request_ids=['abc'])
 
         with zipfile.ZipFile(result, 'r') as zf:
-            summary = json.loads(
+            manifest = json.loads(
                 zf.read([
-                    n for n in zf.namelist() if n.endswith('summary.json')
+                    n for n in zf.namelist() if n.endswith('ids_manifest.json')
                 ][0]))
-        collected_ids = summary['collected']['request_ids']
+        collected_ids = manifest['request_ids']
         assert 'abc-111' in collected_ids
         assert 'abc-222' in collected_ids
 
@@ -1765,13 +1779,13 @@ class TestRequestIdPrefixResolution:
             result = debug_utils.create_debug_dump(request_ids=['nonexistent'])
 
         with zipfile.ZipFile(result, 'r') as zf:
-            summary = json.loads(
+            manifest = json.loads(
                 zf.read([
-                    n for n in zf.namelist() if n.endswith('summary.json')
+                    n for n in zf.namelist() if n.endswith('ids_manifest.json')
                 ][0]))
         # The unmatched prefix should not appear in collected IDs
         # (only system request IDs should be present)
-        assert 'nonexistent' not in summary['collected']['request_ids']
+        assert 'nonexistent' not in manifest['request_ids']
 
 
 # ---------------------------------------------------------------------------
@@ -3098,17 +3112,27 @@ class TestDumpRequestIdInfo:
 
     @mock.patch('sky.utils.debug_utils.requests_lib.get_request')
     def test_request_not_found(self, mock_get_request, tmp_path):
-        """Should handle request not found gracefully."""
+        """A request missing from the DB gets an errors.json entry and a
+        stub request_info.json (not-found is not an exception, so the
+        entry carries no traceback), so the collected ID list can be
+        reconciled from the dump alone."""
         mock_get_request.return_value = None
 
-        errors: List[Dict[str, str]] = []
+        errors: List[Dict[str, Any]] = []
         debug_utils._dump_request_id_info({'req-missing'}, str(tmp_path),
                                           errors)
 
-        # No crash, no error recorded (not-found is not an error)
-        assert not errors
+        assert len(errors) == 1
+        assert errors[0]['component'] == 'requests'
+        assert errors[0]['resource'] == 'req-missing'
+        assert 'not found in database' in errors[0]['error']
+        assert 'traceback' not in errors[0]
         info_path = tmp_path / 'requests' / 'req-missing' / 'request_info.json'
-        assert not info_path.exists()
+        assert info_path.exists()
+        with open(info_path) as f:
+            stub = json.load(f)
+        assert stub['request_id'] == 'req-missing'
+        assert 'not found in database' in stub['error']
 
     @mock.patch('sky.utils.debug_utils.requests_lib.get_request')
     def test_db_failure_records_error(self, mock_get_request, tmp_path):
@@ -3122,6 +3146,12 @@ class TestDumpRequestIdInfo:
         assert errors[0]['component'] == 'requests'
         assert 'DB is down' in errors[0]['error']
         assert 'traceback' in errors[0]
+        # The failed request still leaves a stub artifact.
+        info_path = tmp_path / 'requests' / 'req-fail' / 'request_info.json'
+        with open(info_path) as f:
+            stub = json.load(f)
+        assert stub['request_id'] == 'req-fail'
+        assert 'DB is down' in stub['error']
 
     def test_empty_request_ids_is_noop(self, tmp_path):
         """Empty request_ids should not create any files."""
@@ -3506,13 +3536,14 @@ class TestDumpRequestIdInfoLogCollection:
     @pytest.fixture(autouse=True)
     def _mock_get_request(self):
         with mock.patch('sky.utils.debug_utils.requests_lib.get_request',
-                        return_value=None):
+                        side_effect=lambda request_id: _make_request(
+                            request_id=request_id)):
             yield
 
     def test_logs_collected_via_log_provider(self, tmp_path):
         provider = mock.MagicMock()
 
-        def _fake_copy(request_id, log_type, dest_path):
+        def _fake_copy(request_id, log_type, dest_path, stop_event=None):
             del request_id  # unused
             if log_type == log_provider_lib.RequestLogType.REQUEST:
                 dest_path.write_text('request log content')
@@ -4324,10 +4355,86 @@ class TestRunWithDeadline:
             assert errors[0]['component'] == 'comp'
             assert len(orphans) == 1
             assert orphans[0]['resource'] == 'res'
+            # The orphan record carries a direct reference to the error
+            # record just appended, so reconciliation can rewrite it.
+            assert orphans[0]['error_entry'] is errors[0]
             # The worker thread is orphaned, still running (not killed).
             assert not orphans[0]['future'].done()
         finally:
             release.set()  # let the orphaned worker exit promptly
+
+    def test_timeout_sets_stop_event(self):
+        """On timeout the caller's stop_event is set first, so a
+        cooperating op terminates at its next checkpoint."""
+        stop_event = threading.Event()
+        errors: List[Dict[str, Any]] = []
+        orphans: List[Dict[str, Any]] = []
+        try:
+            ok, _ = debug_utils._run_with_deadline(stop_event.wait,
+                                                   timeout=0.05,
+                                                   component='comp',
+                                                   resource='res',
+                                                   errors=errors,
+                                                   orphans=orphans,
+                                                   stop_event=stop_event)
+            assert ok is False
+            assert stop_event.is_set()
+        finally:
+            stop_event.set()
+
+    def test_timeout_shared_executor_not_shut_down(self):
+        """A caller-provided executor is never shut down by a timeout, and
+        stays usable afterwards."""
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=2)
+        release = threading.Event()
+        errors: List[Dict[str, Any]] = []
+        orphans: List[Dict[str, Any]] = []
+        try:
+            ok, _ = debug_utils._run_with_deadline(release.wait,
+                                                   timeout=0.05,
+                                                   component='comp',
+                                                   resource='res',
+                                                   errors=errors,
+                                                   orphans=orphans,
+                                                   executor=executor)
+            assert ok is False
+            # Still usable after the timeout (submit + run a real op).
+            assert executor.submit(lambda: 'alive').result() == 'alive'
+        finally:
+            release.set()
+            executor.shutdown(wait=True)
+
+    def test_saturated_shared_pool_falls_back_to_fresh_executor(self):
+        """When every shared worker is held by an orphan, a new op still
+        gets a real attempt via a fresh single-worker executor instead of
+        being recorded as timed out without ever starting."""
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        slots = threading.Semaphore(1)
+        release = threading.Event()
+        orphans: List[Dict[str, Any]] = []
+        try:
+            # First op times out and holds the only shared worker.
+            ok, _ = debug_utils._run_with_deadline(release.wait,
+                                                   timeout=0.05,
+                                                   component='c',
+                                                   resource='orphaned',
+                                                   orphans=orphans,
+                                                   executor=executor,
+                                                   executor_slots=slots)
+            assert ok is False
+            # The slot is still held by the orphan, so the second op must
+            # fall back -- and still succeed with a real timeout.
+            ok, result = debug_utils._run_with_deadline(lambda: 'ran',
+                                                        timeout=5,
+                                                        component='c',
+                                                        resource='second',
+                                                        executor=executor,
+                                                        executor_slots=slots)
+            assert ok is True
+            assert result == 'ran'
+        finally:
+            release.set()
+            executor.shutdown(wait=True)
 
     def test_non_timeout_exception_propagates(self):
         """A non-timeout error from fn propagates (each call site keeps its own
@@ -4493,3 +4600,644 @@ class TestOverallDeadlineDump:
         assert result.exists()
         for fn, m in section_mocks.items():
             assert m.call_count == 1, f'{fn} should have run exactly once'
+
+
+# ---------------------------------------------------------------------------
+# Tests for _reconcile_timed_out_ops
+# ---------------------------------------------------------------------------
+class TestReconcileTimedOutOps:
+    """_reconcile_timed_out_ops folds orphan outcomes into error records."""
+
+    @staticmethod
+    def _make_orphan(error_entry=None,
+                     result=None,
+                     exc=None,
+                     publish=None,
+                     resource='res'):
+        future = concurrent.futures.Future()
+        if exc is not None:
+            future.set_exception(exc)
+        else:
+            future.set_result(result)
+        orphan = {
+            'component': 'c',
+            'resource': resource,
+            'future': future,
+            'started': time.monotonic(),
+            'error_entry': error_entry,
+        }
+        if publish is not None:
+            orphan['publish'] = publish
+        return orphan
+
+    def test_done_truthy_with_publish_closure_publishes_and_annotates(
+            self, tmp_path):
+        request_dir = tmp_path / 'requests' / 'req-1'
+        staging = request_dir / '.staging'
+        staging.mkdir(parents=True)
+        (staging / 'request.log').write_text('late content')
+        error_entry = {
+            'component': 'requests',
+            'resource': 'req-1/log',
+            'error': 'req-1/log timed out after 30s; skipped.'
+        }
+        orphan = self._make_orphan(
+            error_entry,
+            result=True,
+            publish=lambda: debug_utils._publish_staged_log(
+                str(request_dir), 'request.log'))
+        debug_utils._reconcile_timed_out_ops([orphan])
+
+        assert (request_dir / 'request.log').read_text() == 'late content'
+        assert not (staging / 'request.log').exists()
+        assert 'completed after the timeout' in error_entry['error']
+        assert 'output is included' in error_entry['error']
+
+    def test_done_truthy_already_published_is_idempotent(self, tmp_path):
+        """A file the worker already published (staging gone, final present)
+        must not be reported as 'could not be published'."""
+        request_dir = tmp_path / 'requests' / 'req-1'
+        request_dir.mkdir(parents=True)
+        (request_dir / 'request.log').write_text('content')
+        error_entry = {'error': 'timed out'}
+        orphan = self._make_orphan(
+            error_entry,
+            result=True,
+            publish=lambda: debug_utils._publish_staged_log(
+                str(request_dir), 'request.log'))
+        debug_utils._reconcile_timed_out_ops([orphan])
+
+        assert 'could not be published' not in error_entry['error']
+        assert 'output is included' in error_entry['error']
+
+    def test_done_truthy_without_closure_says_not_captured(self):
+        error_entry = {'error': 'timed out'}
+        orphan = self._make_orphan(error_entry, result={'some': 'data'})
+        debug_utils._reconcile_timed_out_ops([orphan])
+
+        assert 'completed after the timeout' in error_entry['error']
+        assert 'result was not captured' in error_entry['error']
+
+    def test_done_exception_gets_late_traceback_and_warning(self, monkeypatch):
+        warnings = []
+        monkeypatch.setattr(debug_utils.logger, 'warning',
+                            lambda *a, **k: warnings.append(a))
+        error_entry = {'error': 'timed out'}
+        orphan = self._make_orphan(error_entry, exc=RuntimeError('late boom'))
+        debug_utils._reconcile_timed_out_ops([orphan])
+
+        assert 'raised an exception after the timeout' in error_entry['error']
+        assert 'RuntimeError: late boom' in error_entry['late_traceback']
+        assert warnings
+
+    def test_cancelled_future_is_skipped(self):
+        """A cancelled op never ran; it must not be misread as a late
+        failure (a bare .result() would raise CancelledError)."""
+        error_entry = {'error': 'timed out'}
+        future = concurrent.futures.Future()
+        assert future.cancel()
+        orphan = {
+            'component': 'c',
+            'resource': 'res',
+            'future': future,
+            'started': time.monotonic(),
+            'error_entry': error_entry,
+        }
+        debug_utils._reconcile_timed_out_ops([orphan])
+
+        assert error_entry['error'] == 'timed out'
+        assert 'excluded_from_archive' not in orphan
+
+    def test_still_running_past_grace_is_quarantined(self):
+        release = threading.Event()
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        try:
+            future = executor.submit(release.wait)
+            error_entry = {'error': 'timed out'}
+            orphan = {
+                'component': 'c',
+                'resource': 'res',
+                'future': future,
+                'started': time.monotonic(),
+                'error_entry': error_entry,
+            }
+            debug_utils._reconcile_timed_out_ops([orphan], grace_s=0)
+
+            # The error entry stays accurate (nothing was published), and
+            # the orphan is marked so its final path is pruned from the
+            # zip walk.
+            assert error_entry['error'] == 'timed out'
+            assert orphan['excluded_from_archive'] is True
+            # A logging done-callback is attached: it fires once the
+            # worker eventually finishes.
+            fired = threading.Event()
+            future.add_done_callback(lambda _f: fired.set())
+            release.set()
+            assert fired.wait(5)
+        finally:
+            executor.shutdown(wait=True)
+
+    def test_publish_raising_does_not_abort_other_orphans(self):
+        error_entry1 = {'error': 'timed out'}
+        error_entry2 = {'error': 'timed out'}
+
+        def _bad_publish():
+            raise RuntimeError('publish failed')
+
+        orphan1 = self._make_orphan(error_entry1,
+                                    result=True,
+                                    publish=_bad_publish)
+        orphan2 = self._make_orphan(error_entry2, result=True, resource='res-2')
+        debug_utils._reconcile_timed_out_ops([orphan1, orphan2])
+
+        assert 'could not be published' in error_entry1['error']
+        assert 'result was not captured' in error_entry2['error']
+
+
+# ---------------------------------------------------------------------------
+# Tests for _copy_request_log_file / _publish_staged_log
+# ---------------------------------------------------------------------------
+class TestCopyRequestLogFile:
+    """Staging, the worker-side publish gate, and cleanup."""
+
+    def test_success_publishes_via_rename(self, tmp_path):
+        request_dir = tmp_path / 'requests' / 'req-1'
+        provider = mock.MagicMock()
+
+        def _fake_copy(request_id, log_type, dest_path, stop_event=None):
+            del request_id, log_type, stop_event
+            dest_path.write_text('content')
+            return True
+
+        provider.copy_log_file.side_effect = _fake_copy
+        with mock.patch('sky.utils.debug_utils.log_provider.get_log_provider',
+                        return_value=provider):
+            copied = debug_utils._copy_request_log_file(
+                'req-1', str(request_dir),
+                log_provider_lib.RequestLogType.REQUEST, 'request.log')
+        assert copied
+        assert (request_dir / 'request.log').read_text() == 'content'
+        assert not (request_dir / '.staging' / 'request.log').exists()
+
+    def test_missing_log_returns_false_and_cleans_staging(self, tmp_path):
+        request_dir = tmp_path / 'requests' / 'req-1'
+        provider = mock.MagicMock()
+
+        def _fake_copy(request_id, log_type, dest_path, stop_event=None):
+            del request_id, log_type, stop_event
+            # A provider that touched the dest and still returned False.
+            dest_path.write_text('partial')
+            return False
+
+        provider.copy_log_file.side_effect = _fake_copy
+        with mock.patch('sky.utils.debug_utils.log_provider.get_log_provider',
+                        return_value=provider):
+            copied = debug_utils._copy_request_log_file(
+                'req-1', str(request_dir),
+                log_provider_lib.RequestLogType.REQUEST, 'request.log')
+        assert not copied
+        assert not (request_dir / 'request.log').exists()
+        assert not (request_dir / '.staging' / 'request.log').exists()
+
+    def test_stop_set_leaves_file_in_staging(self, tmp_path):
+        """An abandoned copy that finishes anyway returns True but does not
+        publish: the complete file waits in .staging for the reconciler
+        (worker-side gate)."""
+        request_dir = tmp_path / 'requests' / 'req-1'
+        provider = mock.MagicMock()
+
+        def _fake_copy(request_id, log_type, dest_path, stop_event=None):
+            del request_id, log_type, stop_event
+            dest_path.write_text('complete')
+            return True
+
+        provider.copy_log_file.side_effect = _fake_copy
+        stop_event = threading.Event()
+        stop_event.set()
+        with mock.patch('sky.utils.debug_utils.log_provider.get_log_provider',
+                        return_value=provider):
+            copied = debug_utils._copy_request_log_file(
+                'req-1',
+                str(request_dir),
+                log_provider_lib.RequestLogType.REQUEST,
+                'request.log',
+                stop_event=stop_event)
+        assert copied
+        assert (request_dir / '.staging' /
+                'request.log').read_text() == 'complete'
+        assert not (request_dir / 'request.log').exists()
+
+    def test_publish_oserror_returns_false(self, tmp_path, monkeypatch):
+        request_dir = tmp_path / 'requests' / 'req-1'
+        staging = request_dir / '.staging'
+        staging.mkdir(parents=True)
+        (staging / 'request.log').write_text('content')
+        monkeypatch.setattr(debug_utils.os, 'replace',
+                            mock.Mock(side_effect=OSError('stalled')))
+        assert not debug_utils._publish_staged_log(str(request_dir),
+                                                   'request.log')
+
+
+# ---------------------------------------------------------------------------
+# Tests for the stop_event capability check on providers
+# ---------------------------------------------------------------------------
+class _OldStyleProvider:
+    """A provider whose copy_log_file predates the stop_event parameter."""
+
+    def __init__(self):
+        self.calls = []
+
+    def copy_log_file(self, request_id, log_type, dest_path):
+        self.calls.append((request_id, log_type, dest_path))
+        return True
+
+
+class _NewStyleProvider:
+    """A provider whose copy_log_file accepts the stop_event parameter."""
+
+    def __init__(self):
+        self.calls = []
+
+    def copy_log_file(self, request_id, log_type, dest_path, stop_event=None):
+        self.calls.append((request_id, log_type, dest_path, stop_event))
+        return True
+
+
+class TestProviderCopyLogFileSignature:
+    """stop_event is forwarded only to providers that accept it."""
+
+    def test_old_signature_called_without_kwarg(self, tmp_path):
+        provider = _OldStyleProvider()
+        with mock.patch('sky.utils.debug_utils.log_provider.get_log_provider',
+                        return_value=provider):
+            assert debug_utils._provider_copy_log_file(
+                'r', log_provider_lib.RequestLogType.REQUEST,
+                str(tmp_path / 'dest.log'), None)
+        assert len(provider.calls) == 1
+        assert len(provider.calls[0]) == 3  # no stop_event forwarded
+
+    def test_new_signature_receives_kwarg(self, tmp_path):
+        provider = _NewStyleProvider()
+        stop_event = threading.Event()
+        with mock.patch('sky.utils.debug_utils.log_provider.get_log_provider',
+                        return_value=provider):
+            assert debug_utils._provider_copy_log_file(
+                'r', log_provider_lib.RequestLogType.REQUEST,
+                str(tmp_path / 'dest.log'), stop_event)
+        assert provider.calls[0][3] is stop_event
+
+    def test_signature_error_treated_as_not_capable(self, tmp_path,
+                                                    monkeypatch):
+        provider = _OldStyleProvider()
+
+        def _boom(func):
+            del func
+            raise ValueError('no signature for this callable')
+
+        monkeypatch.setattr(debug_utils.inspect, 'signature', _boom)
+        with mock.patch('sky.utils.debug_utils.log_provider.get_log_provider',
+                        return_value=provider):
+            # Falls back to the old 3-arg call shape instead of raising.
+            assert debug_utils._provider_copy_log_file(
+                'r', log_provider_lib.RequestLogType.REQUEST,
+                str(tmp_path / 'dest.log'), None)
+        assert len(provider.calls[0]) == 3
+
+
+# ---------------------------------------------------------------------------
+# Tests for _dump_request_id_info outcome accounting and executor discipline
+# ---------------------------------------------------------------------------
+class TestDumpRequestIdInfoOutcomes:
+    """Aggregate skip record, closing arithmetic, shared executor."""
+
+    def test_past_deadline_one_aggregate_entry(self, tmp_path, monkeypatch):
+        warnings = []
+        monkeypatch.setattr(debug_utils.logger, 'warning',
+                            lambda *a, **k: warnings.append(a))
+        errors: List[Dict[str, Any]] = []
+        outcomes = debug_utils._dump_request_id_info({'r1', 'r2', 'r3'},
+                                                     str(tmp_path),
+                                                     errors,
+                                                     deadline=time.monotonic() -
+                                                     1)
+
+        # Exactly ONE aggregate entry, not one identical record per
+        # skipped request.
+        skips = [
+            e for e in errors if e['resource'] == 'requests_deadline_skips'
+        ]
+        assert len(skips) == 1
+        skip = skips[0]
+        assert skip['component'] == 'requests'
+        assert skip['error'].startswith(
+            'Skipped: overall debug-dump deadline exceeded.')
+        assert skip['skipped_count'] == 3
+        assert skip['first_skipped_id'] == 'r1'
+        assert skip['budget_exhausted_at'] is not None
+        # Exactly one WARNING, logged at the first per-request skip.
+        deadline_warnings = [w for w in warnings if 'deadline exceeded' in w[0]]
+        assert len(deadline_warnings) == 1
+        # Outcomes arithmetic closes.
+        assert outcomes['in_scope'] == 3
+        assert outcomes['attempted'] == 0
+        assert outcomes['skipped_deadline'] == 3
+        assert (outcomes['in_scope'] == outcomes['attempted'] +
+                outcomes['skipped_deadline'])
+        assert outcomes['skipped_request_ids'] == ['r1', 'r2', 'r3']
+        # No request dir is created for a skipped request.
+        assert not (tmp_path / 'requests' / 'r1').exists()
+
+    def test_outcomes_arithmetic_closes(self, tmp_path):
+
+        def _fake_get(request_id):
+            if request_id == 'r-ok':
+                return _make_request(request_id='r-ok',
+                                     name='sky.launch',
+                                     status='SUCCEEDED')
+            if request_id == 'r-fail':
+                raise RuntimeError('DB is down')
+            return None  # r-missing
+
+        provider = mock.MagicMock()
+
+        def _fake_copy(request_id, log_type, dest_path, stop_event=None):
+            del stop_event  # unused
+            if (request_id == 'r-ok' and
+                    log_type == log_provider_lib.RequestLogType.REQUEST):
+                dest_path.write_text('log')
+                return True
+            return False
+
+        provider.copy_log_file.side_effect = _fake_copy
+        with mock.patch('sky.utils.debug_utils.requests_lib.get_request',
+                        side_effect=_fake_get), \
+             mock.patch(
+                 'sky.utils.debug_utils.log_provider.get_log_provider',
+                 return_value=provider):
+            errors: List[Dict[str, Any]] = []
+            outcomes = debug_utils._dump_request_id_info(
+                {'r-ok', 'r-missing', 'r-fail'}, str(tmp_path), errors)
+
+        assert outcomes['in_scope'] == 3
+        assert outcomes['attempted'] == 3
+        assert outcomes['skipped_deadline'] == 0
+        assert outcomes['info_written'] == 1
+        assert outcomes['not_in_db'] == 1
+        assert outcomes['db_errors'] == 1
+        assert (outcomes['attempted'] == outcomes['info_written'] +
+                outcomes['not_in_db'] + outcomes['db_errors'])
+        assert outcomes['request_log'] == {
+            'found': 1,
+            'not_found': 2,
+            'timed_out': 0
+        }
+        # request_info.json carries the per-log outcomes...
+        with open(tmp_path / 'requests' / 'r-ok' / 'request_info.json',
+                  encoding='utf-8') as f:
+            info = json.load(f)
+        assert info['logs'] == {
+            'request_log': 'found',
+            'request_debug_log': 'not_found'
+        }
+        # ...and every attempted request leaves an artifact (stub or full).
+        for req in ('r-ok', 'r-missing', 'r-fail'):
+            assert (tmp_path / 'requests' / req / 'request_info.json').exists()
+
+    def test_one_shared_executor_for_section(self, tmp_path, monkeypatch):
+        real_executor = concurrent.futures.ThreadPoolExecutor
+        constructions = []
+
+        class _CountingExecutor(real_executor):
+
+            def __init__(self, *args, **kwargs):
+                constructions.append(kwargs.get('thread_name_prefix'))
+                super().__init__(*args, **kwargs)
+
+        monkeypatch.setattr(debug_utils.concurrent.futures,
+                            'ThreadPoolExecutor', _CountingExecutor)
+        with mock.patch('sky.utils.debug_utils.requests_lib.get_request',
+                        return_value=None), \
+             mock.patch('sky.utils.debug_utils.log_provider.get_log_provider',
+                        return_value=mock.MagicMock()):
+            debug_utils._dump_request_id_info({f'r-{i}' for i in range(5)},
+                                              str(tmp_path), [])
+
+        # Exactly one executor for the whole section (previously two were
+        # created per request).
+        assert constructions == ['debug-dump-log-copy']
+
+    def test_saturated_pool_falls_back_per_op(self, tmp_path, monkeypatch):
+        """8 Event-blocked copies hold all shared workers; the next copy
+        still gets a real attempt via a fresh per-op executor."""
+        monkeypatch.setattr(debug_utils, '_REQUEST_LOG_COPY_TIMEOUT', 0.05)
+        real_executor = concurrent.futures.ThreadPoolExecutor
+        constructions = []
+
+        class _CountingExecutor(real_executor):
+
+            def __init__(self, *args, **kwargs):
+                constructions.append(kwargs.get('thread_name_prefix'))
+                super().__init__(*args, **kwargs)
+
+        monkeypatch.setattr(debug_utils.concurrent.futures,
+                            'ThreadPoolExecutor', _CountingExecutor)
+        block = threading.Event()
+        provider = mock.MagicMock()
+
+        def _fake_copy(request_id, log_type, dest_path, stop_event=None):
+            del stop_event  # ignored on purpose: see block.wait() below
+            if request_id.startswith('block'):
+                # Holds its worker until released, ignoring the stop
+                # event (an uninterruptible provider).
+                block.wait()
+                return False
+            if log_type == log_provider_lib.RequestLogType.REQUEST:
+                dest_path.write_text('fast log')
+                return True
+            return False
+
+        provider.copy_log_file.side_effect = _fake_copy
+        request_ids = {f'block-{i}' for i in range(8)} | {'fast'}
+        try:
+            with mock.patch(
+                    'sky.utils.debug_utils.requests_lib.get_request',
+                    return_value=None), \
+                 mock.patch(
+                     'sky.utils.debug_utils.log_provider.get_log_provider',
+                     return_value=provider):
+                debug_utils._dump_request_id_info(request_ids, str(tmp_path),
+                                                  [])
+        finally:
+            block.set()  # release the orphaned workers
+
+        # The fast request's log was really copied and published via the
+        # fallback executor.
+        assert (tmp_path / 'requests' / 'fast' /
+                'request.log').read_text() == 'fast log'
+        # One shared executor + one fresh fallback executor per op that
+        # found the pool saturated (8 blocked requests x 2 log types fill
+        # the 8 workers after 8 ops; the remaining 10 ops fall back, the
+        # last of which is the fast request's debug-log copy).
+        assert constructions.count('debug-dump-log-copy') == 1
+        assert constructions.count(None) == 10
+
+
+# ---------------------------------------------------------------------------
+# Tests for _iter_dump_files
+# ---------------------------------------------------------------------------
+class TestIterDumpFiles:
+    """The pre-zip size sum and zip walk prune .staging and excluded paths."""
+
+    def test_prunes_staging_and_excluded_paths(self, tmp_path):
+        dump_dir = tmp_path / 'dump'
+        r1_staging = dump_dir / 'requests' / 'r1' / '.staging'
+        r1_staging.mkdir(parents=True)
+        (r1_staging / 'request.log').write_text('partial')
+        (dump_dir / 'requests' / 'r1' / 'request.log').write_text('done')
+        (dump_dir / 'requests' / 'r2').mkdir(parents=True)
+        (dump_dir / 'requests' / 'r2' / 'request.log').write_text('quarantined')
+        excluded = {
+            os.path.abspath(str(dump_dir / 'requests' / 'r2' / 'request.log'))
+        }
+        files = list(debug_utils._iter_dump_files(str(dump_dir), excluded))
+        rel = {os.path.relpath(f, str(dump_dir)) for f in files}
+        assert rel == {os.path.join('requests', 'r1', 'request.log')}
+
+    def test_no_exclusions_keeps_everything(self, tmp_path):
+        dump_dir = tmp_path / 'dump'
+        (dump_dir / 'requests' / 'r2').mkdir(parents=True)
+        (dump_dir / 'requests' / 'r2' / 'request.log').write_text('kept')
+        files = list(debug_utils._iter_dump_files(str(dump_dir), set()))
+        assert len(files) == 1
+
+
+# ---------------------------------------------------------------------------
+# End-to-end regression: an orphaned log copy must never contradict the
+# archive (fully event-gated, no sleep-based outcomes).
+# ---------------------------------------------------------------------------
+class TestOrphanedLogCopyDump:
+    """create_debug_dump with a request-log copy that outlives its timeout.
+
+    Variant A: the copy completes right after the timeout (the stop event
+    IS the release signal) -- it must be published during reconciliation
+    and its errors.json entry annotated accordingly.
+    Variant B: the copy is still running past the (zeroed) grace -- its
+    final path must be excluded from the zip while the entry accurately
+    says timed out.
+    """
+
+    _CROSSLINK_FNS = TestOverallDeadlineDump._CROSSLINK_FNS
+    _SECTION_FNS = (
+        '_dump_server_info',
+        '_dump_kube_contexts_info',
+        '_dump_cluster_info',
+        '_dump_managed_job_info',
+    )
+
+    def _run_dump(self, tmp_path, provider):
+        with contextlib.ExitStack() as stack:
+            for fn in self._CROSSLINK_FNS:
+                stack.enter_context(mock.patch(f'sky.utils.debug_utils.{fn}'))
+            # Everything except the requests section.
+            for fn in self._SECTION_FNS:
+                stack.enter_context(mock.patch(f'sky.utils.debug_utils.{fn}'))
+            stack.enter_context(
+                mock.patch(
+                    'sky.utils.debug_utils.requests_lib'
+                    '.get_requests_with_prefix',
+                    side_effect=lambda prefix, fields=None:
+                    [mock.MagicMock(request_id=prefix)]))
+            stack.enter_context(
+                mock.patch('sky.utils.debug_utils.requests_lib.get_request',
+                           side_effect=lambda request_id: _make_request(
+                               request_id=request_id,
+                               name='sky.launch',
+                               status='RUNNING')
+                           if request_id == 'req-orphan' else None))
+            stack.enter_context(
+                mock.patch(
+                    'sky.utils.debug_utils.log_provider.get_log_provider',
+                    return_value=provider))
+            stack.enter_context(
+                mock.patch('sky.utils.debug_utils.DEBUG_DUMP_DIR',
+                           str(tmp_path / 'debug_dumps')))
+            return debug_utils.create_debug_dump(request_ids=['req-orphan'])
+
+    @staticmethod
+    def _read_json(zip_path, suffix):
+        with zipfile.ZipFile(zip_path, 'r') as zf:
+            names = zf.namelist()
+            return names, json.loads(
+                zf.read(next(n for n in names if n.endswith(suffix))))
+
+    def test_orphan_completing_within_grace_is_published(
+            self, tmp_path, monkeypatch):
+        monkeypatch.setattr(debug_utils, '_REQUEST_LOG_COPY_TIMEOUT', 0.05)
+        provider = mock.MagicMock()
+
+        def _fake_copy(request_id, log_type, dest_path, stop_event=None):
+            if (request_id != 'req-orphan' or
+                    log_type != log_provider_lib.RequestLogType.REQUEST):
+                return False
+            # Block until the timeout abandons this copy: the stop event
+            # IS the release signal, so the copy completes
+            # deterministically right after the timeout is recorded, well
+            # inside the reconciliation grace.
+            stop_event.wait()
+            dest_path.write_text('late log content')
+            return True
+
+        provider.copy_log_file.side_effect = _fake_copy
+        result = self._run_dump(tmp_path, provider)
+
+        names, errors = self._read_json(result, 'errors.json')
+        assert not any('.staging' in n for n in names)
+        request_logs = [n for n in names if n.endswith('request.log')]
+        assert len(request_logs) == 1
+        with zipfile.ZipFile(result, 'r') as zf:
+            assert zf.read(request_logs[0]) == b'late log content'
+        # The errors entry says timed out AND that the output made it in.
+        log_entries = [e for e in errors if e['resource'] == 'req-orphan/log']
+        assert len(log_entries) == 1
+        assert 'timed out' in log_entries[0]['error']
+        assert 'completed after the timeout' in log_entries[0]['error']
+        assert 'output is included' in log_entries[0]['error']
+
+    def test_orphan_still_running_past_grace_is_excluded(
+            self, tmp_path, monkeypatch):
+        monkeypatch.setattr(debug_utils, '_REQUEST_LOG_COPY_TIMEOUT', 0.05)
+        # Read at call time by the reconciler, so monkeypatching works.
+        monkeypatch.setattr(debug_utils, '_ORPHAN_GRACE_S', 0)
+        provider = mock.MagicMock()
+        private = threading.Event()
+
+        def _fake_copy(request_id, log_type, dest_path, stop_event=None):
+            del stop_event  # ignored on purpose: a hard-stalled store
+            if (request_id != 'req-orphan' or
+                    log_type != log_provider_lib.RequestLogType.REQUEST):
+                return False
+            # Holds the worker until the test releases it, ignoring the
+            # stop event (a provider that predates the parameter, or a
+            # hard-stalled store).
+            private.wait()
+            dest_path.write_text('quarantined content')
+            return True
+
+        provider.copy_log_file.side_effect = _fake_copy
+        result = self._run_dump(tmp_path, provider)
+        try:
+            names, errors = self._read_json(result, 'errors.json')
+            assert not any('.staging' in n for n in names)
+            assert not any(n.endswith('request.log') for n in names)
+            log_entries = [
+                e for e in errors if e['resource'] == 'req-orphan/log'
+            ]
+            assert len(log_entries) == 1
+            assert 'timed out' in log_entries[0]['error']
+            assert 'completed after the timeout' not in log_entries[0]['error']
+            # The summary did not count the quarantined log as found.
+            _, summary = self._read_json(result, 'summary.json')
+            assert summary['collected']['request_logs_found'] == 0
+            assert summary['collected']['request_logs_missing'] >= 1
+        finally:
+            private.set()  # release the orphaned worker for thread hygiene

--- a/tests/unit_tests/test_sky/utils/test_debug_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_debug_utils.py
@@ -4947,6 +4947,63 @@ class TestDumpRequestIdInfoOutcomes:
         # No request dir is created for a skipped request.
         assert not (tmp_path / 'requests' / 'r1').exists()
 
+    def test_skipped_id_list_only_in_manifest(self, tmp_path):
+        """The full skipped-ID list lives in ids_manifest.json only;
+        summary.json's section_outcomes keeps the count (skipped_deadline)
+        so the summary stays scannable on a dump with many deadline
+        skips."""
+        real_dump = debug_utils._dump_request_id_info
+        past_deadline = time.monotonic() - 1
+
+        def _dump_with_expired_budget(request_ids,
+                                      dump_dir,
+                                      errors=None,
+                                      deadline=None,
+                                      orphans=None):
+            # The section-level check sees the outer (None) deadline, so
+            # the section runs; every request then hits the injected past
+            # deadline inside the loop and is skipped.
+            return real_dump(request_ids,
+                             dump_dir,
+                             errors=errors,
+                             deadline=past_deadline,
+                             orphans=orphans)
+
+        with contextlib.ExitStack() as stack:
+            for fn in TestOverallDeadlineDump._CROSSLINK_FNS:
+                stack.enter_context(mock.patch(f'sky.utils.debug_utils.{fn}'))
+            for fn in ('_dump_server_info', '_dump_kube_contexts_info',
+                       '_dump_cluster_info', '_dump_managed_job_info'):
+                stack.enter_context(mock.patch(f'sky.utils.debug_utils.{fn}'))
+            stack.enter_context(
+                mock.patch('sky.utils.debug_utils._dump_request_id_info',
+                           side_effect=_dump_with_expired_budget))
+            stack.enter_context(
+                mock.patch(
+                    'sky.utils.debug_utils.requests_lib'
+                    '.get_requests_with_prefix',
+                    side_effect=lambda prefix, fields=None:
+                    [mock.MagicMock(request_id=prefix)]))
+            stack.enter_context(
+                mock.patch('sky.utils.debug_utils.DEBUG_DUMP_DIR',
+                           str(tmp_path / 'debug_dumps')))
+            result = debug_utils.create_debug_dump(
+                request_ids=['req-1', 'req-2'])
+
+        with zipfile.ZipFile(result, 'r') as zf:
+            names = zf.namelist()
+            summary = json.loads(
+                zf.read(next(n for n in names if n.endswith('summary.json'))))
+            manifest = json.loads(
+                zf.read(
+                    next(n for n in names if n.endswith('ids_manifest.json'))))
+        skipped = manifest['skipped_request_ids']
+        assert 'req-1' in skipped and 'req-2' in skipped
+        request_outcomes = summary['section_outcomes']['request_ids']
+        assert request_outcomes['skipped_deadline'] == len(skipped)
+        # The ID list itself must not be re-inlined into the summary.
+        assert 'skipped_request_ids' not in request_outcomes
+
     def test_outcomes_arithmetic_closes(self, tmp_path):
 
         def _fake_get(request_id):


### PR DESCRIPTION
## Summary

Two problems in `sky debug-dump`, both evidenced on a dump taken from a production API server with many stale unfinished requests:

**1. Timed-out log copies kept writing into the dump tree after their timeout was recorded.**
Each request-log copy is bounded by a wall-clock timeout, but the timeout only stops the *dump* waiting — the worker thread keeps running. In the evidenced dump, `errors.json` recorded one request's logs as "timed out … and skipped" while the request's `request.log` was present in the zip: the abandoned worker finished the copy *after* the error was written, so the error file directly contradicted the archive. Structurally, an orphan mid-copy while the zip walk reads the file yields a truncated file in the archive; a file completed after `os.walk` passed its directory never enters the zip; and the orphan's exception sits on a future nothing ever reads, so late failures vanish. Each copy also built and tore down its own single-worker `ThreadPoolExecutor` (two per request — tens of thousands of create/destroy cycles on a large dump), and the underlying copy was an uninterruptible `shutil.copy2`, so a hard-stalled log store could pin a thread indefinitely.

**2. errors.json was bloated where it did not matter and silent where it did.**
Of its 2316 entries, 2313 were the identical string `Skipped: overall debug-dump deadline exceeded.` (2310 of them one per request), burying the 3 entries with real diagnostic content; the whole array was then duplicated verbatim inside `summary.json`, which — with the inlined ID lists — made it ~983KB of which roughly 600 bytes were actual summary. Meanwhile, outcomes that *lost* data produced no record at all: 38 cross-linked requests whose DB rows were gone left only a debug-level log line and an empty directory the zip silently drops (zipfile stores no directory entries), and 67% of dumped requests had no `request.log`, recorded nowhere except a debug-level log line.

### Commit 1 — quarantine orphaned writes and reconcile them into errors.json

- Request-log copies now land in `requests/<id>/.staging/` and reach their final name only via an idempotent `os.replace` (`_publish_staged_log`) after the provider copy completed **and** the copy was not abandoned (worker-side publish gate). The zip walk and the pre-zip size sum prune `.staging` directories.
- A new `_reconcile_timed_out_ops` runs after collection but **before** `errors.json` is written: within a fixed 5s grace, an orphan that completed is published from staging and its error record annotated ("…completed after the timeout; its output is included"); an orphan that raised gets a structured `late_traceback` field plus a WARNING; an orphan still running keeps its accurate timed-out record, gets a logging done-callback, and is marked `excluded_from_archive` — its final path goes into a fixed pre-walk exclusion set, so even a stalled rename that completes after reconciliation cannot land in the archive. `errors.json` can no longer contradict the zip.
- The two-per-request executors collapse into one shared 8-worker pool for the whole requests section, guarded by a free-slot semaphore (released via a done-callback, which fires on completion, exception, and cancellation). A saturated pool — all workers held by abandoned copies — falls back to a fresh per-op executor so no op is recorded "timed out" without a real attempt, and `future.cancel()` on timeout keeps queued-not-started work from running late.
- The default `LogProvider.copy_log_file` is now a 1MB-chunked copy that checks an optional `stop_event` before starting and between reads and discards its partial output on stop (`shutil.copystat` keeps `copy2`'s mtime parity), so an abandoned cooperating copy terminates at its next read. The kwarg is optional (default `None` = previous behavior) and is only forwarded to providers whose `copy_log_file` accepts it, so providers that predate the parameter keep working unchanged — they are simply staged and quarantined by the dump layer like any other slow copy.
- The 5s grace is deliberately **not** clamped to the remaining dump budget: orphans exist exactly when the budget is already exhausted, so clamping would zero the grace and make reconciliation dead code (the zip step already runs past the deadline). Reviewers should ratify this choice.

### Commit 2 — record skipped/missing request outcomes and de-bloat the records

- A deadline-exhausted requests loop now writes exactly **one** aggregate `errors.json` entry (component `requests`, resource `requests_deadline_skips`, the canonical `Skipped: overall debug-dump deadline exceeded.` prefix plus `skipped_count`, `first_skipped_id`, and `budget_exhausted_at` — the only entry carrying a timestamp) and logs a single WARNING at the first per-request skip. The full sorted skipped list lives in `ids_manifest.json`.
- A request whose DB row is gone gets an `errors.json` entry (exception-path shape, no traceback) **and** a stub `request_info.json` (`{request_id, error}`); the request directory is created lazily at first write, so no empty directory is ever created and every attempted request leaves an artifact the zip contains.
- Every `request_info.json` carries a `logs` key with the per-log outcome (`found` / `not_found` / `copy_timed_out`); `summary.json`'s `collected` section carries `request_logs_found` / `request_logs_missing` (= `not_found` + `copy_timed_out`; likewise for debug logs); `section_outcomes.requests` closes arithmetically (`in_scope = attempted + skipped_deadline`; `attempted = info_written + not_in_db + db_errors`), so every gap between the summary counts and the on-disk artifacts is explainable from the dump alone.
- `summary.json` no longer inlines the errors array or the ID lists (it keeps the counts and gains `errors_count` plus file pointers); the sorted request/cluster/job ID lists and `skipped_request_ids` live in a new `ids_manifest.json`. **Shape change for external consumers:** tooling that read `summary.json`'s `collected.request_ids` / inlined `errors` must switch to `ids_manifest.json` / `errors.json`. No in-repo consumer parses them (verified: dashboard and CLI don't; the one smoke-test reader is updated here).
- Requests now iterate in sorted order, which makes the dump deterministic and gives the aggregate entry's `first_skipped_id` a well-defined meaning.

### Deliberate partial resolution — missing-log attribution

What is recorded: the per-request outcome taxonomy (`found` / `not_found` / `copy_timed_out`) and the summary coverage counts. What is **not** recorded: the per-cause attribution of a missing log (restart-wiped vs. fetch failure vs. never-written vs. timeout). That is not derivable at the dump layer from the provider's boolean `copy_log_file` API — it would require provider-side cause reporting. `request_info.json`'s `status` and `created_at` remain the correlation source for investigating a `not_found`.

### Residuals (known, not addressed here)

- The `kubernetes_contexts` section deliberately keeps partial per-context directories when it times out (its per-context writes are final-name by design); the reconciler still annotates/logs that section's late outcomes generically, but its partial output is not quarantined.
- Section-level skip records (one per section, at most a handful) are unchanged — only the per-request flood is aggregated.
- `request_logs_missing` counts a late-published orphan log as missing (the copy did not return in time); `errors.json`'s "completed after the timeout; its output is included" annotation is the authoritative resolution.

Note: this change touches `sky/utils/debug_utils.py` in the same regions as other in-flight debug-dump changes, so expect (easily resolvable) conflicts there.

## Tested

- Unit tests: `tests/unit_tests/test_sky/utils/test_debug_utils.py` and `tests/unit_tests/test_sky/server/requests/test_log_provider.py`, including new event-gated end-to-end regressions of the orphan scenario through `create_debug_dump` (no sleep-based outcomes): a copy that completes right after its timeout is published and annotated; a copy still running past a zeroed grace is excluded from the zip with an accurate timed-out record and no `.staging` entries.
- Real-server e2e: started a local API server running this branch (verified via the produced dump's contents), seeded requests, ran `sky debug-dump --recent-minutes 5`, and inspected the zip: `ids_manifest.json` present with sorted IDs, `summary.json` scannable with coverage counts and closing arithmetic, no `.staging` entries, every collected request ID has a `request_info.json`; a second run with one seeded request's log copy tripping the per-copy timeout produced the "completed after the timeout; its output is included" annotation with the log present in the zip — no contradiction.
- Format/lint: `bash format.sh --files …` (yapf/isort/mypy/pylint) clean for the touched files.
- `tests/smoke_tests/test_cli.py::test_debug_dump_cluster` updated for the `ids_manifest.json` move (needs cloud; exercised via `/smoke-test` on the PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
