### PR TITLE
[Core] Stop debug-dump section starvation: shared section budgets, bulk DB fetches, relevance-ordered truncation

### DIFF
--- a/sky/utils/debug_utils.py
+++ b/sky/utils/debug_utils.py
@@ -290,6 +290,10 @@ _REQUEST_BODY_ALLOWLIST: Dict[str, Tuple[str, ...]] = {
 SYSTEM_REQUEST_IDS = [d.id for d in daemons.INTERNAL_REQUEST_DAEMONS
                      ] + [server_constants.ON_BOOT_CHECK_REQUEST_ID]
 
+# Set form of SYSTEM_REQUEST_IDS for the membership check in the request
+# dump ordering (see _dump_request_id_info).
+_SYSTEM_REQUEST_ID_SET = frozenset(SYSTEM_REQUEST_IDS)
+
 # Request names for managed job mutations (excludes read-only queue).
 # Used by both _get_requests_from_managed_jobs and
 # _get_managed_jobs_from_requests.
@@ -324,38 +328,132 @@ class DebugDumpContext(TypedDict):
     timed_out_ops: List[Dict[str, Any]]
 
 
-def _get_requests_from_clusters(debug_dump_context: DebugDumpContext) -> None:
-    """Get all request IDs associated with the given clusters."""
+# Chunk size for bulk request-metadata queries (one IN query per chunk).
+# Kept under the 999 bound-parameter limit of older SQLite builds, while
+# turning thousands of per-ID locked get_request round trips into a handful
+# of queries.
+_REQUEST_DB_CHUNK_SIZE = 500
+
+# Wall-clock cap for one bulk request-metadata query. Normally milliseconds;
+# the cap exists so a single hung DB call -- precisely the failure mode a
+# debug dump investigates -- cannot stall the dump unbounded. Clamped to the
+# remaining budget by _bounded_timeout at each call site.
+_REQUEST_DB_QUERY_TIMEOUT = 60
+
+
+def _get_requests_bulk(
+    request_ids: List[str],
+    fields: Optional[List[str]] = None,
+    *,
+    component: str,
+    resource: str,
+    deadline: Optional[float] = None,
+    errors: Optional[List[Dict[str, str]]] = None,
+    orphans: Optional[List[Dict[str, Any]]] = None,
+) -> List[requests_lib.Request]:
+    """Bulk-fetch request rows for ``request_ids`` via chunked IN queries.
+
+    Replaces one synchronous locked get_request DB round trip per ID (each
+    acquiring a per-request filelock and running its own transaction), which
+    made cross-linking and the requests section issue tens of thousands of
+    sequential per-ID calls on large populations. Each chunk is bounded by
+    _run_with_deadline; on a timeout the fetch stops and returns what it has
+    (best-effort, like the rest of the dump). Other per-chunk failures are
+    recorded and skipped, mirroring the per-ID error handling this replaces.
+
+    Note these bulk reads do not take get_request's per-request filelock, so
+    a row can be a slightly stale (but transaction-consistent) snapshot while
+    a concurrent update is in flight. That is acceptable for a diagnostic
+    dump, and precedented: _get_requests_from_clusters already used
+    get_request_tasks for the same purpose.
+    """
+    rows: List[requests_lib.Request] = []
+    for index, start in enumerate(
+            range(0, len(request_ids), _REQUEST_DB_CHUNK_SIZE)):
+        chunk = request_ids[start:start + _REQUEST_DB_CHUNK_SIZE]
+        try:
+            ok, result = _run_with_deadline(
+                functools.partial(
+                    requests_lib.get_request_tasks,
+                    requests_lib.RequestTaskFilter(request_ids=chunk,
+                                                   fields=fields)),
+                _bounded_timeout(_REQUEST_DB_QUERY_TIMEOUT, deadline),
+                component=component,
+                resource=f'{resource}/{index}',
+                errors=errors,
+                orphans=orphans)
+            if not ok:
+                # Hung query: later chunks would only pile on more abandoned
+                # workers. Keep what we have; the timeout is already recorded.
+                break
+            if result:
+                rows.extend(result)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning(f'Failed to fetch requests ({resource}/{index}): '
+                           f'{e}')
+            if errors is not None:
+                errors.append({
+                    'component': component,
+                    'resource': f'{resource}/{index}',
+                    'error': str(e),
+                    'traceback': _full_traceback()
+                })
+    return rows
+
+
+def _get_requests_from_clusters(debug_dump_context: DebugDumpContext,
+                                deadline: Optional[float] = None) -> None:
+    """Get all request IDs associated with the given clusters.
+
+    The cluster names are queried in chunks (one cluster_names IN query per
+    chunk) instead of one DB round trip per cluster -- a server with hundreds
+    of clusters previously paid for hundreds of sequential queries here
+    before any section ran.
+    """
     if not debug_dump_context['cluster_names']:
         return
-    logger.debug(
-        f'Getting requests for {len(debug_dump_context["cluster_names"])} '
-        f'clusters')
-    for cluster_name in debug_dump_context['cluster_names']:
+    cluster_names = sorted(debug_dump_context['cluster_names'])
+    logger.debug(f'Getting requests for {len(cluster_names)} clusters')
+    new_ids: Set[str] = set()
+    for index, start in enumerate(
+            range(0, len(cluster_names), _REQUEST_DB_CHUNK_SIZE)):
+        chunk = cluster_names[start:start + _REQUEST_DB_CHUNK_SIZE]
         try:
-            requests = requests_lib.get_request_tasks(
-                requests_lib.RequestTaskFilter(cluster_names=[cluster_name],
-                                               fields=['request_id']))
-            new_ids = {request.request_id for request in requests}
-            if new_ids:
-                logger.debug(f'Cross-link: cluster {cluster_name!r} -> '
-                             f'{len(new_ids)} requests: {sorted(new_ids)}')
-            # Only tag IDs that weren't already in the context. Otherwise
-            # a user-seeded or recent-context request would inherit the
-            # via_cluster restriction and get skipped in
-            # _get_clusters_from_requests.
-            newly_added = new_ids - debug_dump_context['request_ids']
-            debug_dump_context['request_ids'] |= new_ids
-            debug_dump_context['request_ids_via_cluster'] |= newly_added
+            ok, requests = _run_with_deadline(
+                functools.partial(
+                    requests_lib.get_request_tasks,
+                    requests_lib.RequestTaskFilter(cluster_names=chunk,
+                                                   fields=['request_id'])),
+                _bounded_timeout(_REQUEST_DB_QUERY_TIMEOUT, deadline),
+                component='cross_link',
+                resource=f'requests_from_clusters/{index}',
+                errors=debug_dump_context['errors'],
+                orphans=debug_dump_context['timed_out_ops'])
+            if not ok:
+                # Hung query: later chunks would only time out too. The
+                # timeout is already recorded above.
+                break
+            if requests:
+                new_ids.update(request.request_id for request in requests)
         except Exception as e:  # pylint: disable=broad-except
-            logger.warning(f'Failed to get requests for cluster '
-                           f'{cluster_name}: {e}')
+            logger.warning(f'Failed to get requests for clusters '
+                           f'({index}): {e}')
             debug_dump_context['errors'].append({
                 'component': 'cross_link',
-                'resource': f'requests_from_cluster/{cluster_name}',
+                'resource': f'requests_from_clusters/{index}',
                 'error': str(e),
                 'traceback': _full_traceback()
             })
+    if new_ids:
+        logger.debug(f'Cross-link: {len(cluster_names)} clusters -> '
+                     f'{len(new_ids)} requests')
+    # Only tag IDs that weren't already in the context. Otherwise
+    # a user-seeded or recent-context request would inherit the
+    # via_cluster restriction and get skipped in
+    # _get_clusters_from_requests.
+    newly_added = new_ids - debug_dump_context['request_ids']
+    debug_dump_context['request_ids'] |= new_ids
+    debug_dump_context['request_ids_via_cluster'] |= newly_added
 
 
 def _get_requests_from_managed_jobs(
@@ -491,7 +589,8 @@ def _get_requests_from_managed_jobs(
         })
 
 
-def _get_clusters_from_requests(debug_dump_context: DebugDumpContext) -> None:
+def _get_clusters_from_requests(debug_dump_context: DebugDumpContext,
+                                deadline: Optional[float] = None) -> None:
     """Get cluster names from the given request IDs.
 
     Skips requests that were themselves added because they reference a
@@ -507,27 +606,25 @@ def _get_clusters_from_requests(debug_dump_context: DebugDumpContext) -> None:
     if not request_ids:
         return
     logger.debug(f'Getting clusters for {len(request_ids)} requests')
-    for request_id in request_ids:
-        try:
-            request = requests_lib.get_request(request_id,
-                                               fields=['cluster_name'])
-            if request is not None and request.cluster_name is not None:
-                logger.debug(f'Cross-link: request {request_id} -> '
-                             f'cluster {request.cluster_name!r}')
-                debug_dump_context['cluster_names'].add(request.cluster_name)
-        except Exception as e:  # pylint: disable=broad-except
-            logger.warning(f'Failed to get cluster for request '
-                           f'{request_id}: {e}')
-            debug_dump_context['errors'].append({
-                'component': 'cross_link',
-                'resource': f'clusters_from_request/{request_id}',
-                'error': str(e),
-                'traceback': _full_traceback()
-            })
+    # One bulk pass instead of a get_request round trip per ID: on a server
+    # with thousands of requests, the per-ID DB calls made this helper alone
+    # take tens of seconds before any section ran.
+    requests = _get_requests_bulk(sorted(request_ids),
+                                  fields=['request_id', 'cluster_name'],
+                                  component='cross_link',
+                                  resource='clusters_from_requests',
+                                  deadline=deadline,
+                                  errors=debug_dump_context['errors'],
+                                  orphans=debug_dump_context['timed_out_ops'])
+    for request in requests:
+        if request.cluster_name is not None:
+            logger.debug(f'Cross-link: request {request.request_id} -> '
+                         f'cluster {request.cluster_name!r}')
+            debug_dump_context['cluster_names'].add(request.cluster_name)
 
 
-def _get_managed_jobs_from_requests(
-        debug_dump_context: DebugDumpContext) -> None:
+def _get_managed_jobs_from_requests(debug_dump_context: DebugDumpContext,
+                                    deadline: Optional[float] = None) -> None:
     """Extract managed job IDs from request bodies.
 
     If any request in the context is a managed job request (launch, cancel,
@@ -554,53 +651,51 @@ def _get_managed_jobs_from_requests(
         return
     logger.debug(f'Getting managed jobs for {len(request_ids)} requests')
 
-    for request_id in request_ids:
-        try:
-            request = requests_lib.get_request(
-                request_id, fields=['name', 'request_body', 'return_value'])
-            if (request is None or
-                    request.name not in _MANAGED_JOB_REQUEST_NAMES):
-                continue
-            body = request.request_body
-            if body is not None:
-                job_id = getattr(body, 'job_id', None)
-                if job_id is not None:
-                    logger.debug(f'Cross-link: request {request_id} -> '
-                                 f'managed job {job_id} via body.job_id')
-                    debug_dump_context['managed_job_ids'].add(job_id)
-                job_ids = getattr(body, 'job_ids', None)
-                if job_ids is not None:
-                    logger.debug(f'Cross-link: request {request_id} -> '
-                                 f'managed jobs {job_ids} via body.job_ids')
-                    debug_dump_context['managed_job_ids'].update(job_ids)
-            # For jobs.launch, the job ID is in the response, not the
-            # request body.
-            jobs_launch_name = (server_constants.REQUEST_NAME_PREFIX +
-                                request_names.RequestName.JOBS_LAUNCH.value)
-            if request.name == jobs_launch_name:
-                rv = request.return_value
-                if isinstance(rv, dict):
-                    resp_job_id = rv.get('job_id')
-                    if isinstance(resp_job_id, list):
-                        debug_dump_context['managed_job_ids'].update(
-                            resp_job_id)
-                        logger.debug(f'Linked request {request_id} '
-                                     f'to managed jobs {resp_job_id} '
-                                     f'via return_value')
-                    elif resp_job_id is not None:
-                        debug_dump_context['managed_job_ids'].add(resp_job_id)
-                        logger.debug(f'Linked request {request_id} '
-                                     f'to managed job {resp_job_id} '
-                                     f'via return_value')
-        except Exception as e:  # pylint: disable=broad-except
-            logger.warning(f'Failed to get managed job info for '
-                           f'request {request_id}: {e}')
-            debug_dump_context['errors'].append({
-                'component': 'cross_link',
-                'resource': f'managed_jobs_from_request/{request_id}',
-                'error': str(e),
-                'traceback': _full_traceback()
-            })
+    # One bulk pass instead of a get_request round trip per ID (see
+    # _get_requests_bulk).
+    requests = _get_requests_bulk(
+        sorted(request_ids),
+        fields=['request_id', 'name', 'request_body', 'return_value'],
+        component='cross_link',
+        resource='managed_jobs_from_requests',
+        deadline=deadline,
+        errors=debug_dump_context['errors'],
+        orphans=debug_dump_context['timed_out_ops'])
+
+    for request in requests:
+        if request.name not in _MANAGED_JOB_REQUEST_NAMES:
+            continue
+        request_id = request.request_id
+        body = request.request_body
+        if body is not None:
+            job_id = getattr(body, 'job_id', None)
+            if job_id is not None:
+                logger.debug(f'Cross-link: request {request_id} -> '
+                             f'managed job {job_id} via body.job_id')
+                debug_dump_context['managed_job_ids'].add(job_id)
+            job_ids = getattr(body, 'job_ids', None)
+            if job_ids is not None:
+                logger.debug(f'Cross-link: request {request_id} -> '
+                             f'managed jobs {job_ids} via body.job_ids')
+                debug_dump_context['managed_job_ids'].update(job_ids)
+        # For jobs.launch, the job ID is in the response, not the
+        # request body.
+        jobs_launch_name = (server_constants.REQUEST_NAME_PREFIX +
+                            request_names.RequestName.JOBS_LAUNCH.value)
+        if request.name == jobs_launch_name:
+            rv = request.return_value
+            if isinstance(rv, dict):
+                resp_job_id = rv.get('job_id')
+                if isinstance(resp_job_id, list):
+                    debug_dump_context['managed_job_ids'].update(resp_job_id)
+                    logger.debug(f'Linked request {request_id} '
+                                 f'to managed jobs {resp_job_id} '
+                                 f'via return_value')
+                elif resp_job_id is not None:
+                    debug_dump_context['managed_job_ids'].add(resp_job_id)
+                    logger.debug(f'Linked request {request_id} '
+                                 f'to managed job {resp_job_id} '
+                                 f'via return_value')
 
 
 def _managed_job_cluster_names_from_records(
@@ -1059,12 +1154,13 @@ def _copy_request_log_file(request_id: str, request_dir: str,
 _REQUEST_LOG_COPY_TIMEOUT = 30
 
 
-def _dump_request_id_info(
-        request_ids: Set[str],
-        dump_dir: str,
-        errors: Optional[List[Dict[str, str]]] = None,
-        deadline: Optional[float] = None,
-        orphans: Optional[List[Dict[str, Any]]] = None) -> None:
+def _dump_request_id_info(request_ids: Set[str],
+                          dump_dir: str,
+                          errors: Optional[List[Dict[str, str]]] = None,
+                          deadline: Optional[float] = None,
+                          orphans: Optional[List[Dict[str, Any]]] = None,
+                          cross_linked_request_ids: Optional[Set[str]] = None,
+                          overall_deadline: Optional[float] = None) -> None:
     """Collect request logs and metadata.
 
     ``deadline`` (absolute monotonic) bounds the section two ways: each
@@ -1072,7 +1168,24 @@ def _dump_request_id_info(
     long-running request's still-streaming log can't dominate), and once the
     budget is gone we stop starting new requests and skip the rest -- so the
     dump still zips what it gathered. Per-request wall-clock is written to
-    ``requests/_timings.json``.
+    ``requests/_timings.json``. ``overall_deadline`` is the dump-level budget
+    the section's cap was carved from: when the section cap expires while the
+    overall budget still has time, the per-request skip records blame the
+    section's share (the later sections are still running); when the overall
+    budget is gone too, they keep blaming the overall deadline.
+
+    Metadata is bulk-fetched in chunked IN queries (see _get_requests_bulk)
+    rather than one locked get_request round trip per request -- those
+    per-ID DB calls dominated the section on servers with thousands of
+    requests. Iteration order is deterministic and relevance-first:
+    always-include system daemons, then user-seeded / recent-context
+    requests, then requests added by cross-link expansion
+    (``cross_linked_request_ids``, i.e. request_ids_via_job |
+    request_ids_via_cluster), each group newest first. A deadline-truncated
+    partial therefore keeps the requests most likely to explain the incident
+    -- hash-order iteration previously spent the budget on months-old dead
+    rows while dropping requests launched seconds before the dump, and even
+    dropped some of the 'always include' system daemons.
     """
     if not request_ids:
         logger.debug('No requests to dump')
@@ -1083,133 +1196,229 @@ def _dump_request_id_info(
     requests_dir = os.path.join(dump_dir, 'requests')
     os.makedirs(requests_dir, exist_ok=True)
 
+    # Order the IDs before dumping anything: a light bulk pass over
+    # (request_id, created_at) gives every ID a recency key, so the dump
+    # order below is the deterministic relevance order from the docstring
+    # instead of Python set-hash order.
+    order_rows = _get_requests_bulk(sorted(request_ids),
+                                    fields=['request_id', 'created_at'],
+                                    component='requests',
+                                    resource='requests_order',
+                                    deadline=deadline,
+                                    errors=errors,
+                                    orphans=orphans)
+    created_at_by_id = {row.request_id: row.created_at for row in order_rows}
+    cross_linked = cross_linked_request_ids or set()
+
+    def _dump_order(request_id: str) -> Tuple[int, float, str]:
+        """Relevance sort key: tier, then newest first, then ID."""
+        if request_id in _SYSTEM_REQUEST_ID_SET:
+            tier = 0
+        elif request_id in cross_linked:
+            tier = 2
+        else:
+            tier = 1
+        # IDs without a row (not in the DB, or unfetched after a failed
+        # batch) sort last within their tier, like the oldest requests.
+        return (tier, -(created_at_by_id.get(request_id) or 0.0), request_id)
+
+    ordered_ids = sorted(request_ids, key=_dump_order)
+
     timings: List[Dict[str, Any]] = []
-    for request_id in request_ids:
-        if _deadline_exceeded(deadline):
-            if errors is not None:
-                errors.append({
-                    'component': 'requests',
-                    'resource': request_id,
-                    'error': 'Skipped: overall debug-dump deadline exceeded.',
-                })
-            continue
-        request_start = time.monotonic()
-        request_dir = os.path.join(requests_dir, request_id)
-        os.makedirs(request_dir, exist_ok=True)
+    # Full metadata is fetched one chunk at a time rather than all up front:
+    # decoded request bodies can be large, so holding every row at once
+    # would spike the dump's memory footprint (the per-request fetch this
+    # replaces kept peak memory at a single row).
+    fetch_ok = True
+    for chunk_start in range(0, len(ordered_ids), _REQUEST_DB_CHUNK_SIZE):
+        chunk = ordered_ids[chunk_start:chunk_start + _REQUEST_DB_CHUNK_SIZE]
+        request_rows: Dict[str, Any] = {}
+        # Whether this chunk's metadata query completed. Members of a chunk
+        # that timed out (or was never fetched after an earlier timeout) are
+        # 'metadata not fetched', not 'not found in DB' -- the distinction
+        # matters when diagnosing the dump itself.
+        chunk_fetched = False
+        if fetch_ok and not _deadline_exceeded(deadline):
+            try:
+                ok, rows = _run_with_deadline(
+                    functools.partial(
+                        requests_lib.get_request_tasks,
+                        requests_lib.RequestTaskFilter(request_ids=chunk)),
+                    _bounded_timeout(_REQUEST_DB_QUERY_TIMEOUT, deadline),
+                    component='requests',
+                    resource=(f'requests_metadata/'
+                              f'{chunk_start // _REQUEST_DB_CHUNK_SIZE}'),
+                    errors=errors,
+                    orphans=orphans)
+                if ok:
+                    chunk_fetched = True
+                    if rows:
+                        request_rows = {row.request_id: row for row in rows}
+                else:
+                    # Hung query -- a DB call that never returns is exactly
+                    # what a debug dump investigates. Stop fetching (later
+                    # chunks would only time out too); keep iterating so the
+                    # remaining requests still get their skip records and
+                    # log copies. The timeout is already recorded above.
+                    fetch_ok = False
+            except Exception as e:  # pylint: disable=broad-except
+                logger.warning(f'Failed to fetch request metadata: {e}')
+                if errors is not None:
+                    errors.append({
+                        'component': 'requests',
+                        'resource':
+                            (f'requests_metadata/'
+                             f'{chunk_start // _REQUEST_DB_CHUNK_SIZE}'),
+                        'error': str(e),
+                        'traceback': _full_traceback()
+                    })
+        for request_id in chunk:
+            if _deadline_exceeded(deadline):
+                if errors is not None:
+                    # The section cap expired. Which budget to blame: when the
+                    # overall deadline still has time left, the later sections
+                    # are still running and this skip is the section's own
+                    # share running out; when the overall budget is gone too
+                    # (an earlier section consumed nearly everything), the
+                    # skip is the overall deadline's fault.
+                    if (overall_deadline is not None and
+                            not _deadline_exceeded(overall_deadline)):
+                        error_text = ('Skipped: request_ids section budget '
+                                      'exceeded.')
+                    else:
+                        error_text = ('Skipped: overall debug-dump deadline '
+                                      'exceeded.')
+                    errors.append({
+                        'component': 'requests',
+                        'resource': request_id,
+                        'error': error_text,
+                    })
+                continue
+            request_start = time.monotonic()
+            request_dir = os.path.join(requests_dir, request_id)
+            os.makedirs(request_dir, exist_ok=True)
 
-        # Get request metadata from DB
-        try:
-            request = requests_lib.get_request(request_id)
-            if request is not None:
-                request_info: Dict[str, Any] = {
-                    'request_id': request.request_id,
-                    'name': request.name,
-                    'status': request.status.value if request.status else None,
-                    'created_at': request.created_at,
-                    'created_at_human': debug_dump_helpers.epoch_to_human(
-                        request.created_at),
-                    'finished_at': request.finished_at,
-                    'finished_at_human': debug_dump_helpers.epoch_to_human(
-                        request.finished_at),
-                    'cluster_name': request.cluster_name,
-                    'user_id': request.user_id,
-                    'status_msg': request.status_msg,
-                    'schedule_type': (request.schedule_type.value
-                                      if request.schedule_type else None),
-                    'request_body': _sanitize_request_body(request),
-                }
+            # Request metadata, bulk-fetched per chunk above.
+            request = request_rows.get(request_id)
+            try:
+                if request is not None:
+                    request_info: Dict[str, Any] = {
+                        'request_id': request.request_id,
+                        'name': request.name,
+                        'status': request.status.value
+                                  if request.status else None,
+                        'created_at': request.created_at,
+                        'created_at_human': debug_dump_helpers.epoch_to_human(
+                            request.created_at),
+                        'finished_at': request.finished_at,
+                        'finished_at_human': debug_dump_helpers.epoch_to_human(
+                            request.finished_at),
+                        'cluster_name': request.cluster_name,
+                        'user_id': request.user_id,
+                        'status_msg': request.status_msg,
+                        'schedule_type': (request.schedule_type.value
+                                          if request.schedule_type else None),
+                        'request_body': _sanitize_request_body(request),
+                    }
 
-                # Include error info if present
-                try:
-                    error = request.get_error()
-                    if error:
-                        request_info['error'] = {
-                            'type': error.get('type'),
-                            'message': error.get('message'),
-                        }
-                except Exception:  # pylint: disable=broad-except
-                    pass
+                    # Include error info if present
+                    try:
+                        error = request.get_error()
+                        if error:
+                            request_info['error'] = {
+                                'type': error.get('type'),
+                                'message': error.get('message'),
+                            }
+                    except Exception:  # pylint: disable=broad-except
+                        pass
 
-                request_info_path = os.path.join(request_dir,
-                                                 'request_info.json')
-                with open(request_info_path, 'w', encoding='utf-8') as f:
-                    json.dump(request_info, f, indent=2, default=str)
-                logger.debug(
-                    f'Dumped request {request_id} '
-                    f'(name={request.name}, '
-                    f'status='
-                    f'{request.status.value if request.status else None})')
-            else:
-                logger.debug(f'Request {request_id} not found in DB')
-        except Exception as e:  # pylint: disable=broad-except
-            logger.warning(f'Failed to get info for request {request_id}: {e}')
-            if errors is not None:
-                errors.append({
-                    'component': 'requests',
-                    'resource': request_id,
-                    'error': str(e),
-                    'traceback': _full_traceback()
-                })
+                    request_info_path = os.path.join(request_dir,
+                                                     'request_info.json')
+                    with open(request_info_path, 'w', encoding='utf-8') as f:
+                        json.dump(request_info, f, indent=2, default=str)
+                    logger.debug(
+                        f'Dumped request {request_id} '
+                        f'(name={request.name}, '
+                        f'status='
+                        f'{request.status.value if request.status else None})')
+                else:
+                    if chunk_fetched:
+                        logger.debug(f'Request {request_id} not found in DB')
+                    else:
+                        logger.debug(f'Request {request_id} metadata not '
+                                     'fetched (chunk fetch failed or '
+                                     'timed out)')
+            except Exception as e:  # pylint: disable=broad-except
+                logger.warning(
+                    f'Failed to get info for request {request_id}: {e}')
+                if errors is not None:
+                    errors.append({
+                        'component': 'requests',
+                        'resource': request_id,
+                        'error': str(e),
+                        'traceback': _full_traceback()
+                    })
 
-        # Copy request log file. Routed through the LogProvider so that
-        # deployments whose request logs are not on the local filesystem
-        # can fetch them from wherever they live. Deadline-bounded: a
-        # streaming/active request's copy can block for tens of seconds.
-        try:
-            ok, copied = _run_with_deadline(
-                functools.partial(_copy_request_log_file, request_id,
-                                  request_dir,
-                                  log_provider.RequestLogType.REQUEST,
-                                  'request.log'),
-                _bounded_timeout(_REQUEST_LOG_COPY_TIMEOUT, deadline),
-                component='requests',
-                resource=f'{request_id}/log',
-                errors=errors,
-                orphans=orphans)
-            if ok and copied:
-                logger.debug(f'Copied request log for {request_id}')
-            elif ok:
-                logger.debug(f'Request log not found for {request_id}')
-        except Exception as e:  # pylint: disable=broad-except
-            logger.warning(f'Failed to copy log for request {request_id}: {e}')
-            if errors is not None:
-                errors.append({
-                    'component': 'requests',
-                    'resource': f'{request_id}/log',
-                    'error': str(e),
-                    'traceback': _full_traceback()
-                })
+            # Copy request log file. Routed through the LogProvider so that
+            # deployments whose request logs are not on the local filesystem
+            # can fetch them from wherever they live. Deadline-bounded: a
+            # streaming/active request's copy can block for tens of seconds.
+            try:
+                ok, copied = _run_with_deadline(
+                    functools.partial(_copy_request_log_file, request_id,
+                                      request_dir,
+                                      log_provider.RequestLogType.REQUEST,
+                                      'request.log'),
+                    _bounded_timeout(_REQUEST_LOG_COPY_TIMEOUT, deadline),
+                    component='requests',
+                    resource=f'{request_id}/log',
+                    errors=errors,
+                    orphans=orphans)
+                if ok and copied:
+                    logger.debug(f'Copied request log for {request_id}')
+                elif ok:
+                    logger.debug(f'Request log not found for {request_id}')
+            except Exception as e:  # pylint: disable=broad-except
+                logger.warning(
+                    f'Failed to copy log for request {request_id}: {e}')
+                if errors is not None:
+                    errors.append({
+                        'component': 'requests',
+                        'resource': f'{request_id}/log',
+                        'error': str(e),
+                        'traceback': _full_traceback()
+                    })
 
-        # Copy debug log file (only exists when
-        # ENABLE_REQUEST_DEBUG_LOGGING is enabled). Deadline-bounded too.
-        try:
-            ok, copied = _run_with_deadline(
-                functools.partial(_copy_request_log_file, request_id,
-                                  request_dir,
-                                  log_provider.RequestLogType.DEBUG,
-                                  'request_debug.log'),
-                _bounded_timeout(_REQUEST_LOG_COPY_TIMEOUT, deadline),
-                component='requests',
-                resource=f'{request_id}/request_debug.log',
-                errors=errors,
-                orphans=orphans)
-            if ok and copied:
-                logger.debug(f'Copied debug log for {request_id}')
-        except Exception as e:  # pylint: disable=broad-except
-            logger.warning(
-                f'Failed to copy debug log for request {request_id}: {e}')
-            if errors is not None:
-                errors.append({
-                    'component': 'requests',
-                    'resource': f'{request_id}/request_debug.log',
-                    'error': str(e),
-                    'traceback': _full_traceback()
-                })
+            # Copy debug log file (only exists when
+            # ENABLE_REQUEST_DEBUG_LOGGING is enabled). Deadline-bounded too.
+            try:
+                ok, copied = _run_with_deadline(
+                    functools.partial(_copy_request_log_file, request_id,
+                                      request_dir,
+                                      log_provider.RequestLogType.DEBUG,
+                                      'request_debug.log'),
+                    _bounded_timeout(_REQUEST_LOG_COPY_TIMEOUT, deadline),
+                    component='requests',
+                    resource=f'{request_id}/request_debug.log',
+                    errors=errors,
+                    orphans=orphans)
+                if ok and copied:
+                    logger.debug(f'Copied debug log for {request_id}')
+            except Exception as e:  # pylint: disable=broad-except
+                logger.warning(
+                    f'Failed to copy debug log for request {request_id}: {e}')
+                if errors is not None:
+                    errors.append({
+                        'component': 'requests',
+                        'resource': f'{request_id}/request_debug.log',
+                        'error': str(e),
+                        'traceback': _full_traceback()
+                    })
 
-        timings.append({
-            'request_id': request_id,
-            'duration_s': round(time.monotonic() - request_start, 2),
-        })
+            timings.append({
+                'request_id': request_id,
+                'duration_s': round(time.monotonic() - request_start, 2),
+            })
 
     try:
         with open(os.path.join(requests_dir, '_timings.json'),
@@ -2222,9 +2431,12 @@ def _build_debug_dump(
     ``deadline`` is an optional absolute ``time.monotonic()`` best-effort
     budget: once it passes, the remaining section calls are skipped (each with
     its own recorded skip record) instead of run, and in-flight per-operation
-    timeouts are clamped to the remaining budget. The client-info / errors /
-    summary writes below always run so the partial dump is self-describing.
-    ``None`` (the default) keeps the previous behavior exactly.
+    timeouts are clamped to the remaining budget. Each section is additionally
+    capped at an equal share of the budget still remaining, so an oversized
+    early section cannot starve the later ones (see the section loop). The
+    client-info / errors / summary writes below always run so the partial dump
+    is self-describing. ``None`` (the default) keeps the previous behavior
+    exactly.
     """
     # Populate the context and cross-link related resources. Each helper
     # runs exactly once, and the order is load-bearing:
@@ -2265,13 +2477,13 @@ def _build_debug_dump(
                                  recent_minutes,
                                  reachability,
                                  deadline=deadline)
-    _get_managed_jobs_from_requests(debug_dump_context)
+    _get_managed_jobs_from_requests(debug_dump_context, deadline=deadline)
     _get_job_clusters_from_managed_jobs(debug_dump_context)
-    _get_requests_from_clusters(debug_dump_context)
+    _get_requests_from_clusters(debug_dump_context, deadline=deadline)
     _get_requests_from_managed_jobs(debug_dump_context,
                                     reachability,
                                     deadline=deadline)
-    _get_clusters_from_requests(debug_dump_context)
+    _get_clusters_from_requests(debug_dump_context, deadline=deadline)
     _get_clusters_from_managed_jobs(debug_dump_context)
 
     # Always include system daemon requests
@@ -2301,31 +2513,48 @@ def _build_debug_dump(
     # starve the sections the caller asked for. Every section is now
     # deadline-aware (its internal calls are bounded and it's skipped once the
     # budget is gone), so the build always reaches the zip step with a coherent
-    # partial instead of being hard-killed mid-section.
-    sections: List[Tuple[str, Callable[[], None]]] = [
-        ('server_info', lambda: _dump_server_info(
-            dump_dir, errors=errors, deadline=deadline, orphans=orphans)),
-        ('request_ids',
-         lambda: _dump_request_id_info(debug_dump_context['request_ids'],
-                                       dump_dir,
-                                       errors=errors,
-                                       deadline=deadline,
-                                       orphans=orphans)),
-        ('clusters',
-         lambda: _dump_cluster_info(debug_dump_context['cluster_names'],
-                                    dump_dir,
-                                    reachability,
-                                    errors=errors,
-                                    deadline=deadline)),
-        ('managed_jobs',
-         lambda: _dump_managed_job_info(debug_dump_context['managed_job_ids'],
-                                        dump_dir,
-                                        reachability,
-                                        errors=errors,
-                                        deadline=deadline,
-                                        orphans=orphans)),
-        ('kubernetes_contexts', lambda: _dump_kube_contexts_info(
-            dump_dir, errors=errors, deadline=deadline, orphans=orphans)),
+    # partial instead of being hard-killed mid-section. On top of that
+    # ordering, each section's deadline is capped at an equal share of the
+    # budget still remaining (see the loop below), so a huge early section
+    # (e.g. request_ids on a server with thousands of requests) cannot starve
+    # the later ones to literally 0.0s.
+    sections: List[Tuple[str, Callable[[Optional[float]], None]]] = [
+        ('server_info', lambda section_deadline: _dump_server_info(
+            dump_dir, errors=errors, deadline=section_deadline, orphans=orphans)
+        ),
+        (
+            'request_ids',
+            lambda section_deadline: _dump_request_id_info(
+                debug_dump_context['request_ids'],
+                dump_dir,
+                errors=errors,
+                deadline=section_deadline,
+                orphans=orphans,
+                cross_linked_request_ids=(debug_dump_context[
+                    'request_ids_via_job'] | debug_dump_context[
+                        'request_ids_via_cluster']),
+                # The dump-level budget the section cap was carved from, so
+                # per-request skip records can blame the right budget (see
+                # _dump_request_id_info).
+                overall_deadline=deadline)),
+        ('clusters', lambda section_deadline: _dump_cluster_info(
+            debug_dump_context['cluster_names'],
+            dump_dir,
+            reachability,
+            errors=errors,
+            deadline=section_deadline)),
+        ('managed_jobs', lambda section_deadline: _dump_managed_job_info(
+            debug_dump_context['managed_job_ids'],
+            dump_dir,
+            reachability,
+            errors=errors,
+            deadline=section_deadline,
+            orphans=orphans)),
+        ('kubernetes_contexts', lambda section_deadline:
+         _dump_kube_contexts_info(dump_dir,
+                                  errors=errors,
+                                  deadline=section_deadline,
+                                  orphans=orphans)),
     ]
     budget = _remaining_budget(deadline)
     logger.info(f'debug dump: collecting {len(sections)} sections '
@@ -2337,7 +2566,7 @@ def _build_debug_dump(
     # see where the budget went (and which sections were skipped) without
     # grepping the worker log.
     section_timings: List[Dict[str, Any]] = []
-    for name, dump_section in sections:
+    for index, (name, dump_section) in enumerate(sections):
         if _deadline_exceeded(deadline):
             logger.warning(f'Skipping debug-dump section {name!r}: overall '
                            'deadline exceeded.')
@@ -2360,16 +2589,42 @@ def _build_debug_dump(
         # 'start' with no matching 'done' pins the culprit.
         section_start = time.monotonic()
         remaining = _remaining_budget(deadline)
-        logger.info(f'debug dump: section {name!r} start' + (
-            '' if remaining is None else f' ({remaining:.0f}s budget left)'))
-        dump_section()
+        # Budget sharing: cap each section at an equal share of the budget
+        # still remaining, across the sections not yet run (including this
+        # one). Without the cap, one huge section -- typically request_ids on
+        # a server with thousands of requests -- consumes the whole budget
+        # and every later section is skipped with 0.0s (a dump taken during
+        # a k8s incident then contains no cluster / controller / Kueue
+        # evidence at all). Sections that finish early return their unused
+        # share to the pool (each share is recomputed from what is actually
+        # left), and the last section always gets everything that remains.
+        # ``None`` (no overall deadline) keeps the previous uncapped
+        # behavior.
+        section_deadline = deadline
+        share: Optional[float] = None
+        if remaining is not None:
+            share = max(remaining, 0.0) / (len(sections) - index)
+            section_deadline = section_start + share
+        logger.info(f'debug dump: section {name!r} start' +
+                    ('' if remaining is None or share is None else
+                     f' ({remaining:.0f}s budget left, '
+                     f'section capped at {share:.0f}s)'))
+        dump_section(section_deadline)
         duration = time.monotonic() - section_start
         logger.info(f'debug dump: section {name!r} done in {duration:.1f}s')
-        section_timings.append({
+        section_timing: Dict[str, Any] = {
             'section': name,
             'status': 'completed',
             'duration_s': round(duration, 2),
-        })
+        }
+        if share is not None:
+            # With a deadline, duration ~= budget_share_s reads as 'capped
+            # by design' rather than 'slow population' -- without the share,
+            # a section that ran its full cap is indistinguishable from one
+            # that happened to take that long. Absent under deadline=None,
+            # where no share is computed.
+            section_timing['budget_share_s'] = round(share, 2)
+        section_timings.append(section_timing)
 
     # Write client info if provided
     if client_info:

--- a/tests/unit_tests/test_sky/utils/test_debug_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_debug_utils.py
@@ -149,17 +149,19 @@ class TestGetRequestsFromClusters:
 
     @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
     def test_multiple_clusters(self, mock_get_tasks):
-        """Each cluster name should be queried separately."""
-        mock_get_tasks.side_effect = [
-            [_make_request(request_id='req-a')],
-            [_make_request(request_id='req-b')],
+        """All cluster names are queried in one batched call."""
+        mock_get_tasks.return_value = [
+            _make_request(request_id='req-a'),
+            _make_request(request_id='req-b'),
         ]
         ctx = _make_context(cluster_names={'cluster-1', 'cluster-2'})
 
         debug_utils._get_requests_from_clusters(ctx)
 
         assert ctx['request_ids'] == {'req-a', 'req-b'}
-        assert mock_get_tasks.call_count == 2
+        mock_get_tasks.assert_called_once()
+        task_filter = mock_get_tasks.call_args[0][0]
+        assert task_filter.cluster_names == ['cluster-1', 'cluster-2']
 
     @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
     def test_empty_cluster_names_is_noop(self, mock_get_tasks):
@@ -185,15 +187,122 @@ class TestGetRequestsFromClusters:
     @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
     def test_deduplicates_request_ids(self, mock_get_tasks):
         """Duplicate request IDs across clusters should be deduplicated."""
-        mock_get_tasks.side_effect = [
-            [_make_request(request_id='req-dup')],
-            [_make_request(request_id='req-dup')],
+        mock_get_tasks.return_value = [
+            _make_request(request_id='req-dup'),
+            _make_request(request_id='req-dup'),
         ]
         ctx = _make_context(cluster_names={'cluster-1', 'cluster-2'})
 
         debug_utils._get_requests_from_clusters(ctx)
 
         assert ctx['request_ids'] == {'req-dup'}
+
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_many_clusters_are_queried_in_chunks(self, mock_get_tasks):
+        """Cluster names are batched into cluster_names IN queries under the
+        DB bind-parameter limit, not one query per cluster."""
+        mock_get_tasks.return_value = []
+        names = sorted(f'cluster-{i:04d}' for i in range(1001))
+        ctx = _make_context(cluster_names=set(names))
+
+        debug_utils._get_requests_from_clusters(ctx)
+
+        assert mock_get_tasks.call_count == 3
+        chunk_sizes = [
+            len(call.args[0].cluster_names)
+            for call in mock_get_tasks.call_args_list
+        ]
+        assert chunk_sizes == [500, 500, 1]
+        queried = sorted(name for call in mock_get_tasks.call_args_list
+                         for name in call.args[0].cluster_names)
+        assert queried == names
+
+
+# ---------------------------------------------------------------------------
+# Tests for _get_requests_bulk
+# ---------------------------------------------------------------------------
+class TestGetRequestsBulk:
+    """The chunked bulk request-metadata fetch."""
+
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_chunks_ids_over_the_bind_limit(self, mock_get_tasks):
+        """>500 IDs are fetched with one IN query per 500-ID chunk, and the
+        filter carries the chunk's IDs and the requested field projection."""
+        mock_get_tasks.return_value = []
+        ids = [f'req-{i:04d}' for i in range(1001)]
+
+        rows = debug_utils._get_requests_bulk(ids,
+                                              fields=['request_id'],
+                                              component='test',
+                                              resource='bulk')
+
+        assert not rows
+        assert mock_get_tasks.call_count == 3
+        chunk_sizes = [
+            len(call.args[0].request_ids)
+            for call in mock_get_tasks.call_args_list
+        ]
+        assert chunk_sizes == [500, 500, 1]
+        # Each call carries exactly its chunk of IDs and the projection.
+        for index, call in enumerate(mock_get_tasks.call_args_list):
+            assert call.args[0].request_ids == ids[index * 500:(index + 1) *
+                                                   500]
+            assert call.args[0].fields == ['request_id']
+
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_raising_chunk_records_error_and_continues(self, mock_get_tasks,
+                                                       monkeypatch):
+        """A chunk whose query raises records the error, and later chunks
+        are still fetched."""
+        monkeypatch.setattr(debug_utils, '_REQUEST_DB_CHUNK_SIZE', 1)
+        good_rows = [_make_request(request_id='req-good')]
+        mock_get_tasks.side_effect = [
+            RuntimeError('DB is down'),
+            good_rows,
+        ]
+        errors: List[Dict[str, str]] = []
+
+        rows = debug_utils._get_requests_bulk(['req-a', 'req-b'],
+                                              component='test',
+                                              resource='bulk',
+                                              errors=errors)
+
+        # The failed chunk is recorded, the second chunk still ran.
+        assert mock_get_tasks.call_count == 2
+        assert rows == good_rows
+        assert len(errors) == 1
+        assert errors[0]['resource'] == 'bulk/0'
+        assert 'DB is down' in errors[0]['error']
+
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_hung_chunk_stops_fetching(self, mock_get_tasks, monkeypatch):
+        """A chunk that never returns records the timeout and stops later
+        chunks from piling on more abandoned workers."""
+        monkeypatch.setattr(debug_utils, '_REQUEST_DB_CHUNK_SIZE', 1)
+        monkeypatch.setattr(debug_utils, '_REQUEST_DB_QUERY_TIMEOUT', 0.2)
+        calls = {'count': 0}
+
+        def _fake_get_tasks(*args, **kwargs):
+            del args, kwargs  # unused
+            calls['count'] += 1
+            if calls['count'] == 1:
+                time.sleep(1.0)  # hung query
+            return []
+
+        mock_get_tasks.side_effect = _fake_get_tasks
+        errors: List[Dict[str, str]] = []
+        orphans: List[Dict[str, Any]] = []
+
+        debug_utils._get_requests_bulk(['req-a', 'req-b', 'req-c'],
+                                       component='test',
+                                       resource='bulk',
+                                       errors=errors,
+                                       orphans=orphans)
+
+        assert mock_get_tasks.call_count == 1
+        assert len(orphans) == 1
+        assert orphans[0]['resource'] == 'bulk/0'
+        assert any('timed out' in e['error'] for e in errors)
 
 
 # ---------------------------------------------------------------------------
@@ -450,65 +559,73 @@ class TestGetRequestsFromManagedJobs:
 # ---------------------------------------------------------------------------
 class TestGetClustersFromRequests:
 
-    @mock.patch('sky.utils.debug_utils.requests_lib.get_request')
-    def test_finds_cluster_names_from_requests(self, mock_get_request):
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_finds_cluster_names_from_requests(self, mock_get_tasks):
         """Should collect cluster names from request metadata."""
-        mock_get_request.return_value = _make_request(request_id='req-1',
-                                                      cluster_name='my-cluster')
+        mock_get_tasks.return_value = [
+            _make_request(request_id='req-1', cluster_name='my-cluster')
+        ]
         ctx = _make_context(request_ids={'req-1'})
 
         debug_utils._get_clusters_from_requests(ctx)
 
-        assert 'my-cluster' in ctx['cluster_names']
-        mock_get_request.assert_called_once_with('req-1',
-                                                 fields=['cluster_name'])
+        assert ctx['cluster_names'] == {'my-cluster'}
+        mock_get_tasks.assert_called_once()
+        task_filter = mock_get_tasks.call_args[0][0]
+        assert task_filter.request_ids == ['req-1']
+        assert task_filter.fields == ['request_id', 'cluster_name']
 
-    @mock.patch('sky.utils.debug_utils.requests_lib.get_request')
-    def test_skips_none_cluster_name(self, mock_get_request):
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_skips_none_cluster_name(self, mock_get_tasks):
         """Requests with None cluster_name should be skipped."""
-        mock_get_request.return_value = _make_request(request_id='req-1',
-                                                      cluster_name=None)
+        mock_get_tasks.return_value = [
+            _make_request(request_id='req-1', cluster_name=None)
+        ]
         ctx = _make_context(request_ids={'req-1'})
 
         debug_utils._get_clusters_from_requests(ctx)
 
         assert ctx['cluster_names'] == set()
 
-    @mock.patch('sky.utils.debug_utils.requests_lib.get_request')
-    def test_skips_none_request(self, mock_get_request):
-        """If request is not found (returns None), skip it."""
-        mock_get_request.return_value = None
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_skips_missing_request(self, mock_get_tasks):
+        """IDs absent from the bulk result (not in DB) are skipped."""
+        mock_get_tasks.return_value = []
         ctx = _make_context(request_ids={'req-nonexistent'})
 
         debug_utils._get_clusters_from_requests(ctx)
 
         assert ctx['cluster_names'] == set()
+        assert not ctx['errors']
 
-    @mock.patch('sky.utils.debug_utils.requests_lib.get_request')
-    def test_empty_request_ids_is_noop(self, mock_get_request):
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_empty_request_ids_is_noop(self, mock_get_tasks):
         """Empty request_ids should not trigger any DB call."""
         ctx = _make_context(request_ids=set())
 
         debug_utils._get_clusters_from_requests(ctx)
 
-        mock_get_request.assert_not_called()
+        mock_get_tasks.assert_not_called()
         assert ctx['cluster_names'] == set()
 
-    @mock.patch('sky.utils.debug_utils.requests_lib.get_request')
-    def test_db_failure_logs_warning(self, mock_get_request):
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_db_failure_logs_warning(self, mock_get_tasks):
         """DB failure should log warning but not crash."""
-        mock_get_request.side_effect = RuntimeError('DB error')
+        mock_get_tasks.side_effect = RuntimeError('DB error')
         ctx = _make_context(request_ids={'req-1'})
 
         # Should not raise
         debug_utils._get_clusters_from_requests(ctx)
 
         assert ctx['cluster_names'] == set()
+        assert len(ctx['errors']) == 1
+        assert ctx['errors'][0]['component'] == 'cross_link'
+        assert 'DB error' in ctx['errors'][0]['error']
 
-    @mock.patch('sky.utils.debug_utils.requests_lib.get_request')
-    def test_multiple_requests_collect_clusters(self, mock_get_request):
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_multiple_requests_collect_clusters(self, mock_get_tasks):
         """Multiple requests should collect all distinct cluster names."""
-        mock_get_request.side_effect = [
+        mock_get_tasks.return_value = [
             _make_request(request_id='req-1', cluster_name='cluster-a'),
             _make_request(request_id='req-2', cluster_name='cluster-b'),
             _make_request(request_id='req-3', cluster_name='cluster-a'),
@@ -832,26 +949,30 @@ class TestCrossLinkOrdering:
 # ---------------------------------------------------------------------------
 class TestGetManagedJobsFromRequests:
 
-    @mock.patch('sky.utils.debug_utils.requests_lib.get_request')
-    def test_extracts_job_id_from_launch(self, mock_get_request):
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_extracts_job_id_from_launch(self, mock_get_tasks):
         """Should extract job_id from a jobs.launch request body."""
         body = SimpleNamespace(job_id=42, job_ids=None)
-        mock_get_request.return_value = _make_request(request_id='req-1',
-                                                      request_body=body,
-                                                      name='sky.jobs.launch')
+        mock_get_tasks.return_value = [
+            _make_request(request_id='req-1',
+                          request_body=body,
+                          name='sky.jobs.launch')
+        ]
         ctx = _make_context(request_ids={'req-1'})
 
         debug_utils._get_managed_jobs_from_requests(ctx)
 
         assert 42 in ctx['managed_job_ids']
 
-    @mock.patch('sky.utils.debug_utils.requests_lib.get_request')
-    def test_extracts_job_ids_from_cancel(self, mock_get_request):
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_extracts_job_ids_from_cancel(self, mock_get_tasks):
         """Should extract job_ids list from a jobs.cancel request body."""
         body = SimpleNamespace(job_id=None, job_ids=[10, 20])
-        mock_get_request.return_value = _make_request(request_id='req-1',
-                                                      request_body=body,
-                                                      name='sky.jobs.cancel')
+        mock_get_tasks.return_value = [
+            _make_request(request_id='req-1',
+                          request_body=body,
+                          name='sky.jobs.cancel')
+        ]
         ctx = _make_context(request_ids={'req-1'})
 
         debug_utils._get_managed_jobs_from_requests(ctx)
@@ -859,25 +980,29 @@ class TestGetManagedJobsFromRequests:
         assert 10 in ctx['managed_job_ids']
         assert 20 in ctx['managed_job_ids']
 
-    @mock.patch('sky.utils.debug_utils.requests_lib.get_request')
-    def test_skips_non_managed_job_requests(self, mock_get_request):
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_skips_non_managed_job_requests(self, mock_get_tasks):
         """Should skip requests that are not managed job requests."""
-        mock_get_request.return_value = _make_request(
-            request_id='req-1',
-            request_body=SimpleNamespace(cluster_name='my-cluster'),
-            name='sky.launch')
+        mock_get_tasks.return_value = [
+            _make_request(
+                request_id='req-1',
+                request_body=SimpleNamespace(cluster_name='my-cluster'),
+                name='sky.launch')
+        ]
         ctx = _make_context(request_ids={'req-1'})
 
         debug_utils._get_managed_jobs_from_requests(ctx)
 
         assert ctx['managed_job_ids'] == set()
 
-    @mock.patch('sky.utils.debug_utils.requests_lib.get_request')
-    def test_skips_none_body(self, mock_get_request):
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_skips_none_body(self, mock_get_tasks):
         """Should skip requests with None body."""
-        mock_get_request.return_value = _make_request(request_id='req-1',
-                                                      request_body=None,
-                                                      name='sky.jobs.launch')
+        mock_get_tasks.return_value = [
+            _make_request(request_id='req-1',
+                          request_body=None,
+                          name='sky.jobs.launch')
+        ]
         ctx = _make_context(request_ids={'req-1'})
 
         debug_utils._get_managed_jobs_from_requests(ctx)
@@ -892,39 +1017,46 @@ class TestGetManagedJobsFromRequests:
 
         assert ctx['managed_job_ids'] == set()
 
-    @mock.patch('sky.utils.debug_utils.requests_lib.get_request')
-    def test_db_failure_does_not_crash(self, mock_get_request):
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_db_failure_does_not_crash(self, mock_get_tasks):
         """DB failure should not crash the function."""
-        mock_get_request.side_effect = RuntimeError('DB error')
+        mock_get_tasks.side_effect = RuntimeError('DB error')
         ctx = _make_context(request_ids={'req-1'})
 
         # Should not raise
         debug_utils._get_managed_jobs_from_requests(ctx)
 
         assert ctx['managed_job_ids'] == set()
+        assert len(ctx['errors']) == 1
+        assert ctx['errors'][0]['component'] == 'cross_link'
+        assert 'DB error' in ctx['errors'][0]['error']
 
-    @mock.patch('sky.utils.debug_utils.requests_lib.get_request')
-    def test_extracts_job_id_from_return_value(self, mock_get_request):
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_extracts_job_id_from_return_value(self, mock_get_tasks):
         """Should extract job_id from jobs.launch return_value."""
-        mock_get_request.return_value = _make_request(
-            request_id='req-1',
-            request_body=SimpleNamespace(job_id=None, job_ids=None),
-            return_value={'job_id': 42},
-            name='sky.jobs.launch')
+        mock_get_tasks.return_value = [
+            _make_request(request_id='req-1',
+                          request_body=SimpleNamespace(job_id=None,
+                                                       job_ids=None),
+                          return_value={'job_id': 42},
+                          name='sky.jobs.launch')
+        ]
         ctx = _make_context(request_ids={'req-1'})
 
         debug_utils._get_managed_jobs_from_requests(ctx)
 
         assert 42 in ctx['managed_job_ids']
 
-    @mock.patch('sky.utils.debug_utils.requests_lib.get_request')
-    def test_extracts_job_ids_list_from_return_value(self, mock_get_request):
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_extracts_job_ids_list_from_return_value(self, mock_get_tasks):
         """Should extract list of job_ids from jobs.launch return_value."""
-        mock_get_request.return_value = _make_request(
-            request_id='req-1',
-            request_body=SimpleNamespace(job_id=None, job_ids=None),
-            return_value={'job_id': [42, 43]},
-            name='sky.jobs.launch')
+        mock_get_tasks.return_value = [
+            _make_request(request_id='req-1',
+                          request_body=SimpleNamespace(job_id=None,
+                                                       job_ids=None),
+                          return_value={'job_id': [42, 43]},
+                          name='sky.jobs.launch')
+        ]
         ctx = _make_context(request_ids={'req-1'})
 
         debug_utils._get_managed_jobs_from_requests(ctx)
@@ -1153,9 +1285,9 @@ class TestPopulateRecentContext:
 # ---------------------------------------------------------------------------
 class TestCrossLinkCycleBreak:
 
-    @mock.patch('sky.utils.debug_utils.requests_lib.get_request')
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
     def test_request_added_via_job_does_not_reseed_managed_jobs(
-            self, mock_get_request):
+            self, mock_get_tasks):
         """job → request → job cycle is broken."""
         # Simulate: req-from-job was added by _get_requests_from_managed_jobs
         # (e.g. matched on body.name="sb-sweep-8"). Its body.job_id would
@@ -1163,9 +1295,11 @@ class TestCrossLinkCycleBreak:
         # seed job A. Without the guard, B would be added to
         # managed_job_ids.
         body = SimpleNamespace(job_id=999, job_ids=None)
-        mock_get_request.return_value = _make_request(request_id='req-from-job',
-                                                      request_body=body,
-                                                      name='sky.jobs.launch')
+        mock_get_tasks.return_value = [
+            _make_request(request_id='req-from-job',
+                          request_body=body,
+                          name='sky.jobs.launch')
+        ]
         ctx = _make_context(
             request_ids={'req-from-job'},
             request_ids_via_job={'req-from-job'},
@@ -1176,19 +1310,21 @@ class TestCrossLinkCycleBreak:
 
         assert ctx['managed_job_ids'] == {42}
         # The guarded request was never even fetched.
-        mock_get_request.assert_not_called()
+        mock_get_tasks.assert_not_called()
 
-    @mock.patch('sky.utils.debug_utils.requests_lib.get_request')
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
     def test_request_added_via_cluster_does_not_reseed_clusters(
-            self, mock_get_request):
+            self, mock_get_tasks):
         """cluster → request → cluster cycle is broken."""
         # Simulate: req-from-cluster was added by
         # _get_requests_from_clusters. Its cluster_name points at a
         # DIFFERENT cluster than the seed (since the request also
         # touched another cluster). Without the guard, that other
         # cluster would be added to cluster_names.
-        mock_get_request.return_value = _make_request(
-            request_id='req-from-cluster', cluster_name='other-cluster')
+        mock_get_tasks.return_value = [
+            _make_request(request_id='req-from-cluster',
+                          cluster_name='other-cluster')
+        ]
         ctx = _make_context(
             request_ids={'req-from-cluster'},
             request_ids_via_cluster={'req-from-cluster'},
@@ -1198,15 +1334,17 @@ class TestCrossLinkCycleBreak:
         debug_utils._get_clusters_from_requests(ctx)
 
         assert ctx['cluster_names'] == {'seed-cluster'}
-        mock_get_request.assert_not_called()
+        mock_get_tasks.assert_not_called()
 
-    @mock.patch('sky.utils.debug_utils.requests_lib.get_request')
-    def test_unrestricted_request_still_expands_jobs(self, mock_get_request):
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_unrestricted_request_still_expands_jobs(self, mock_get_tasks):
         """A user-seeded request (no provenance tag) still expands."""
         body = SimpleNamespace(job_id=42, job_ids=None)
-        mock_get_request.return_value = _make_request(request_id='req-seed',
-                                                      request_body=body,
-                                                      name='sky.jobs.launch')
+        mock_get_tasks.return_value = [
+            _make_request(request_id='req-seed',
+                          request_body=body,
+                          name='sky.jobs.launch')
+        ]
         # No provenance tag — this came from user input or recent context.
         ctx = _make_context(request_ids={'req-seed'})
 
@@ -1214,12 +1352,12 @@ class TestCrossLinkCycleBreak:
 
         assert 42 in ctx['managed_job_ids']
 
-    @mock.patch('sky.utils.debug_utils.requests_lib.get_request')
-    def test_unrestricted_request_still_expands_clusters(
-            self, mock_get_request):
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_unrestricted_request_still_expands_clusters(self, mock_get_tasks):
         """A user-seeded request (no provenance tag) still expands."""
-        mock_get_request.return_value = _make_request(request_id='req-seed',
-                                                      cluster_name='c1')
+        mock_get_tasks.return_value = [
+            _make_request(request_id='req-seed', cluster_name='c1')
+        ]
         ctx = _make_context(request_ids={'req-seed'})
 
         debug_utils._get_clusters_from_requests(ctx)
@@ -1311,10 +1449,9 @@ class TestCrossLinkCycleBreak:
         # Pre-existing request was not tagged → still expandable downstream.
         assert ctx['request_ids_via_job'] == set()
 
-    @mock.patch('sky.utils.debug_utils.requests_lib.get_request')
     @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
     def test_all_users_cancel_does_not_drag_unrelated_jobs(
-            self, mock_get_tasks, mock_get_request):
+            self, mock_get_tasks):
         """A historic `cancel --all-users` request must not pollute the
         dump.
 
@@ -1349,7 +1486,8 @@ class TestCrossLinkCycleBreak:
         debug_utils._get_managed_jobs_from_requests(ctx)
 
         assert ctx['managed_job_ids'] == {1}
-        mock_get_request.assert_not_called()
+        # Only step 1's scan queried the DB; step 2 fetched nothing.
+        assert mock_get_tasks.call_count == 1
 
 
 # ---------------------------------------------------------------------------
@@ -3071,17 +3209,19 @@ class TestRedactTaskYaml:
 class TestDumpRequestIdInfo:
     """Tests for the _dump_request_id_info function."""
 
-    @mock.patch('sky.utils.debug_utils.requests_lib.get_request')
-    def test_happy_path_writes_request_info(self, mock_get_request, tmp_path):
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_happy_path_writes_request_info(self, mock_get_tasks, tmp_path):
         """Should write request_info.json with correct fields."""
-        mock_get_request.return_value = _make_request(
-            request_id='req-1',
-            name='sky.launch',
-            status='SUCCEEDED',
-            cluster_name='my-cluster',
-            created_at=1700000000.0,
-            finished_at=1700001000.0,
-        )
+        mock_get_tasks.return_value = [
+            _make_request(
+                request_id='req-1',
+                name='sky.launch',
+                status='SUCCEEDED',
+                cluster_name='my-cluster',
+                created_at=1700000000.0,
+                finished_at=1700001000.0,
+            )
+        ]
 
         errors: List[Dict[str, str]] = []
         debug_utils._dump_request_id_info({'req-1'}, str(tmp_path), errors)
@@ -3096,10 +3236,10 @@ class TestDumpRequestIdInfo:
         assert data['cluster_name'] == 'my-cluster'
         assert not errors
 
-    @mock.patch('sky.utils.debug_utils.requests_lib.get_request')
-    def test_request_not_found(self, mock_get_request, tmp_path):
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_request_not_found(self, mock_get_tasks, tmp_path):
         """Should handle request not found gracefully."""
-        mock_get_request.return_value = None
+        mock_get_tasks.return_value = []
 
         errors: List[Dict[str, str]] = []
         debug_utils._dump_request_id_info({'req-missing'}, str(tmp_path),
@@ -3107,21 +3247,23 @@ class TestDumpRequestIdInfo:
 
         # No crash, no error recorded (not-found is not an error)
         assert not errors
-        info_path = tmp_path / 'requests' / 'req-missing' / 'request_info.json'
+        info_path = (tmp_path / 'requests' / 'req-missing' /
+                     'request_info.json')
         assert not info_path.exists()
 
-    @mock.patch('sky.utils.debug_utils.requests_lib.get_request')
-    def test_db_failure_records_error(self, mock_get_request, tmp_path):
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_db_failure_records_error(self, mock_get_tasks, tmp_path):
         """DB failure should record error but not crash."""
-        mock_get_request.side_effect = RuntimeError('DB is down')
+        mock_get_tasks.side_effect = RuntimeError('DB is down')
 
         errors: List[Dict[str, str]] = []
         debug_utils._dump_request_id_info({'req-fail'}, str(tmp_path), errors)
 
-        assert len(errors) == 1
-        assert errors[0]['component'] == 'requests'
-        assert 'DB is down' in errors[0]['error']
-        assert 'traceback' in errors[0]
+        # Both bulk passes (ordering + metadata) record the failure.
+        assert len(errors) == 2
+        assert all(e['component'] == 'requests' for e in errors)
+        assert all('DB is down' in e['error'] for e in errors)
+        assert all('traceback' in e for e in errors)
 
     def test_empty_request_ids_is_noop(self, tmp_path):
         """Empty request_ids should not create any files."""
@@ -3132,11 +3274,11 @@ class TestDumpRequestIdInfo:
         assert not (tmp_path / 'requests').exists()
 
     @mock.patch('sky.utils.debug_utils.log_provider.get_log_provider')
-    @mock.patch('sky.utils.debug_utils.requests_lib.get_request')
-    def test_copies_log_file_when_exists(self, mock_get_request,
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_copies_log_file_when_exists(self, mock_get_tasks,
                                          mock_get_provider, tmp_path):
         """Should copy request log via the LogProvider."""
-        mock_get_request.return_value = _make_request(request_id='req-log')
+        mock_get_tasks.return_value = [_make_request(request_id='req-log')]
         provider = mock.MagicMock()
         provider.copy_log_file.return_value = True
         mock_get_provider.return_value = provider
@@ -3150,6 +3292,227 @@ class TestDumpRequestIdInfo:
             call.args[2] for call in provider.copy_log_file.call_args_list
         ]
         assert any(p.name == 'request.log' for p in dest_paths)
+
+    @mock.patch('sky.utils.debug_utils.log_provider.get_log_provider')
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_hung_metadata_chunk_keeps_processing_remaining(
+            self, mock_get_tasks, mock_get_provider, tmp_path, monkeypatch):
+        """A hung metadata chunk stops further chunk fetching (no piling on
+        abandoned workers) while iteration continues: the remaining requests
+        still get their log-copy attempts and timings entries."""
+        monkeypatch.setattr(debug_utils, '_REQUEST_DB_CHUNK_SIZE', 2)
+        monkeypatch.setattr(debug_utils, '_REQUEST_DB_QUERY_TIMEOUT', 0.2)
+        ids = {'req-a', 'req-b', 'req-c', 'req-d'}
+        order_rows = [
+            _make_request(request_id=rid, created_at=1000.0)
+            for rid in sorted(ids)
+        ]
+        metadata_calls = {'count': 0}
+
+        def _fake_get_tasks(request_task_filter):
+            if request_task_filter.fields:
+                # Ordering pass (request_id, created_at projection).
+                return order_rows
+            metadata_calls['count'] += 1
+            if metadata_calls['count'] == 1:
+                time.sleep(1.0)  # hung metadata query
+            return []
+
+        mock_get_tasks.side_effect = _fake_get_tasks
+        provider = mock.MagicMock()
+        provider.copy_log_file.return_value = False
+        mock_get_provider.return_value = provider
+        errors: List[Dict[str, str]] = []
+        orphans: List[Dict[str, Any]] = []
+
+        debug_utils._dump_request_id_info(ids,
+                                          str(tmp_path),
+                                          errors,
+                                          deadline=None,
+                                          orphans=orphans)
+
+        # Two ordering chunks, then exactly one (hung) metadata chunk --
+        # the second metadata chunk was never attempted.
+        assert mock_get_tasks.call_count == 3
+        assert len(orphans) == 1
+        assert orphans[0]['resource'] == 'requests_metadata/0'
+        # Every request still got both of its log-copy attempts.
+        copied_ids = {
+            call.args[0] for call in provider.copy_log_file.call_args_list
+        }
+        assert copied_ids == ids
+        assert provider.copy_log_file.call_count == 2 * len(ids)
+        # And every request still has a timings entry.
+        with open(tmp_path / 'requests' / '_timings.json',
+                  encoding='utf-8') as f:
+            timings = json.load(f)
+        assert {entry['request_id'] for entry in timings} == ids
+
+    @mock.patch('sky.utils.debug_utils.logger')
+    @mock.patch('sky.utils.debug_utils.log_provider.get_log_provider')
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_timed_out_chunk_members_not_reported_as_absent(
+            self, mock_get_tasks, mock_get_provider, mock_logger, tmp_path,
+            monkeypatch):
+        """Members of a metadata chunk that timed out are logged as
+        'metadata not fetched', not as 'not found in DB' -- the rows may well
+        exist; the fetch is what failed."""
+        monkeypatch.setattr(debug_utils, '_REQUEST_DB_CHUNK_SIZE', 2)
+        monkeypatch.setattr(debug_utils, '_REQUEST_DB_QUERY_TIMEOUT', 0.2)
+        ids = {'req-a', 'req-b', 'req-c', 'req-d'}
+        order_rows = [
+            _make_request(request_id=rid, created_at=1000.0)
+            for rid in sorted(ids)
+        ]
+        metadata_calls = {'count': 0}
+
+        def _fake_get_tasks(request_task_filter):
+            if request_task_filter.fields:
+                return order_rows
+            metadata_calls['count'] += 1
+            if metadata_calls['count'] == 1:
+                time.sleep(1.0)  # hung metadata query
+            return []
+
+        mock_get_tasks.side_effect = _fake_get_tasks
+        mock_get_provider.return_value = mock.MagicMock()
+
+        debug_utils._dump_request_id_info(ids, str(tmp_path), deadline=None)
+
+        debug_messages = [
+            str(call.args[0]) for call in mock_logger.debug.call_args_list
+        ]
+        assert any('metadata not fetched' in m for m in debug_messages)
+        assert not any('not found in DB' in m for m in debug_messages)
+
+    @mock.patch('sky.utils.debug_utils.log_provider.get_log_provider')
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_skip_blames_section_budget_when_overall_remains(
+            self, mock_get_tasks, mock_get_provider, tmp_path):
+        """When the section cap expires while the overall dump budget still
+        has time, per-request skip records blame the section's share -- the
+        later sections are still running."""
+        ids = {f'req-{i}' for i in range(3)}
+        mock_get_tasks.return_value = [
+            _make_request(request_id=f'req-{i}', created_at=1000.0 + i)
+            for i in range(3)
+        ]
+        provider = mock.MagicMock()
+        provider.copy_log_file.side_effect = lambda *args: time.sleep(0.35)
+        mock_get_provider.return_value = provider
+
+        errors: List[Dict[str, str]] = []
+        debug_utils._dump_request_id_info(ids,
+                                          str(tmp_path),
+                                          errors,
+                                          deadline=time.monotonic() + 1.0,
+                                          overall_deadline=time.monotonic() +
+                                          3600)
+
+        skip_errors = [e for e in errors if e['error'].startswith('Skipped:')]
+        assert skip_errors, 'expected the section cap to expire mid-section'
+        assert all(e['error'] == 'Skipped: request_ids section budget '
+                   'exceeded.' for e in skip_errors)
+        assert not any(
+            'overall debug-dump deadline' in e['error'] for e in errors)
+
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_skip_blames_overall_deadline_when_overall_also_exceeded(
+            self, mock_get_tasks, tmp_path):
+        """When the overall deadline has also been exceeded at skip time
+        (e.g. an earlier section consumed nearly the whole budget, so this
+        section started with a sliver and its cap is already past), the
+        per-request skip records keep blaming the overall deadline."""
+        # A slow query makes the (already-expired) ordering pass time out
+        # deterministically instead of racing an instant mock against a
+        # non-positive timeout.
+        mock_get_tasks.side_effect = lambda *args, **kwargs: time.sleep(0.05)
+
+        errors: List[Dict[str, str]] = []
+        debug_utils._dump_request_id_info({'req-0', 'req-1', 'req-2'},
+                                          str(tmp_path),
+                                          errors,
+                                          deadline=time.monotonic() - 1.0,
+                                          overall_deadline=time.monotonic() -
+                                          0.5)
+
+        skip_errors = [e for e in errors if e['error'].startswith('Skipped:')]
+        assert len(skip_errors) == 3
+        assert all(e['error'] == 'Skipped: overall debug-dump deadline '
+                   'exceeded.' for e in skip_errors)
+        assert not any('section budget exceeded' in e['error'] for e in errors)
+
+
+class TestDumpRequestIdInfoOrdering:
+    """The dump order is deterministic and relevance-first.
+
+    Hash-order iteration previously let a deadline-truncated partial drop an
+    arbitrary 24% of requests -- including requests launched seconds before
+    the dump -- while fully processing months-old dead rows.
+    """
+
+    @staticmethod
+    def _timings_order(tmp_path) -> List[str]:
+        with open(tmp_path / 'requests' / '_timings.json',
+                  encoding='utf-8') as f:
+            return [entry['request_id'] for entry in json.load(f)]
+
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_newest_first(self, mock_get_tasks, tmp_path):
+        """Within a tier, newer requests are dumped before older ones."""
+        mock_get_tasks.return_value = [
+            _make_request(request_id='old', created_at=1000.0),
+            _make_request(request_id='new', created_at=2000.0),
+        ]
+
+        debug_utils._dump_request_id_info({'old', 'new'}, str(tmp_path))
+
+        assert self._timings_order(tmp_path) == ['new', 'old']
+
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_system_daemons_first(self, mock_get_tasks, tmp_path):
+        """Always-include system daemon IDs are dumped before anything
+        else, even when their rows are old (daemon rows are created once
+        and never refreshed)."""
+        daemon_id = debug_utils.SYSTEM_REQUEST_IDS[0]
+        mock_get_tasks.return_value = [
+            _make_request(request_id=daemon_id, created_at=1000.0),
+            _make_request(request_id='fresh-user-req', created_at=2000.0),
+        ]
+
+        debug_utils._dump_request_id_info({daemon_id, 'fresh-user-req'},
+                                          str(tmp_path))
+
+        assert self._timings_order(tmp_path) == [daemon_id, 'fresh-user-req']
+
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_cross_linked_after_user_seeded(self, mock_get_tasks, tmp_path):
+        """Cross-link-expanded IDs are dumped after user-seeded /
+        recent-context ones, even when they are newer."""
+        mock_get_tasks.return_value = [
+            _make_request(request_id='via-cluster', created_at=2000.0),
+            _make_request(request_id='user-seeded', created_at=1000.0),
+        ]
+
+        debug_utils._dump_request_id_info(
+            {'via-cluster', 'user-seeded'},
+            str(tmp_path),
+            cross_linked_request_ids={'via-cluster'})
+
+        assert self._timings_order(tmp_path) == ['user-seeded', 'via-cluster']
+
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_deterministic_for_unknown_created_at(self, mock_get_tasks,
+                                                  tmp_path):
+        """IDs with no DB row sort last within their tier, ordered by ID,
+        so the iteration order is reproducible across runs."""
+        mock_get_tasks.return_value = []
+
+        debug_utils._dump_request_id_info({'b', 'a', 'c'},
+                                          str(tmp_path),
+                                          cross_linked_request_ids={'c'})
+
+        assert self._timings_order(tmp_path) == ['a', 'b', 'c']
 
 
 # ---------------------------------------------------------------------------
@@ -3504,9 +3867,9 @@ class TestDumpRequestIdInfoLogCollection:
     """_dump_request_id_info collects logs via the LogProvider."""
 
     @pytest.fixture(autouse=True)
-    def _mock_get_request(self):
-        with mock.patch('sky.utils.debug_utils.requests_lib.get_request',
-                        return_value=None):
+    def _mock_get_request_tasks(self):
+        with mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks',
+                        return_value=[]):
             yield
 
     def test_logs_collected_via_log_provider(self, tmp_path):
@@ -4438,6 +4801,12 @@ class TestOverallDeadlineDump:
             name = next(n for n in zf.namelist() if n.endswith('errors.json'))
             return json.loads(zf.read(name))
 
+    @staticmethod
+    def _read_summary(zip_path):
+        with zipfile.ZipFile(zip_path, 'r') as zf:
+            name = next(n for n in zf.namelist() if n.endswith('summary.json'))
+            return json.loads(zf.read(name))
+
     def test_past_deadline_skips_sections_but_still_zips(self, tmp_path):
         """An already-passed overall_deadline (e.g. the caller spent the whole
         budget queueing) skips every section with its own recorded reason, yet
@@ -4464,6 +4833,12 @@ class TestOverallDeadlineDump:
         ]
         assert len(skip_records) == len(self._SECTION_FNS)
         assert all(e['resource'] == 'section' for e in skip_records)
+        # Overall-deadline exhaustion never produces section-budget
+        # records: the whole-section skips keep the overall text.
+        assert not [
+            e for e in errors
+            if 'section budget exceeded' in e.get('error', '')
+        ]
 
     def test_no_deadline_runs_all_sections(self, tmp_path):
         """overall_deadline=None == unchanged behavior: every section runs and
@@ -4493,3 +4868,167 @@ class TestOverallDeadlineDump:
         assert result.exists()
         for fn, m in section_mocks.items():
             assert m.call_count == 1, f'{fn} should have run exactly once'
+
+    def test_sections_share_the_budget(self, tmp_path):
+        """With an overall deadline, every section is capped at an equal
+        share of the budget still remaining, so an oversized early section
+        (e.g. request_ids on a server with thousands of requests) cannot
+        consume the whole budget and starve the later sections to 0.0s.
+        Sections that finish early return their unused share to the pool,
+        and the last section is capped only by the overall deadline. Share
+        bounds are asserted against each section's recorded start time (the
+        internal section_start is not observable from here)."""
+        # (section fn name, monotonic start, received deadline), appended by
+        # the mock sections as they run.
+        recorded: List[Any] = []
+
+        def _record(fn_name):
+
+            def _section(*args, **kwargs):
+                del args  # unused
+                recorded.append(
+                    (fn_name, time.monotonic(), kwargs.get('deadline')))
+
+            return _section
+
+        with self._patched_dump(tmp_path) as section_mocks:
+            for fn, m in section_mocks.items():
+                m.side_effect = _record(fn)
+            result = debug_utils.create_debug_dump(
+                cluster_names=['c'], overall_deadline=time.time() + 2.0)
+
+        assert len(recorded) == 5
+        assert all(deadline is not None for _, _, deadline in recorded)
+        # Every section's cap is at most an equal share of the budget still
+        # remaining at its recorded start: the internal overall deadline is
+        # at or before the first section's start plus the requested budget.
+        first_start = recorded[0][1]
+        n_sections = len(recorded)
+        for index, (_, start, deadline) in enumerate(recorded):
+            share_bound = (first_start + 2.0 - start) / (n_sections - index)
+            assert deadline <= start + share_bound + 0.05, (
+                f'section {index} cap exceeds its share')
+        # Instant sections return their unused share: caps are
+        # non-decreasing across the run.
+        deadlines_in_order = [deadline for _, _, deadline in recorded]
+        assert deadlines_in_order == sorted(deadlines_in_order)
+        # Each completed section's share is surfaced in summary.json, so
+        # duration ~= budget_share_s reads as 'capped by design'.
+        timings = self._read_summary(result)['section_timings']
+        assert len(timings) == 5
+        assert all(t['status'] == 'completed' for t in timings)
+        assert all('budget_share_s' in t for t in timings)
+
+    def test_slow_first_section_leaves_budget_for_later_sections(
+            self, tmp_path):
+        """A section that runs to its full cap cannot starve the later ones:
+        every section still runs (none skipped_deadline) and each receives a
+        positive share. Each mock section sleeps until the deadline it
+        receives -- not a fixed duration -- so the budget math, not the
+        test's timing, drives the outcome."""
+        recorded: List[Any] = []
+
+        def _sleep_until_cap(fn_name):
+
+            def _section(*args, **kwargs):
+                del args  # unused
+                deadline = kwargs.get('deadline')
+                recorded.append((fn_name, time.monotonic(), deadline))
+                if deadline is not None:
+                    time.sleep(max(0.0, deadline - time.monotonic()))
+
+            return _section
+
+        with self._patched_dump(tmp_path) as section_mocks:
+            for fn, m in section_mocks.items():
+                m.side_effect = _sleep_until_cap(fn)
+            result = debug_utils.create_debug_dump(
+                cluster_names=['c'], overall_deadline=time.time() + 2.0)
+
+        # All five sections ran -- none was skipped for the deadline.
+        assert len(recorded) == 5
+        # Every section received a positive share of the remaining budget.
+        for _, start, deadline in recorded:
+            assert deadline is not None
+            assert deadline > start
+        # And no more than an equal share of what remained at its start.
+        first_start = recorded[0][1]
+        for index, (_, start, deadline) in enumerate(recorded):
+            share_bound = (first_start + 2.0 - start) / (len(recorded) - index)
+            assert deadline <= start + share_bound + 0.05, (
+                f'section {index} cap exceeds its share')
+        # The summary agrees: everything completed, nothing skipped.
+        timings = self._read_summary(result)['section_timings']
+        assert [t['status'] for t in timings] == ['completed'] * 5
+        # No skip records at all.
+        errors = self._read_errors(result)
+        assert not [
+            e for e in errors if e.get('error', '').startswith('Skipped:')
+        ]
+
+    def test_capped_request_ids_section_keeps_errors_consistent(self, tmp_path):
+        """Integration: a tight section cap on request_ids (real section,
+        slow log copies) followed by completed later sections produces a
+        non-contradictory errors.json -- the per-request skips blame the
+        section's share, nothing blames the overall deadline, and the
+        summary shows every section completed."""
+        with contextlib.ExitStack() as stack:
+            for fn in self._CROSSLINK_FNS:
+                stack.enter_context(mock.patch(f'sky.utils.debug_utils.{fn}'))
+            # Instant sections; request_ids runs for real.
+            for fn in ('_dump_server_info', '_dump_cluster_info',
+                       '_dump_managed_job_info', '_dump_kube_contexts_info'):
+                stack.enter_context(mock.patch(f'sky.utils.debug_utils.{fn}'))
+            stack.enter_context(
+                mock.patch('sky.utils.debug_utils.DEBUG_DUMP_DIR',
+                           str(tmp_path / 'debug_dumps')))
+            rows = [
+                _make_request(request_id=rid, created_at=1000.0)
+                for rid in debug_utils.SYSTEM_REQUEST_IDS
+            ]
+            stack.enter_context(
+                mock.patch(
+                    'sky.utils.debug_utils.requests_lib.get_request_tasks',
+                    return_value=rows))
+            provider = mock.MagicMock()
+            provider.copy_log_file.side_effect = lambda *args: time.sleep(0.05)
+            stack.enter_context(
+                mock.patch(
+                    'sky.utils.debug_utils.log_provider.get_log_provider',
+                    return_value=provider))
+            result = debug_utils.create_debug_dump(
+                overall_deadline=time.time() + 2.0)
+
+        # The section populated some requests before its cap expired...
+        with zipfile.ZipFile(result, 'r') as zf:
+            assert any(n.endswith('request_info.json') for n in zf.namelist())
+        # ...per-request skips exist and all blame the section's share...
+        errors = self._read_errors(result)
+        section_skips = [
+            e for e in errors
+            if e.get('error') == 'Skipped: request_ids section budget '
+            'exceeded.'
+        ]
+        assert section_skips
+        # ...and nothing blames the overall deadline (all sections ran).
+        assert not [
+            e for e in errors
+            if 'overall debug-dump deadline' in e.get('error', '')
+        ]
+        # The later sections completed after request_ids was capped.
+        timings = self._read_summary(result)['section_timings']
+        assert [t['status'] for t in timings] == ['completed'] * 5
+        assert all('budget_share_s' in t for t in timings)
+
+    def test_no_deadline_passes_uncapped_sections(self, tmp_path):
+        """overall_deadline=None: sections receive no per-section cap."""
+        with self._patched_dump(tmp_path) as section_mocks:
+            result = debug_utils.create_debug_dump(cluster_names=['c'],
+                                                   overall_deadline=None)
+
+        for fn, m in section_mocks.items():
+            assert m.call_args[1]['deadline'] is None, \
+                f'{fn} should be uncapped'
+        # No share is computed without a deadline.
+        timings = self._read_summary(result)['section_timings']
+        assert all('budget_share_s' not in t for t in timings)


### PR DESCRIPTION
## Summary

A production server with many stale unfinished requests produced a debug dump where the first section (`request_ids`) consumed 579s of the 601s budget, so `clusters`, `managed_jobs`, and `kubernetes_contexts` were each skipped with 0.0s — a dump taken during a Kubernetes-heavy incident contained no cluster-side, controller, or Kueue evidence at all, arguably the most diagnostic sections. Before any section ran, cross-link helpers issued ~15,900 sequential per-ID DB round trips (~91.5s), and the request loop then re-fetched every request individually again. Because the loop iterated an unordered `Set[str]`, the deadline dropped an arbitrary 24% of requests — including requests launched seconds before the dump and 2 of the 8 always-include system daemons — while fully processing thousands of months-old dead rows.

### Mechanism map

| Mechanism | Problem | Evidence | Where |
|---|---|---|---|
| Section budget sharing | First section consumed the whole budget; later sections got 0.0s | `request_ids` ran 579.5s of the 601s budget, then three sections skipped with 0.0s each | section loop in `_build_debug_dump` |
| Bulk-bounded DB fetches | ~15,900 sequential locked per-ID queries, unbounded by the deadline machinery | cross-link timeline: 52.7s + 38.8s + 3.2s of per-ID loops before any section | `_get_requests_bulk` + the three cross-link helpers + `_dump_request_id_info` |
| Deterministic relevance ordering | Hash-order iteration dropped fresh requests and system daemons while fully processing months-old dead rows | a RUNNING request launched one second before the dump was dropped; 4847 provably-logless dead rows each got a full fetch + write + two copy attempts | `_dump_request_id_info` ordering pass |

The three mechanisms were designed and verified as one unit (the ordering protects the freshest requests *within* the share the section cap gives them; the cap without ordering would still burn the share on dead rows; the bulk fetch without the cap would still be unbounded) — splitting the diff would make each piece individually incomplete, which is why this is one PR despite the size.

### What each mechanism does

**Section budget sharing.** Each section is capped at an equal share of the budget still remaining, recomputed per section: early finishers return their unused share to the pool, and the last section always gets everything that remains. `deadline=None` keeps the previous uncapped behavior (every section receives `deadline=None`; the ordering and bulk fetches intentionally still apply). Per-request skip records inside the `request_ids` section now distinguish *which* budget ran out: `Skipped: request_ids section budget exceeded.` when the section cap expired while the overall budget still had time (the common case — the later sections are still running), and the existing overall-deadline text when the overall budget is gone too. Each completed section's timing entry carries `budget_share_s`, so `duration_s ~= budget_share_s` reads as "capped by design" rather than "slow population" (previously a 579.5s `request_ids` entry hid 2,310 dropped requests behind `status: completed`).

**Bulk-bounded DB fetches.** `_get_requests_bulk` replaces the per-ID locked `get_request` round trips with chunked 500-ID `IN` queries (under SQLite's 999 bind-parameter limit). Every chunk routes through `_run_with_deadline` with a 60s cap clamped to the remaining deadline — a single hung DB query, precisely the failure mode a debug dump investigates, can no longer stall the dump unbounded, with or without an overall deadline. A timed-out chunk stops further chunk fetching (no piling on abandoned workers) but keeps iterating, so the remaining requests still get skip records and log-copy attempts; a raising chunk records its error and later chunks continue. The ~15,900 sequential locked round trips become roughly 4 bulk passes x ceil(N/500) `IN` queries per pass (~24 instant queries at the production population of ~9.5k IDs). Cross-link rows are deliberately re-fetched in the section rather than reused: the chunked re-fetch is negligible (sub-second per pass) and avoids coupling the section to cross-link internals and their field projections.

The fetch loop in `_get_requests_bulk` and the metadata loop in `_dump_request_id_info` are intentionally two loops, not one shared helper: the bulk helper accumulates all rows (fine for its light projections), while the section's loop must interleave fetch-with-process in dump order to bound memory at ~500 decoded rows and to keep emitting skip records after a hung chunk.

**Deterministic relevance ordering.** A light `(request_id, created_at)` bulk pass gives every ID a recency key; the dump order is then system daemons first, then user-seeded/recent-context requests, then cross-link-expanded ones (`request_ids_via_job | request_ids_via_cluster`), newest first within each tier, with IDs unknown to the DB sorting last in their tier. A deadline-truncated partial therefore keeps the requests most likely to explain the incident, and reruns are reproducible (order was previously Python hash order). Members of a metadata chunk that timed out are logged as `metadata not fetched` rather than `not found in DB` — the row may well exist; the fetch is what failed.

### Combined budget math (for reviewers of the related in-flight debug-dump changes)

Overall deadline → pre-section cross-link phase (this PR: each chunk capped at 60s clamped to the overall deadline; a related change adds a formal fraction-of-deadline cap on the whole phase) → equal section shares recomputed per section (this PR) → context-population sub-budget (related change) → per-chunk 60s caps inside sections (this PR). A section may exceed its cap by one in-flight bounded op (observed ~0.05s over a 0.68s share in an end-to-end run) — bounded, and consistent with the documented best-effort deadline semantics. This PR does not add a negative-timeout floor in `_bounded_timeout` (clamping an already-exhausted deadline can produce non-positive timeouts); that is owned by the related deadline-coverage change. errors.json is standalone non-contradictory: the pre-existing `_run_with_deadline` records use the `<component>/<resource> timed out after Ns` text and never the deadline-exceeded text, so the three record kinds do not collide here; aligning reason strings across the related changes is deferred to whichever lands second.

`budget_share_s` has a designated cut-line: if merging against the other in-flight summary.json changes gets awkward, the key can be dropped and the gates read the `(Ns budget left, section capped at Ms)` INFO log line instead.

## Tested

- Unit tests: `tests/unit_tests/test_sky/utils/test_debug_utils.py` — new coverage for the ordering tiers, chunk boundaries (>500 IDs → 500/500/1 with the right `RequestTaskFilter` contents), hung-chunk and raising-chunk behavior, section share bounds (mock sections record `(start, received_deadline)`; a slow first section sleeps until the deadline it receives and the later sections still run), both per-request skip-text branches, `budget_share_s` present/absent, and an integration-style non-contradictory-errors.json test (real `request_ids` section capped by a tight share, later sections complete, no overall-deadline per-request records). `bash format.sh --files` clean on `sky/utils/debug_utils.py` (pylint: no messages); the test file shows only pre-existing message categories.
- Full-file run in this development environment shows exactly 8 failures, all pre-existing environment failures (`TestDumpKubeContextsInfo` 6 + `TestCollectClusterKubernetesResources` 2; the local kubeconfig leaks a real context into the tests) — byte-identical list on unmodified master.
- Functional simulation (3000 requests whose log copies need ~120s under a 10s budget — the production infeasibility shape): all five sections `completed` with none `skipped_deadline`, the three later sections each received a positive capped share, all system daemons and all 49 freshest requests kept, the truncation edge touched only months-old rows.
- End-to-end against a real local API server seeded with 3000 months-old CANCELLED never-finished rows, fresh RUNNING rows, a cluster, and a `jobs.launch` row: with a single-digit effective budget all five sections completed, every skipped ID was a stale-row ID with a section-budget record, `request_ids` duration ~= its share, and the cluster/job sections had work; an uncapped rerun collected the exact full population (content equivalence — ordering and access pattern intentionally differ, no byte-identity claimed).

## Noticed but not fixed here (out of scope)

- `class TestDumpClusterInfo` is defined twice in the test file (the second shadows the first, so the first class's tests never run; pylint E0102) — pre-existing on master.
- `_get_requests_from_managed_jobs` issues one unbounded (single, already-bulk) `get_request_tasks` call, and `_dump_server_info` makes one fixed-ID `get_request` call for the boot request — both outside this change's scope.
- Serial log copies remain a known efficiency limitation (fewer requests fit per share); the section cap bounds the section and the relevance ordering protects the freshest requests regardless, so it is deferred as follow-up work.

This will likely conflict with other in-flight debug-dump changes touching `sky/utils/debug_utils.py` (the section list/loop, `_dump_request_id_info`, and the cross-link helpers are the shared hot spots); the reconciliation plan is described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
