### PR TITLE
[Core] Make the debug dump self-describing: summary truth, per-section outcomes, manifest, quiet log

### DIFF
--- a/sky/utils/debug_utils.py
+++ b/sky/utils/debug_utils.py
@@ -182,6 +182,36 @@ def _log_timed_out_stragglers(orphans: List[Dict[str, Any]]) -> None:
         logger.exception('_log_timed_out_stragglers failed')
 
 
+def _count_item_dirs_with_files(
+        parent_dir: str,
+        name_filter: Optional[Callable[[str], bool]] = None) -> int:
+    """Count subdirectories of ``parent_dir`` that contain at least one file.
+
+    Sections create a directory per item up front, but an item that produced
+    no data (e.g. a request ID that is no longer in the DB) leaves an empty
+    directory -- which the os.walk-based zipping silently drops. Counting
+    only directories with content therefore yields the number that matches
+    what actually lands in the dump zip. ``name_filter`` restricts which
+    subdirectory names count as items (e.g. the managed-jobs section skips
+    its non-per-job ``controller_*`` directories). Best-effort: an
+    unreadable directory counts as empty.
+    """
+    try:
+        entries = list(pathlib.Path(parent_dir).iterdir())
+    except OSError:
+        return 0
+    count = 0
+    for entry in entries:
+        if name_filter is not None and not name_filter(entry.name):
+            continue
+        try:
+            if entry.is_dir() and any(entry.iterdir()):
+                count += 1
+        except OSError:
+            continue
+    return count
+
+
 # Persistent location for debug dumps
 DEBUG_DUMP_DIR = '~/.sky/debug_dumps'
 
@@ -774,6 +804,16 @@ def _populate_recent_context(
         f'Populating context with resources from last {minutes} minutes')
     cutoff_time = time.time() - (minutes * 60)
 
+    # The dump's own request is RUNNING while this scan runs, so without an
+    # explicit exclusion it would include itself -- and copying its
+    # request.log / request_debug.log would ship the dump's own output
+    # stream a second time inside the artifact. Only this accidental
+    # self-inclusion is excluded: explicitly requesting the dump's own
+    # request ID still dumps it. Outside a server-side request execution
+    # (e.g. tests, in-process callers) there is no own request to exclude.
+    own_request_id = (common_utils.get_current_request_id()
+                      if common_utils.is_in_request_context() else None)
+
     # Get recent requests (cluster names are handled by
     # _get_clusters_from_requests during cross-linking)
     try:
@@ -782,6 +822,12 @@ def _populate_recent_context(
                                            fields=['request_id',
                                                    'finished_at']))
         for request in requests:
+            if own_request_id is not None and (request.request_id
+                                               == own_request_id):
+                logger.debug('Recent: excluding the debug dump\'s own '
+                             f'request {request.request_id} (its logs are '
+                             'the dump itself)')
+                continue
             logger.debug(f'Recent: including request {request.request_id} '
                          f'(finished_at={request.finished_at},'
                          f' cutoff={cutoff_time:.0f})')
@@ -1064,7 +1110,8 @@ def _dump_request_id_info(
         dump_dir: str,
         errors: Optional[List[Dict[str, str]]] = None,
         deadline: Optional[float] = None,
-        orphans: Optional[List[Dict[str, Any]]] = None) -> None:
+        orphans: Optional[List[Dict[str,
+                                    Any]]] = None) -> Optional[Dict[str, int]]:
     """Collect request logs and metadata.
 
     ``deadline`` (absolute monotonic) bounds the section two ways: each
@@ -1073,19 +1120,31 @@ def _dump_request_id_info(
     budget is gone we stop starting new requests and skip the rest -- so the
     dump still zips what it gathered. Per-request wall-clock is written to
     ``requests/_timings.json``.
+
+    Returns per-item stats for summary.json -- ``dumped`` (request info
+    written), ``not_found`` (request ID no longer in the DB) and
+    ``skipped_deadline`` (never attempted, budget gone) -- which together
+    account for every request in the section's scope. ``None`` when there
+    are no requests to dump.
     """
     if not request_ids:
         logger.debug('No requests to dump')
-        return
+        return None
     logger.debug(f'Entering _dump_request_id_info for '
                  f'{len(request_ids)} requests')
 
     requests_dir = os.path.join(dump_dir, 'requests')
     os.makedirs(requests_dir, exist_ok=True)
 
+    stats: Dict[str, int] = {
+        'dumped': 0,
+        'not_found': 0,
+        'skipped_deadline': 0,
+    }
     timings: List[Dict[str, Any]] = []
     for request_id in request_ids:
         if _deadline_exceeded(deadline):
+            stats['skipped_deadline'] += 1
             if errors is not None:
                 errors.append({
                     'component': 'requests',
@@ -1139,7 +1198,9 @@ def _dump_request_id_info(
                     f'(name={request.name}, '
                     f'status='
                     f'{request.status.value if request.status else None})')
+                stats['dumped'] += 1
             else:
+                stats['not_found'] += 1
                 logger.debug(f'Request {request_id} not found in DB')
         except Exception as e:  # pylint: disable=broad-except
             logger.warning(f'Failed to get info for request {request_id}: {e}')
@@ -1219,6 +1280,7 @@ def _dump_request_id_info(
     except OSError as e:
         logger.debug(f'Failed to write request timings: {e}')
     logger.debug('Exiting _dump_request_id_info')
+    return stats
 
 
 # Short connection timeout for the skylet-log-path resolution command. The
@@ -1529,7 +1591,8 @@ def _dump_kube_contexts_info(
         dump_dir: str,
         errors: Optional[List[Dict[str, str]]] = None,
         deadline: Optional[float] = None,
-        orphans: Optional[List[Dict[str, Any]]] = None) -> None:
+        orphans: Optional[List[Dict[str,
+                                    Any]]] = None) -> Optional[Dict[str, int]]:
     """Dump cluster-WIDE k8s objects once per allowed kube context.
 
     The GPU-metrics pods (Prometheus server, DCGM exporter) and the non-Workload
@@ -1562,6 +1625,10 @@ def _dump_kube_contexts_info(
     the fixed cap. On timeout the batch is abandoned (its worker recorded in
     ``orphans``) and whatever landed on disk is kept. Best-effort throughout:
     errors are recorded, never aborts the dump.
+
+    Returns per-item stats for summary.json (``dumped``: context directories
+    with at least one file -- whatever landed on disk, including a partial
+    batch cut off by the timeout), or ``None`` when there is nothing to dump.
     """
     try:
         contexts = clouds.Kubernetes.existing_allowed_contexts(silent=True)
@@ -1574,7 +1641,7 @@ def _dump_kube_contexts_info(
                 'error': str(e),
                 'traceback': _full_traceback(),
             })
-        return
+        return None
 
     # Always dump the API server's own in-cluster context, even when it's been
     # excluded as a compute target (explicit allowed_contexts list, or
@@ -1586,7 +1653,7 @@ def _dump_kube_contexts_info(
     # Dedupe defensively while preserving order (None = in-cluster is allowed).
     unique_contexts = list(dict.fromkeys(contexts))
     if not unique_contexts:
-        return
+        return None
 
     contexts_root = os.path.join(dump_dir, 'kubernetes_contexts')
     os.makedirs(contexts_root, exist_ok=True)
@@ -1622,7 +1689,7 @@ def _dump_kube_contexts_info(
     if not ok or results is None:
         # Timed out: _run_with_deadline recorded the skip + orphan; per-context
         # dirs written before the cutoff remain on disk as a partial.
-        return
+        return {'dumped': _count_item_dirs_with_files(contexts_root)}
 
     timings: List[Dict[str, Any]] = []
     for context, (ctx_errors, duration_s) in zip(unique_contexts, results):
@@ -1647,6 +1714,7 @@ def _dump_kube_contexts_info(
             json.dump(timings, f, indent=2)
     except OSError as e:
         logger.debug(f'Failed to write kube-context timings: {e}')
+    return {'dumped': _count_item_dirs_with_files(contexts_root)}
 
 
 _KubeContextReachabilityChecker = Callable[[Optional[str]], bool]
@@ -1891,11 +1959,12 @@ def _dump_one_cluster(cluster_name: str,
     return errors
 
 
-def _dump_cluster_info(cluster_names: Set[str],
-                       dump_dir: str,
-                       reachability: '_KubeContextReachabilityChecker',
-                       errors: Optional[List[Dict[str, str]]] = None,
-                       deadline: Optional[float] = None) -> None:
+def _dump_cluster_info(
+        cluster_names: Set[str],
+        dump_dir: str,
+        reachability: '_KubeContextReachabilityChecker',
+        errors: Optional[List[Dict[str, str]]] = None,
+        deadline: Optional[float] = None) -> Optional[Dict[str, int]]:
     """Collect cluster state and events.
 
     Clusters are dumped in parallel: each cluster's collection can make slow
@@ -1903,10 +1972,14 @@ def _dump_cluster_info(cluster_names: Set[str],
     a single unreachable cluster stack its timeout in front of every other
     cluster. run_in_parallel keeps per-cluster best-effort isolation -- each
     worker returns its own error records, merged here after all finish.
+
+    Returns per-item stats for summary.json (``dumped``: cluster directories
+    with at least one file, i.e. what actually lands in the dump zip), or
+    ``None`` when there are no clusters to dump.
     """
     if not cluster_names:
         logger.debug('No clusters to dump')
-        return
+        return None
     logger.debug(f'Entering _dump_cluster_info for '
                  f'{len(cluster_names)} clusters')
 
@@ -1924,7 +1997,11 @@ def _dump_cluster_info(cluster_names: Set[str],
         for cluster_errors in results:
             errors.extend(cluster_errors)
 
+    stats: Dict[str, int] = {
+        'dumped': _count_item_dirs_with_files(clusters_dir),
+    }
     logger.debug('Exiting _dump_cluster_info')
+    return stats
 
 
 def _dump_managed_job_info(
@@ -1933,17 +2010,22 @@ def _dump_managed_job_info(
         reachability: '_KubeContextReachabilityChecker',
         errors: Optional[List[Dict[str, str]]] = None,
         deadline: Optional[float] = None,
-        orphans: Optional[List[Dict[str, Any]]] = None) -> None:
+        orphans: Optional[List[Dict[str,
+                                    Any]]] = None) -> Optional[Dict[str, int]]:
     """Collect managed job state and logs.
 
     Both phases exec into the jobs controller outside consolidation mode,
     so both are gated on the controller context's reachability -- one
     memoized probe covers the whole section (and, via the shared cache,
     reuses the clusters section's probe of the same context).
+
+    Returns per-item stats for summary.json (``dumped``: managed-job
+    directories with at least one file, i.e. what actually lands in the
+    dump zip), or ``None`` when there are no managed jobs to dump.
     """
     if not managed_job_ids:
         logger.debug('No managed jobs to dump')
-        return
+        return None
     logger.debug(f'Entering _dump_managed_job_info for '
                  f'{len(managed_job_ids)} managed jobs')
 
@@ -1959,7 +2041,7 @@ def _dump_managed_job_info(
                 _controller_skip_error('managed_jobs', 'controller_access',
                                        dead_context))
         logger.debug('Exiting _dump_managed_job_info')
-        return
+        return {'dumped': 0}
 
     # Phase 1: Queue info from queue_v2 (works in both consolidation and
     # non-consolidation modes via existing gRPC/SSH plumbing)
@@ -1971,7 +2053,15 @@ def _dump_managed_job_info(
     _collect_controller_debug_data(list(managed_job_ids), dump_dir, errors,
                                    deadline)
 
+    stats: Dict[str, int] = {
+        # Per-job directories only: the controller-side phase also writes
+        # non-per-job directories (controller_system/, controller_submit_logs/
+        # ) under managed_jobs/, which are not scoped jobs.
+        'dumped': _count_item_dirs_with_files(jobs_dir,
+                                              name_filter=str.isdigit),
+    }
     logger.debug('Exiting _dump_managed_job_info')
+    return stats
 
 
 def _dump_managed_job_queue_info(
@@ -2205,6 +2295,34 @@ def _collect_controller_debug_data(job_ids: List[int],
         f'and {len(file_path_entries)} rsynced files from controller')
 
 
+# Maps a dump section to the summary.json 'collected' count key it feeds
+# (sections not listed here contribute no top-level collected count).
+_SECTION_COLLECTED_KEYS = {
+    'request_ids': 'request_count',
+    'clusters': 'cluster_count',
+    'managed_jobs': 'managed_job_count',
+}
+
+# Maps a dump section to the dump-root paths it writes, so summary.json can
+# attribute bytes per section after collection finishes. Paths are matched
+# against the first path component of each collected file, so a directory
+# entry covers everything written beneath it. 'context_population' writes no
+# files. Controller-side managed-job data also lands under managed_jobs/ (see
+# _collect_controller_debug_data), so it is attributed to managed_jobs.
+_SECTION_OUTPUT_PATHS = {
+    'server_info': ('server_info.json',),
+    'request_ids': ('requests',),
+    'clusters': ('clusters',),
+    'managed_jobs': ('managed_jobs',),
+    'kubernetes_contexts': ('kubernetes_contexts',),
+}
+
+# How many of the largest collected files to list (largest first) in
+# summary.json and manifest.json, so a multi-GB dump can be navigated without
+# running du over the extracted tree.
+_LARGEST_FILES_LISTED = 10
+
+
 def _build_debug_dump(
     dump_dir: str,
     debug_dump_context: DebugDumpContext,
@@ -2216,16 +2334,24 @@ def _build_debug_dump(
     """Build the debug dump contents in dump_dir.
 
     Populates context via cross-linking, then dumps all sections
-    (server info, requests, clusters, managed jobs, client info,
-    errors, summary).
+    (server info, requests, clusters, managed jobs, kubernetes contexts),
+    then writes errors.json, summary.json and a manifest.json file
+    inventory.
 
     ``deadline`` is an optional absolute ``time.monotonic()`` best-effort
     budget: once it passes, the remaining section calls are skipped (each with
     its own recorded skip record) instead of run, and in-flight per-operation
     timeouts are clamped to the remaining budget. The client-info / errors /
-    summary writes below always run so the partial dump is self-describing.
-    ``None`` (the default) keeps the previous behavior exactly.
+    summary / manifest writes below always run so the partial dump is
+    self-describing. ``None`` (the default) keeps the previous behavior
+    exactly.
     """
+    build_start_mono = time.monotonic()
+    build_start_wall = time.time()
+    # Per-section wall-clock + status, surfaced in summary.json so a reader can
+    # see where the budget went (and which sections were skipped) without
+    # grepping the worker log.
+    section_timings: List[Dict[str, Any]] = []
     # Populate the context and cross-link related resources. Each helper
     # runs exactly once, and the order is load-bearing:
     # 1. Expand clusters -> jobs BEFORE anything else adds cluster names
@@ -2256,6 +2382,11 @@ def _build_debug_dump(
     _kube_context_reachable.cache_clear()
     reachability = _kube_context_reachable
 
+    # Time the population phase like a section (it has no section_timings
+    # entry otherwise): on a large deployment the cross-link scans can take
+    # minutes, and without this entry the section timings sum to far less
+    # than the dump's total duration, hiding where the time went.
+    context_start = time.monotonic()
     logger.debug('Cross-linking related resources')
     _get_managed_jobs_from_clusters(debug_dump_context,
                                     reachability,
@@ -2276,6 +2407,12 @@ def _build_debug_dump(
 
     # Always include system daemon requests
     debug_dump_context['request_ids'].update(SYSTEM_REQUEST_IDS)
+
+    section_timings.append({
+        'section': 'context_population',
+        'status': 'completed',
+        'duration_s': round(time.monotonic() - context_start, 2),
+    })
 
     logger.debug(f'After cross-linking: '
                  f'{len(debug_dump_context["request_ids"])} requests, '
@@ -2302,7 +2439,7 @@ def _build_debug_dump(
     # deadline-aware (its internal calls are bounded and it's skipped once the
     # budget is gone), so the build always reaches the zip step with a coherent
     # partial instead of being hard-killed mid-section.
-    sections: List[Tuple[str, Callable[[], None]]] = [
+    sections: List[Tuple[str, Callable[[], Optional[Dict[str, int]]]]] = [
         ('server_info', lambda: _dump_server_info(
             dump_dir, errors=errors, deadline=deadline, orphans=orphans)),
         ('request_ids',
@@ -2333,10 +2470,16 @@ def _build_debug_dump(
                 f'{len(debug_dump_context["cluster_names"])} clusters, '
                 f'{len(debug_dump_context["managed_job_ids"])} managed jobs); '
                 f'budget={"unbounded" if budget is None else f"{budget:.0f}s"}')
-    # Per-section wall-clock + status, surfaced in summary.json so a reader can
-    # see where the budget went (and which sections were skipped) without
-    # grepping the worker log.
-    section_timings: List[Dict[str, Any]] = []
+    # Actual per-resource counts, taken from what the sections report they
+    # wrote -- NOT from the planned scope above -- so summary.json's
+    # 'collected' reflects what is really in the dump (e.g. 0 clusters when
+    # the clusters section was skipped by the deadline). Sections that did
+    # not run leave their count at 0.
+    collected_counts: Dict[str, int] = {
+        'request_count': 0,
+        'cluster_count': 0,
+        'managed_job_count': 0,
+    }
     for name, dump_section in sections:
         if _deadline_exceeded(deadline):
             logger.warning(f'Skipping debug-dump section {name!r}: overall '
@@ -2362,14 +2505,27 @@ def _build_debug_dump(
         remaining = _remaining_budget(deadline)
         logger.info(f'debug dump: section {name!r} start' + (
             '' if remaining is None else f' ({remaining:.0f}s budget left)'))
-        dump_section()
+        stats = dump_section()
         duration = time.monotonic() - section_start
         logger.info(f'debug dump: section {name!r} done in {duration:.1f}s')
-        section_timings.append({
+        timing_entry: Dict[str, Any] = {
             'section': name,
             'status': 'completed',
             'duration_s': round(duration, 2),
-        })
+        }
+        # Sections report what they actually collected by returning a stats
+        # dict (``None`` when there is nothing to itemize, e.g. server_info);
+        # anything else is ignored. A section that deadline-skipped some of
+        # its scoped items is marked partial, so a reader of summary.json
+        # alone sees the truncation without grepping errors.json.
+        if isinstance(stats, dict):
+            timing_entry.update(stats)
+            if stats.get('skipped_deadline', 0):
+                timing_entry['status'] = 'completed_partial'
+            count_key = _SECTION_COLLECTED_KEYS.get(name)
+            if count_key is not None and 'dumped' in stats:
+                collected_counts[count_key] = stats['dumped']
+        section_timings.append(timing_entry)
 
     # Write client info if provided
     if client_info:
@@ -2385,10 +2541,53 @@ def _build_debug_dump(
     with open(errors_path, 'w', encoding='utf-8') as f:
         json.dump(errors, f, indent=2, default=str)
 
-    # Write summary file
+    # Account for the dump's own contents: a file inventory (manifest.json)
+    # and size / count roll-ups (summary.json), so a multi-GB dump can be
+    # navigated from summary.json alone and verified against manifest.json.
+    # Measured here -- after all sections ran, before summary.json and
+    # manifest.json themselves are written, and while debug_dump.log is still
+    # growing -- so sizes are point-in-time (noted in the manifest), close
+    # enough to navigate by.
+    inventory: List[Tuple[str, int]] = []
+    for root, _, files in os.walk(dump_dir):
+        for file_name in files:
+            file_path = os.path.join(root, file_name)
+            try:
+                inventory.append(
+                    (os.path.relpath(file_path,
+                                     dump_dir), os.path.getsize(file_path)))
+            except OSError:
+                continue
+    section_size_bytes = {
+        section:
+        sum(size for path, size in inventory if path.split(os.sep)[0] in paths)
+        for section, paths in _SECTION_OUTPUT_PATHS.items()
+    }
+    for timing in section_timings:
+        if timing['section'] in section_size_bytes:
+            timing['size_bytes'] = section_size_bytes[timing['section']]
+    largest_files = [{
+        'path': path,
+        'size_bytes': size,
+    } for path, size in sorted(inventory, key=lambda item: -item[1])
+                     [:_LARGEST_FILES_LISTED]]
+    total_size_bytes = sum(size for _, size in inventory)
+
+    collection_end_wall = time.time()
+    total_duration_s = time.monotonic() - build_start_mono
+    # Reconstruct the caller's wall-clock deadline (create_debug_dump
+    # re-anchors it onto our monotonic clock; see there) so summary.json can
+    # state the budget without threading the wall-clock value through.
+    deadline_wall = (build_start_wall + (deadline - build_start_mono)
+                     if deadline is not None else None)
+
+    # Write summary file. 'scope' is the planned, cross-linked context;
+    # 'collected' is what the sections actually wrote -- the two differ
+    # whenever the deadline truncates the dump, and a reader of summary.json
+    # alone must be able to see that.
     summary: Dict[str, Any] = {
         'requested': requested,
-        'collected': {
+        'scope': {
             'request_count': len(debug_dump_context['request_ids']),
             'cluster_count': len(debug_dump_context['cluster_names']),
             'managed_job_count': len(debug_dump_context['managed_job_ids']),
@@ -2396,12 +2595,59 @@ def _build_debug_dump(
             'cluster_names': sorted(debug_dump_context['cluster_names']),
             'managed_job_ids': sorted(debug_dump_context['managed_job_ids']),
         },
+        'collected': collected_counts,
+        'truncated': any(t['status'] in ('skipped_deadline',
+                                         'completed_partial')
+                         for t in section_timings),
+        'collection_start_time': build_start_wall,
+        'collection_start_time_human':
+            debug_dump_helpers.epoch_to_human(build_start_wall),
+        'collection_end_time': collection_end_wall,
+        'collection_end_time_human':
+            debug_dump_helpers.epoch_to_human(collection_end_wall),
+        'total_duration_s': round(total_duration_s, 2),
+        'overall_deadline': deadline_wall,
+        'overall_deadline_human':
+            debug_dump_helpers.epoch_to_human(deadline_wall),
+        'budget_remaining_at_start_s':
+            (None if deadline is None else round(deadline - build_start_mono, 2)
+            ),
+        'total_size_bytes': total_size_bytes,
+        'file_count': len(inventory),
+        'largest_files': largest_files,
         'section_timings': section_timings,
         'errors': errors,
     }
     summary_path = os.path.join(dump_dir, 'summary.json')
     with open(summary_path, 'w', encoding='utf-8') as f:
         json.dump(summary, f, indent=2)
+
+    # Write the manifest last, after everything above is known. Not indented:
+    # on a large dump the file list runs to tens of thousands of entries, and
+    # this is a machine index (jq/grep) rather than prose.
+    manifest: Dict[str, Any] = {
+        'collection_start_time': build_start_wall,
+        'collection_start_time_human':
+            debug_dump_helpers.epoch_to_human(build_start_wall),
+        'collection_end_time': collection_end_wall,
+        'collection_end_time_human':
+            debug_dump_helpers.epoch_to_human(collection_end_wall),
+        'total_duration_s': round(total_duration_s, 2),
+        'file_count': len(inventory),
+        'total_size_bytes': total_size_bytes,
+        'section_size_bytes': section_size_bytes,
+        'largest_files': largest_files,
+        'files': [{
+            'path': path,
+            'size_bytes': size,
+        } for path, size in sorted(inventory)],
+        'note': ('Point-in-time inventory taken after collection finished, '
+                 'before summary.json / manifest.json were written; '
+                 'debug_dump.log keeps growing until the zip step completes.'),
+    }
+    manifest_path = os.path.join(dump_dir, 'manifest.json')
+    with open(manifest_path, 'w', encoding='utf-8') as f:
+        json.dump(manifest, f)
 
 
 def create_debug_dump(
@@ -2506,15 +2752,20 @@ def create_debug_dump(
         os.makedirs(dump_dir)
         logger.debug(f'Building dump in temp directory: {dump_dir}')
 
-        # Attach a file handler to capture debug-level logs into the dump
-        # itself. We attach to the root 'sky' logger so that logs from all sky.*
-        # modules are captured, not just sky.utils.debug_utils.  Also attach to
-        # sky.provision which has propagate=False.  This mirrors
-        # sky_logging.add_debug_log_handler().
-        debug_handler = logging.FileHandler(
-            os.path.join(dump_dir, 'debug_dump.log'))
+        # Attach a file handler to capture the dump's operational trail
+        # (section start/done, skips, timeouts, warnings) into the dump
+        # itself. INFO, not DEBUG: at DEBUG the artifact is dominated by
+        # per-item noise from unrelated subsystems -- one line per scanned
+        # request, per deserialized request body, per managed-job record --
+        # which on a large deployment is tens of MB dwarfing the handful of
+        # lines that describe the dump itself. We attach to the root 'sky'
+        # logger so that logs from all sky.* modules are captured, not just
+        # sky.utils.debug_utils.  Also attach to sky.provision which has
+        # propagate=False.  This mirrors sky_logging.add_debug_log_handler().
+        debug_log_path = os.path.join(dump_dir, 'debug_dump.log')
+        debug_handler = logging.FileHandler(debug_log_path)
         debug_handler.setFormatter(sky_logging.FORMATTER)
-        debug_handler.setLevel(logging.DEBUG)
+        debug_handler.setLevel(logging.INFO)
         sky_root_logger = logging.getLogger('sky')
         provision_logger = logging.getLogger('sky.provision')
         try:
@@ -2534,41 +2785,58 @@ def create_debug_dump(
                               client_info,
                               requested=original_requested,
                               deadline=deadline)
-            # Report any op whose worker thread is still running (before we
-            # detach the handler, so it lands in debug_dump.log too).
+            # Report any op whose worker thread is still running (while the
+            # handler is still attached, so it lands in debug_dump.log too).
             _log_timed_out_stragglers(debug_dump_context['timed_out_ops'])
+
+            # Log total dump size before zipping
+            total_dump_size = sum(f.stat().st_size
+                                  for f in pathlib.Path(dump_dir).rglob('*')
+                                  if f.is_file())
+
+            # Create zip file in PERSISTENT location (outside temp dir).
+            # debug_dump.log is deliberately excluded from this walk and
+            # written into the zip after the handler is closed below, so the
+            # archived copy includes the zip-stats lines -- detaching the
+            # handler first (the old behavior) meant the artifact's log ended
+            # at the straggler warnings, and the zip stats reached no
+            # artifact at all.
+            zip_filename = f'debug_dump_{timestamp}.zip'
+            zip_file_path = dump_base_dir / zip_filename
+            # INFO so the zip step is visible in the worker log: it is the last
+            # thing that runs before the dump is durable, and slow zips eat
+            # into any outer deadline's buffer (see the per-section logging
+            # note above).
+            logger.info(f'debug dump: collection done, zipping '
+                        f'{total_dump_size} bytes to {zip_filename}')
+
+            zip_start = time.monotonic()
+            file_count = 0
+            with zipfile.ZipFile(zip_file_path, 'w',
+                                 zipfile.ZIP_DEFLATED) as zipf:
+                for root, _, files in os.walk(dump_dir):
+                    for file in files:
+                        file_path = os.path.join(root, file)
+                        if file_path == debug_log_path:
+                            continue
+                        arcname = os.path.relpath(file_path, temp_dir)
+                        zipf.write(file_path, arcname)
+                        file_count += 1
+
+            logger.info(f'debug dump: created {zip_filename} '
+                        f'({file_count} files) '
+                        f'in {time.monotonic() - zip_start:.1f}s')
         finally:
             sky_root_logger.removeHandler(debug_handler)
             provision_logger.removeHandler(debug_handler)
             debug_handler.flush()
             debug_handler.close()
 
-        # Log total dump size before zipping
-        total_dump_size = sum(f.stat().st_size
-                              for f in pathlib.Path(dump_dir).rglob('*')
-                              if f.is_file())
-
-        # Create zip file in PERSISTENT location (outside temp dir)
-        zip_filename = f'debug_dump_{timestamp}.zip'
-        zip_file_path = dump_base_dir / zip_filename
-        # INFO so the zip step is visible in the worker log: it is the last
-        # thing that runs before the dump is durable, and slow zips eat into
-        # any outer deadline's buffer (see the per-section logging note above).
-        logger.info(f'debug dump: collection done, zipping {total_dump_size} '
-                    f'bytes to {zip_filename}')
-
-        zip_start = time.monotonic()
-        file_count = 0
-        with zipfile.ZipFile(zip_file_path, 'w', zipfile.ZIP_DEFLATED) as zipf:
-            for root, _, files in os.walk(dump_dir):
-                for file in files:
-                    file_path = os.path.join(root, file)
-                    arcname = os.path.relpath(file_path, temp_dir)
-                    zipf.write(file_path, arcname)
-                    file_count += 1
-
-        logger.info(f'debug dump: created {zip_filename} ({file_count} files) '
-                    f'in {time.monotonic() - zip_start:.1f}s')
+        # The handler is closed, so debug_dump.log is complete; add it to the
+        # zip as the last entry.
+        with zipfile.ZipFile(zip_file_path, 'a', zipfile.ZIP_DEFLATED) as zipf:
+            zipf.write(debug_log_path, os.path.relpath(debug_log_path,
+                                                       temp_dir))
 
     logger.info(f'debug dump: finished in {time.monotonic() - dump_start:.1f}s '
                 f'-> {zip_file_path}')

--- a/sky/utils/debug_utils.py
+++ b/sky/utils/debug_utils.py
@@ -804,30 +804,18 @@ def _populate_recent_context(
         f'Populating context with resources from last {minutes} minutes')
     cutoff_time = time.time() - (minutes * 60)
 
-    # The dump's own request is RUNNING while this scan runs, so without an
-    # explicit exclusion it would include itself -- and copying its
-    # request.log / request_debug.log would ship the dump's own output
-    # stream a second time inside the artifact. Only this accidental
-    # self-inclusion is excluded: explicitly requesting the dump's own
-    # request ID still dumps it. Outside a server-side request execution
-    # (e.g. tests, in-process callers) there is no own request to exclude.
-    own_request_id = (common_utils.get_current_request_id()
-                      if common_utils.is_in_request_context() else None)
-
     # Get recent requests (cluster names are handled by
-    # _get_clusters_from_requests during cross-linking)
+    # _get_clusters_from_requests during cross-linking). The dump's own
+    # (running) request intentionally stays in scope here: its
+    # request_info.json records who triggered the dump, when, and with what
+    # parameters. Its log copies are skipped separately, at the log-copy
+    # level in _dump_request_id_info (skip_log_request_ids).
     try:
         requests = requests_lib.get_request_tasks(
             requests_lib.RequestTaskFilter(finished_after=cutoff_time,
                                            fields=['request_id',
                                                    'finished_at']))
         for request in requests:
-            if own_request_id is not None and (request.request_id
-                                               == own_request_id):
-                logger.debug('Recent: excluding the debug dump\'s own '
-                             f'request {request.request_id} (its logs are '
-                             'the dump itself)')
-                continue
             logger.debug(f'Recent: including request {request.request_id} '
                          f'(finished_at={request.finished_at},'
                          f' cutoff={cutoff_time:.0f})')
@@ -1106,12 +1094,13 @@ _REQUEST_LOG_COPY_TIMEOUT = 30
 
 
 def _dump_request_id_info(
-        request_ids: Set[str],
-        dump_dir: str,
-        errors: Optional[List[Dict[str, str]]] = None,
-        deadline: Optional[float] = None,
-        orphans: Optional[List[Dict[str,
-                                    Any]]] = None) -> Optional[Dict[str, int]]:
+    request_ids: Set[str],
+    dump_dir: str,
+    errors: Optional[List[Dict[str, str]]] = None,
+    deadline: Optional[float] = None,
+    orphans: Optional[List[Dict[str, Any]]] = None,
+    skip_log_request_ids: Optional[Set[str]] = None
+) -> Optional[Dict[str, int]]:
     """Collect request logs and metadata.
 
     ``deadline`` (absolute monotonic) bounds the section two ways: each
@@ -1121,11 +1110,24 @@ def _dump_request_id_info(
     dump still zips what it gathered. Per-request wall-clock is written to
     ``requests/_timings.json``.
 
-    Returns per-item stats for summary.json -- ``dumped`` (request info
-    written), ``not_found`` (request ID no longer in the DB) and
-    ``skipped_deadline`` (never attempted, budget gone) -- which together
-    account for every request in the section's scope. ``None`` when there
-    are no requests to dump.
+    ``skip_log_request_ids`` lists requests whose metadata
+    (request_info.json) is still collected but whose log copies are skipped
+    -- used for the dump's own request, whose operational trail is already
+    archived in debug_dump.log.
+
+    Returns per-item stats for summary.json: ``planned`` (requests in the
+    section's scope), ``dumped``, ``not_found`` (request ID no longer in
+    the DB) and ``skipped_deadline`` (never attempted, budget gone), or
+    ``None`` when there are no requests to dump. ``dumped`` is DISK-DERIVED
+    (per-request directories containing at least one file -- exactly what
+    the os.walk-based zipping keeps), so it can OVERLAP ``not_found``: the
+    log-copy blocks below run for every attempted request, including a
+    DB-pruned one whose logs still exist on disk, and such a request counts
+    in both buckets. ``planned == dumped + not_found + skipped_deadline``
+    therefore holds exactly when every not-found request left no files on
+    disk. A request whose DB fetch raised but whose log copy landed counts
+    in ``dumped`` (and is recorded in errors.json); a DB-fetch failure that
+    wrote nothing to disk appears only in errors.json.
     """
     if not request_ids:
         logger.debug('No requests to dump')
@@ -1137,6 +1139,7 @@ def _dump_request_id_info(
     os.makedirs(requests_dir, exist_ok=True)
 
     stats: Dict[str, int] = {
+        'planned': len(request_ids),
         'dumped': 0,
         'not_found': 0,
         'skipped_deadline': 0,
@@ -1198,7 +1201,6 @@ def _dump_request_id_info(
                     f'(name={request.name}, '
                     f'status='
                     f'{request.status.value if request.status else None})')
-                stats['dumped'] += 1
             else:
                 stats['not_found'] += 1
                 logger.debug(f'Request {request_id} not found in DB')
@@ -1212,60 +1214,75 @@ def _dump_request_id_info(
                     'traceback': _full_traceback()
                 })
 
+        # A request listed in skip_log_request_ids (the dump's own request)
+        # keeps its metadata above but skips both log copies below:
+        # debug_dump.log already archives this dump's own operational trail
+        # (at INFO -- the request's DEBUG stream is deliberately not shipped
+        # in the artifact at all).
+        skip_logs = (skip_log_request_ids is not None and
+                     request_id in skip_log_request_ids)
+        if skip_logs:
+            logger.debug(f'Skipping log copies for request {request_id}: '
+                         'debug_dump.log archives this dump\'s own '
+                         'operational trail')
+
         # Copy request log file. Routed through the LogProvider so that
         # deployments whose request logs are not on the local filesystem
         # can fetch them from wherever they live. Deadline-bounded: a
         # streaming/active request's copy can block for tens of seconds.
-        try:
-            ok, copied = _run_with_deadline(
-                functools.partial(_copy_request_log_file, request_id,
-                                  request_dir,
-                                  log_provider.RequestLogType.REQUEST,
-                                  'request.log'),
-                _bounded_timeout(_REQUEST_LOG_COPY_TIMEOUT, deadline),
-                component='requests',
-                resource=f'{request_id}/log',
-                errors=errors,
-                orphans=orphans)
-            if ok and copied:
-                logger.debug(f'Copied request log for {request_id}')
-            elif ok:
-                logger.debug(f'Request log not found for {request_id}')
-        except Exception as e:  # pylint: disable=broad-except
-            logger.warning(f'Failed to copy log for request {request_id}: {e}')
-            if errors is not None:
-                errors.append({
-                    'component': 'requests',
-                    'resource': f'{request_id}/log',
-                    'error': str(e),
-                    'traceback': _full_traceback()
-                })
+        if not skip_logs:
+            try:
+                ok, copied = _run_with_deadline(
+                    functools.partial(_copy_request_log_file, request_id,
+                                      request_dir,
+                                      log_provider.RequestLogType.REQUEST,
+                                      'request.log'),
+                    _bounded_timeout(_REQUEST_LOG_COPY_TIMEOUT, deadline),
+                    component='requests',
+                    resource=f'{request_id}/log',
+                    errors=errors,
+                    orphans=orphans)
+                if ok and copied:
+                    logger.debug(f'Copied request log for {request_id}')
+                elif ok:
+                    logger.debug(f'Request log not found for {request_id}')
+            except Exception as e:  # pylint: disable=broad-except
+                logger.warning(
+                    f'Failed to copy log for request {request_id}: {e}')
+                if errors is not None:
+                    errors.append({
+                        'component': 'requests',
+                        'resource': f'{request_id}/log',
+                        'error': str(e),
+                        'traceback': _full_traceback()
+                    })
 
         # Copy debug log file (only exists when
         # ENABLE_REQUEST_DEBUG_LOGGING is enabled). Deadline-bounded too.
-        try:
-            ok, copied = _run_with_deadline(
-                functools.partial(_copy_request_log_file, request_id,
-                                  request_dir,
-                                  log_provider.RequestLogType.DEBUG,
-                                  'request_debug.log'),
-                _bounded_timeout(_REQUEST_LOG_COPY_TIMEOUT, deadline),
-                component='requests',
-                resource=f'{request_id}/request_debug.log',
-                errors=errors,
-                orphans=orphans)
-            if ok and copied:
-                logger.debug(f'Copied debug log for {request_id}')
-        except Exception as e:  # pylint: disable=broad-except
-            logger.warning(
-                f'Failed to copy debug log for request {request_id}: {e}')
-            if errors is not None:
-                errors.append({
-                    'component': 'requests',
-                    'resource': f'{request_id}/request_debug.log',
-                    'error': str(e),
-                    'traceback': _full_traceback()
-                })
+        if not skip_logs:
+            try:
+                ok, copied = _run_with_deadline(
+                    functools.partial(_copy_request_log_file, request_id,
+                                      request_dir,
+                                      log_provider.RequestLogType.DEBUG,
+                                      'request_debug.log'),
+                    _bounded_timeout(_REQUEST_LOG_COPY_TIMEOUT, deadline),
+                    component='requests',
+                    resource=f'{request_id}/request_debug.log',
+                    errors=errors,
+                    orphans=orphans)
+                if ok and copied:
+                    logger.debug(f'Copied debug log for {request_id}')
+            except Exception as e:  # pylint: disable=broad-except
+                logger.warning(
+                    f'Failed to copy debug log for request {request_id}: {e}')
+                if errors is not None:
+                    errors.append({
+                        'component': 'requests',
+                        'resource': f'{request_id}/request_debug.log',
+                        'error': str(e),
+                        'traceback': _full_traceback()
+                    })
 
         timings.append({
             'request_id': request_id,
@@ -1279,6 +1296,12 @@ def _dump_request_id_info(
             json.dump(timings, f, indent=2)
     except OSError as e:
         logger.debug(f'Failed to write request timings: {e}')
+    # Disk-derived, like the other itemized sections: count the per-request
+    # directories that actually hold a file (what the zip keeps), not an
+    # in-loop counter -- the two diverge when a DB fetch fails but a log
+    # copy lands, or when a not-found request's logs still exist (see the
+    # docstring for the overlap semantics).
+    stats['dumped'] = _count_item_dirs_with_files(requests_dir)
     logger.debug('Exiting _dump_request_id_info')
     return stats
 
@@ -1626,9 +1649,14 @@ def _dump_kube_contexts_info(
     ``orphans``) and whatever landed on disk is kept. Best-effort throughout:
     errors are recorded, never aborts the dump.
 
-    Returns per-item stats for summary.json (``dumped``: context directories
-    with at least one file -- whatever landed on disk, including a partial
-    batch cut off by the timeout), or ``None`` when there is nothing to dump.
+    Returns per-item stats for summary.json (``planned``: contexts in
+    scope; ``dumped``: context directories with at least one file --
+    whatever landed on disk, including a partial batch cut off by the
+    timeout, so it is a lower bound on what abandoned workers may still
+    write before the zip; ``skipped_deadline``: present only on the timeout
+    path, where it is inferred as ``planned - dumped`` -- the batch was
+    abandoned before completing), or ``None`` when there is nothing to
+    dump.
     """
     try:
         contexts = clouds.Kubernetes.existing_allowed_contexts(silent=True)
@@ -1688,8 +1716,19 @@ def _dump_kube_contexts_info(
     )
     if not ok or results is None:
         # Timed out: _run_with_deadline recorded the skip + orphan; per-context
-        # dirs written before the cutoff remain on disk as a partial.
-        return {'dumped': _count_item_dirs_with_files(contexts_root)}
+        # dirs written before the cutoff remain on disk as a partial. The
+        # abandoned workers' per-context errors are unrecoverable here, so
+        # the skipped count is inferred as planned minus what landed. Note
+        # both counts are taken at return time -- abandoned workers may
+        # still land context dirs before the zip's os.walk, so 'dumped' is
+        # a lower bound on the zip's contents.
+        planned = len(unique_contexts)
+        dumped = _count_item_dirs_with_files(contexts_root)
+        return {
+            'planned': planned,
+            'dumped': dumped,
+            'skipped_deadline': planned - dumped,
+        }
 
     timings: List[Dict[str, Any]] = []
     for context, (ctx_errors, duration_s) in zip(unique_contexts, results):
@@ -1714,7 +1753,10 @@ def _dump_kube_contexts_info(
             json.dump(timings, f, indent=2)
     except OSError as e:
         logger.debug(f'Failed to write kube-context timings: {e}')
-    return {'dumped': _count_item_dirs_with_files(contexts_root)}
+    return {
+        'planned': len(unique_contexts),
+        'dumped': _count_item_dirs_with_files(contexts_root),
+    }
 
 
 _KubeContextReachabilityChecker = Callable[[Optional[str]], bool]
@@ -1973,9 +2015,10 @@ def _dump_cluster_info(
     cluster. run_in_parallel keeps per-cluster best-effort isolation -- each
     worker returns its own error records, merged here after all finish.
 
-    Returns per-item stats for summary.json (``dumped``: cluster directories
-    with at least one file, i.e. what actually lands in the dump zip), or
-    ``None`` when there are no clusters to dump.
+    Returns per-item stats for summary.json (``planned``: clusters in
+    scope; ``dumped``: cluster directories with at least one file, i.e.
+    what actually lands in the dump zip), or ``None`` when there are no
+    clusters to dump.
     """
     if not cluster_names:
         logger.debug('No clusters to dump')
@@ -1998,6 +2041,7 @@ def _dump_cluster_info(
             errors.extend(cluster_errors)
 
     stats: Dict[str, int] = {
+        'planned': len(cluster_names),
         'dumped': _count_item_dirs_with_files(clusters_dir),
     }
     logger.debug('Exiting _dump_cluster_info')
@@ -2019,9 +2063,10 @@ def _dump_managed_job_info(
     memoized probe covers the whole section (and, via the shared cache,
     reuses the clusters section's probe of the same context).
 
-    Returns per-item stats for summary.json (``dumped``: managed-job
-    directories with at least one file, i.e. what actually lands in the
-    dump zip), or ``None`` when there are no managed jobs to dump.
+    Returns per-item stats for summary.json (``planned``: managed jobs in
+    scope; ``dumped``: managed-job directories with at least one file, i.e.
+    what actually lands in the dump zip), or ``None`` when there are no
+    managed jobs to dump.
     """
     if not managed_job_ids:
         logger.debug('No managed jobs to dump')
@@ -2041,7 +2086,14 @@ def _dump_managed_job_info(
                 _controller_skip_error('managed_jobs', 'controller_access',
                                        dead_context))
         logger.debug('Exiting _dump_managed_job_info')
-        return {'dumped': 0}
+        # Controller unreachable: nothing was attempted, so the section
+        # reads 'completed' with a legible planned/dumped disparity -- the
+        # per-item failure is already recorded in errors.json (see the
+        # canonical outcome-shape note at the section runner).
+        return {
+            'planned': len(managed_job_ids),
+            'dumped': 0,
+        }
 
     # Phase 1: Queue info from queue_v2 (works in both consolidation and
     # non-consolidation modes via existing gRPC/SSH plumbing)
@@ -2057,6 +2109,7 @@ def _dump_managed_job_info(
         # Per-job directories only: the controller-side phase also writes
         # non-per-job directories (controller_system/, controller_submit_logs/
         # ) under managed_jobs/, which are not scoped jobs.
+        'planned': len(managed_job_ids),
         'dumped': _count_item_dirs_with_files(jobs_dir,
                                               name_filter=str.isdigit),
     }
@@ -2301,6 +2354,7 @@ _SECTION_COLLECTED_KEYS = {
     'request_ids': 'request_count',
     'clusters': 'cluster_count',
     'managed_jobs': 'managed_job_count',
+    'kubernetes_contexts': 'kubernetes_context_count',
 }
 
 # Maps a dump section to the dump-root paths it writes, so summary.json can
@@ -2439,15 +2493,27 @@ def _build_debug_dump(
     # deadline-aware (its internal calls are bounded and it's skipped once the
     # budget is gone), so the build always reaches the zip step with a coherent
     # partial instead of being hard-killed mid-section.
+
+    # The dump's own request stays in scope (its request_info.json records
+    # who triggered the dump, when, and with what parameters), but its log
+    # copies are skipped: debug_dump.log already archives this dump's own
+    # operational trail. Resolved here rather than in create_debug_dump so
+    # direct _build_debug_dump callers keep their signature. Outside a
+    # server-side request execution (tests, in-process callers) there is no
+    # own request to skip.
+    own_request_id = (common_utils.get_current_request_id()
+                      if common_utils.is_in_request_context() else None)
     sections: List[Tuple[str, Callable[[], Optional[Dict[str, int]]]]] = [
         ('server_info', lambda: _dump_server_info(
             dump_dir, errors=errors, deadline=deadline, orphans=orphans)),
-        ('request_ids',
-         lambda: _dump_request_id_info(debug_dump_context['request_ids'],
-                                       dump_dir,
-                                       errors=errors,
-                                       deadline=deadline,
-                                       orphans=orphans)),
+        ('request_ids', lambda: _dump_request_id_info(
+            debug_dump_context['request_ids'],
+            dump_dir,
+            errors=errors,
+            deadline=deadline,
+            orphans=orphans,
+            skip_log_request_ids=({own_request_id}
+                                  if own_request_id is not None else None))),
         ('clusters',
          lambda: _dump_cluster_info(debug_dump_context['cluster_names'],
                                     dump_dir,
@@ -2479,6 +2545,7 @@ def _build_debug_dump(
         'request_count': 0,
         'cluster_count': 0,
         'managed_job_count': 0,
+        'kubernetes_context_count': 0,
     }
     for name, dump_section in sections:
         if _deadline_exceeded(deadline):
@@ -2513,11 +2580,36 @@ def _build_debug_dump(
             'status': 'completed',
             'duration_s': round(duration, 2),
         }
-        # Sections report what they actually collected by returning a stats
-        # dict (``None`` when there is nothing to itemize, e.g. server_info);
-        # anything else is ignored. A section that deadline-skipped some of
-        # its scoped items is marked partial, so a reader of summary.json
-        # alone sees the truncation without grepping errors.json.
+        # Canonical per-section outcome shape (each itemized section returns
+        # this; ``None`` or a non-dict when there is nothing to itemize,
+        # e.g. server_info, is ignored):
+        #   {planned, dumped, skipped_deadline, not_found?}
+        # * 'planned' is the section's scoped item count.
+        # * 'dumped' is DISK-DERIVED (item directories containing at least
+        #   one file -- exactly what the os.walk-based zipping keeps), so it
+        #   can OVERLAP 'not_found' when a DB-pruned request still has logs
+        #   on disk (the log-copy blocks run for every attempted request):
+        #   planned == dumped + skipped_deadline + not_found holds exactly
+        #   when not-found requests left no files. Requests whose DB fetch
+        #   raised but whose log copies landed count in 'dumped' and in
+        #   errors.json; DB-fetch failures that wrote nothing to disk appear
+        #   only in errors.json.
+        # * 'skipped_deadline' is an exact in-loop count for the requests
+        #   section, but on the kubernetes_contexts batch-timeout path it is
+        #   INFERRED (planned - dumped: the batch was abandoned before
+        #   completing). That timeout can fire from the fixed
+        #   _KUBE_CONTEXTS_TIMEOUT cap with no overall deadline at all -- in
+        #   which case the summary 'truncated' flag is still correct, since
+        #   the dump genuinely is incomplete. Both 'dumped' and the inferred
+        #   skip are return-time counts while abandoned workers may still
+        #   land directories before the zip's os.walk, so the counts are a
+        #   lower bound on the zip's contents, never an overstatement.
+        # 'completed_partial' keys on skipped_deadline > 0 (deadline / batch
+        # truncation) deliberately and NOT on dumped < planned: per-item
+        # failures are already recorded in errors.json -- which is why e.g.
+        # the managed-jobs controller-unreachable gate (planned=N, dumped=0,
+        # an errors.json record) still reads 'completed' with a legible
+        # planned/dumped disparity instead of a misleading 'partial'.
         if isinstance(stats, dict):
             timing_entry.update(stats)
             if stats.get('skipped_deadline', 0):
@@ -2795,14 +2887,17 @@ def create_debug_dump(
                                   if f.is_file())
 
             # Create zip file in PERSISTENT location (outside temp dir).
-            # debug_dump.log is deliberately excluded from this walk and
-            # written into the zip after the handler is closed below, so the
-            # archived copy includes the zip-stats lines -- detaching the
-            # handler first (the old behavior) meant the artifact's log ended
-            # at the straggler warnings, and the zip stats reached no
-            # artifact at all.
+            # debug_dump.log and manifest.json are deliberately excluded
+            # from this walk and appended after it: the log only once the
+            # handler is closed below, so the archived copy includes the
+            # zip-stats lines, and the manifest last of all, after the zip's
+            # own stats are known (see the append below). Detaching the
+            # handler before zipping (the old behavior) meant the
+            # artifact's log ended at the straggler warnings, and the zip
+            # stats reached no artifact at all.
             zip_filename = f'debug_dump_{timestamp}.zip'
             zip_file_path = dump_base_dir / zip_filename
+            manifest_path = os.path.join(dump_dir, 'manifest.json')
             # INFO so the zip step is visible in the worker log: it is the last
             # thing that runs before the dump is durable, and slow zips eat
             # into any outer deadline's buffer (see the per-section logging
@@ -2817,7 +2912,7 @@ def create_debug_dump(
                 for root, _, files in os.walk(dump_dir):
                     for file in files:
                         file_path = os.path.join(root, file)
-                        if file_path == debug_log_path:
+                        if file_path in (debug_log_path, manifest_path):
                             continue
                         arcname = os.path.relpath(file_path, temp_dir)
                         zipf.write(file_path, arcname)
@@ -2832,11 +2927,41 @@ def create_debug_dump(
             debug_handler.flush()
             debug_handler.close()
 
-        # The handler is closed, so debug_dump.log is complete; add it to the
-        # zip as the last entry.
+        # The handler is closed, so debug_dump.log is complete; add it to
+        # the zip.
         with zipfile.ZipFile(zip_file_path, 'a', zipfile.ZIP_DEFLATED) as zipf:
             zipf.write(debug_log_path, os.path.relpath(debug_log_path,
                                                        temp_dir))
+
+        # manifest.json goes in as the true final entry, after the zip's own
+        # stats are known: entry_count is exact (pass-1 files + debug_dump.log
+        # + the manifest itself) and compressed_size_bytes is measured after
+        # the log append, excluding the manifest entry (written after those
+        # stats). Best-effort: on failure the dump still returns -- a valid
+        # zip minus manifest.json already exists, and the warning lands in
+        # the worker log (the debug handler is closed by now).
+        try:
+            with open(manifest_path, 'r', encoding='utf-8') as f:
+                zip_manifest: Dict[str, Any] = json.load(f)
+            zip_manifest['zip'] = {
+                'entry_count': file_count + 2,
+                'zip_duration_s': round(time.monotonic() - zip_start, 2),
+                'compressed_size_bytes': os.path.getsize(zip_file_path),
+            }
+            zip_manifest['note'] = (
+                'Point-in-time inventory taken after collection finished, '
+                'before summary.json / manifest.json were written; '
+                'debug_dump.log sizes are as of handler close; '
+                'zip.entry_count and zip.compressed_size_bytes exclude the '
+                'manifest entry itself (written last, after those stats '
+                'were measured).')
+            with zipfile.ZipFile(zip_file_path, 'a',
+                                 zipfile.ZIP_DEFLATED) as zipf:
+                zipf.writestr(os.path.relpath(manifest_path, temp_dir),
+                              json.dumps(zip_manifest))
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning(f'Failed to append manifest.json to the debug '
+                           f'dump zip {zip_filename}: {e}')
 
     logger.info(f'debug dump: finished in {time.monotonic() - dump_start:.1f}s '
                 f'-> {zip_file_path}')

--- a/tests/unit_tests/test_sky/utils/test_debug_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_debug_utils.py
@@ -1098,6 +1098,36 @@ class TestPopulateRecentContext:
 
         assert 'req-running' in ctx['request_ids']
 
+    @mock.patch('sky.utils.debug_utils.common_utils.is_in_request_context',
+                return_value=True)
+    @mock.patch('sky.utils.debug_utils.common_utils.get_current_request_id',
+                return_value='own-dump-request')
+    @mock.patch('sky.jobs.server.core.queue_v2')
+    @mock.patch('sky.utils.debug_utils.global_user_state.get_clusters')
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_excludes_own_request(self, mock_get_tasks, mock_get_clusters,
+                                  mock_queue_v2, mock_get_own_id,
+                                  mock_in_request_context):
+        """The dump's own (running) request must not include itself.
+
+        Without the exclusion, copying the dump request's own
+        request.log / request_debug.log ships the dump's output stream a
+        second time inside the artifact."""
+        own_request = _make_request(request_id='own-dump-request',
+                                    finished_at=None)
+        other_request = _make_request(request_id='req-other', finished_at=None)
+        mock_get_tasks.return_value = [own_request, other_request]
+        mock_get_clusters.return_value = []
+        mock_queue_v2.return_value = ([], 0, {}, 0, [])
+
+        ctx = _make_context()
+        debug_utils._populate_recent_context(ctx,
+                                             minutes=60.0,
+                                             reachability=_StubReachability())
+
+        assert 'own-dump-request' not in ctx['request_ids']
+        assert 'req-other' in ctx['request_ids']
+
     @mock.patch('sky.jobs.server.core.queue_v2')
     @mock.patch('sky.utils.debug_utils.global_user_state.get_clusters')
     @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
@@ -1596,7 +1626,15 @@ class TestCreateDebugDump:
             mock_jobs_from_req, mock_clusters_from_req, mock_clusters_from_jobs,
             mock_dump_server, mock_dump_requests, mock_dump_clusters,
             mock_dump_jobs, tmp_path):
-        """Summary should reflect the final collected counts."""
+        """Summary should reflect what the sections report they collected.
+
+        'collected' counts come from the section stats (what was actually
+        written); 'scope' counts come from the planned cross-linked context
+        (which also includes the always-added system request IDs).
+        """
+        mock_dump_requests.return_value = {'dumped': 3}
+        mock_dump_clusters.return_value = {'dumped': 1}
+        mock_dump_jobs.return_value = {'dumped': 1}
         with mock.patch('sky.utils.debug_utils.DEBUG_DUMP_DIR',
                         str(tmp_path / 'debug_dumps')):
             result = debug_utils.create_debug_dump(
@@ -1610,11 +1648,17 @@ class TestCreateDebugDump:
             summary_files = [n for n in names if n.endswith('summary.json')]
             summary_data = json.loads(zf.read(summary_files[0]))
 
-            # System request IDs are always added
             collected = summary_data['collected']
-            assert collected['request_count'] >= 2  # At least our 2 + system
-            assert collected['cluster_count'] >= 1
-            assert collected['managed_job_count'] >= 1
+            assert collected['request_count'] == 3
+            assert collected['cluster_count'] == 1
+            assert collected['managed_job_count'] == 1
+
+            # System request IDs are always added to the scope
+            scope = summary_data['scope']
+            assert scope['request_count'] >= 2  # At least our 2 + system
+            assert scope['cluster_count'] >= 1
+            assert scope['managed_job_count'] >= 1
+            assert 'req-1' in scope['request_ids']
 
     @mock.patch('sky.utils.debug_utils._dump_managed_job_info')
     @mock.patch('sky.utils.debug_utils._dump_cluster_info')
@@ -1738,7 +1782,7 @@ class TestRequestIdPrefixResolution:
                 zf.read([
                     n for n in zf.namelist() if n.endswith('summary.json')
                 ][0]))
-        collected_ids = summary['collected']['request_ids']
+        collected_ids = summary['scope']['request_ids']
         assert 'abc-111' in collected_ids
         assert 'abc-222' in collected_ids
 
@@ -1771,7 +1815,7 @@ class TestRequestIdPrefixResolution:
                 ][0]))
         # The unmatched prefix should not appear in collected IDs
         # (only system request IDs should be present)
-        assert 'nonexistent' not in summary['collected']['request_ids']
+        assert 'nonexistent' not in summary['scope']['request_ids']
 
 
 # ---------------------------------------------------------------------------
@@ -3084,7 +3128,8 @@ class TestDumpRequestIdInfo:
         )
 
         errors: List[Dict[str, str]] = []
-        debug_utils._dump_request_id_info({'req-1'}, str(tmp_path), errors)
+        stats = debug_utils._dump_request_id_info({'req-1'}, str(tmp_path),
+                                                  errors)
 
         info_path = tmp_path / 'requests' / 'req-1' / 'request_info.json'
         assert info_path.exists()
@@ -3095,6 +3140,7 @@ class TestDumpRequestIdInfo:
         assert data['status'] == 'SUCCEEDED'
         assert data['cluster_name'] == 'my-cluster'
         assert not errors
+        assert stats == {'dumped': 1, 'not_found': 0, 'skipped_deadline': 0}
 
     @mock.patch('sky.utils.debug_utils.requests_lib.get_request')
     def test_request_not_found(self, mock_get_request, tmp_path):
@@ -3102,13 +3148,37 @@ class TestDumpRequestIdInfo:
         mock_get_request.return_value = None
 
         errors: List[Dict[str, str]] = []
-        debug_utils._dump_request_id_info({'req-missing'}, str(tmp_path),
-                                          errors)
+        stats = debug_utils._dump_request_id_info({'req-missing'},
+                                                  str(tmp_path), errors)
 
         # No crash, no error recorded (not-found is not an error)
         assert not errors
         info_path = tmp_path / 'requests' / 'req-missing' / 'request_info.json'
         assert not info_path.exists()
+        assert stats == {'dumped': 0, 'not_found': 1, 'skipped_deadline': 0}
+
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request')
+    def test_deadline_skip_stats(self, mock_get_request, tmp_path):
+        """An exhausted budget should skip every request and report it.
+
+        The per-item skip records land in errors.json; the section stats
+        (returned here, surfaced in summary.json's section_timings) carry
+        the count so the section can be marked completed_partial.
+        """
+        mock_get_request.return_value = _make_request(request_id='req-1')
+
+        errors: List[Dict[str, str]] = []
+        stats = debug_utils._dump_request_id_info({'req-1', 'req-2', 'req-3'},
+                                                  str(tmp_path),
+                                                  errors,
+                                                  deadline=time.monotonic() - 1)
+
+        assert stats == {'dumped': 0, 'not_found': 0, 'skipped_deadline': 3}
+        assert len(errors) == 3
+        assert all(
+            e['error'] == 'Skipped: overall debug-dump deadline exceeded.'
+            for e in errors)
+        assert not mock_get_request.called
 
     @mock.patch('sky.utils.debug_utils.requests_lib.get_request')
     def test_db_failure_records_error(self, mock_get_request, tmp_path):
@@ -3126,10 +3196,11 @@ class TestDumpRequestIdInfo:
     def test_empty_request_ids_is_noop(self, tmp_path):
         """Empty request_ids should not create any files."""
         errors: List[Dict[str, str]] = []
-        debug_utils._dump_request_id_info(set(), str(tmp_path), errors)
+        stats = debug_utils._dump_request_id_info(set(), str(tmp_path), errors)
 
         assert not errors
         assert not (tmp_path / 'requests').exists()
+        assert stats is None
 
     @mock.patch('sky.utils.debug_utils.log_provider.get_log_provider')
     @mock.patch('sky.utils.debug_utils.requests_lib.get_request')
@@ -4493,3 +4564,212 @@ class TestOverallDeadlineDump:
         assert result.exists()
         for fn, m in section_mocks.items():
             assert m.call_count == 1, f'{fn} should have run exactly once'
+
+
+# ---------------------------------------------------------------------------
+# Tests for summary.json truthfulness and the dump's self-accounting
+# (manifest.json, section stats, debug_dump.log level / zip stats).
+# ---------------------------------------------------------------------------
+class TestSummaryTruth:
+    """summary.json must describe what was actually collected, and the dump
+    must account for its own time, size and contents."""
+
+    _CROSSLINK_FNS = (
+        '_get_managed_jobs_from_clusters',
+        '_populate_recent_context',
+        '_get_managed_jobs_from_requests',
+        '_get_job_clusters_from_managed_jobs',
+        '_get_requests_from_clusters',
+        '_get_requests_from_managed_jobs',
+        '_get_clusters_from_requests',
+        '_get_clusters_from_managed_jobs',
+    )
+    _SECTION_FNS = (
+        '_dump_server_info',
+        '_dump_kube_contexts_info',
+        '_dump_request_id_info',
+        '_dump_cluster_info',
+        '_dump_managed_job_info',
+    )
+
+    @contextlib.contextmanager
+    def _patched_dump(self, tmp_path):
+        """Patch all cross-link + section helpers; yield the section mocks.
+
+        Also stubs request-ID prefix resolution (same as
+        TestCreateDebugDump): inputs resolve to themselves.
+        """
+
+        def _fake_prefix_lookup(prefix, fields=None):
+            return [mock.MagicMock(request_id=prefix)]
+
+        with contextlib.ExitStack() as stack:
+            for fn in self._CROSSLINK_FNS:
+                stack.enter_context(mock.patch(f'sky.utils.debug_utils.{fn}'))
+            section_mocks = {
+                fn:
+                stack.enter_context(mock.patch(f'sky.utils.debug_utils.{fn}'))
+                for fn in self._SECTION_FNS
+            }
+            stack.enter_context(
+                mock.patch('sky.utils.debug_utils.DEBUG_DUMP_DIR',
+                           str(tmp_path / 'debug_dumps')))
+            with mock.patch(
+                    'sky.utils.debug_utils.requests_lib'
+                    '.get_requests_with_prefix',
+                    side_effect=_fake_prefix_lookup):
+                yield section_mocks
+
+    @staticmethod
+    def _read_from_zip(zip_path, suffix):
+        with zipfile.ZipFile(zip_path, 'r') as zf:
+            name = next(n for n in zf.namelist() if n.endswith(suffix))
+            return json.loads(zf.read(name)), zf.namelist()
+
+    def test_section_stats_mark_partial_and_feed_collected(self, tmp_path):
+        """A section that deadline-skipped items must be marked
+        completed_partial with a dumped/skipped breakdown, and the summary's
+        'collected' counts must come from those stats -- not from the planned
+        scope."""
+        with self._patched_dump(tmp_path) as section_mocks:
+            section_mocks['_dump_request_id_info'].return_value = {
+                'dumped': 7,
+                'not_found': 1,
+                'skipped_deadline': 2,
+            }
+            section_mocks['_dump_cluster_info'].return_value = {'dumped': 4}
+            section_mocks['_dump_managed_job_info'].return_value = {'dumped': 0}
+            result = debug_utils.create_debug_dump(request_ids=['req-1'],
+                                                   cluster_names=['c1'],
+                                                   managed_job_ids=[3])
+
+        summary, _ = self._read_from_zip(result, 'summary.json')
+        timings = {t['section']: t for t in summary['section_timings']}
+        assert timings['request_ids']['status'] == 'completed_partial'
+        assert timings['request_ids']['dumped'] == 7
+        assert timings['request_ids']['not_found'] == 1
+        assert timings['request_ids']['skipped_deadline'] == 2
+        assert timings['clusters']['status'] == 'completed'
+        assert summary['collected'] == {
+            'request_count': 7,
+            'cluster_count': 4,
+            'managed_job_count': 0,
+        }
+        assert summary['truncated'] is True
+        # The planned scope still reports the full cross-linked context.
+        assert summary['scope']['request_count'] >= 1
+        assert 'req-1' in summary['scope']['request_ids']
+
+    def test_all_completed_sections_not_truncated(self, tmp_path):
+        """No deadline skips anywhere: no completed_partial status, and
+        'truncated' is False."""
+        with self._patched_dump(tmp_path) as section_mocks:
+            section_mocks['_dump_request_id_info'].return_value = {
+                'dumped': 5,
+                'not_found': 0,
+                'skipped_deadline': 0,
+            }
+            result = debug_utils.create_debug_dump(request_ids=['req-1'])
+
+        summary, _ = self._read_from_zip(result, 'summary.json')
+        timings = {t['section']: t for t in summary['section_timings']}
+        assert timings['request_ids']['status'] == 'completed'
+        assert summary['truncated'] is False
+
+    def test_past_deadline_collected_is_zero_scope_intact(self, tmp_path):
+        """Deadline-truncated dump: collected counts are all zero (no section
+        wrote anything) while the scope still shows the planned context, and
+        the summary flags the truncation."""
+        with self._patched_dump(tmp_path):
+            result = debug_utils.create_debug_dump(
+                cluster_names=['c'], overall_deadline=time.time() - 1)
+
+        summary, _ = self._read_from_zip(result, 'summary.json')
+        assert summary['collected'] == {
+            'request_count': 0,
+            'cluster_count': 0,
+            'managed_job_count': 0,
+        }
+        assert summary['scope']['cluster_count'] == 1
+        assert summary['scope']['cluster_names'] == ['c']
+        assert summary['truncated'] is True
+        statuses = {
+            t['section']: t['status'] for t in summary['section_timings']
+        }
+        assert statuses['clusters'] == 'skipped_deadline'
+
+    def test_summary_and_manifest_account_for_the_dump(self, tmp_path):
+        """summary.json carries budget/duration/size fields and
+        manifest.json carries the file inventory; section_timings covers the
+        context-population phase and attributes bytes per section."""
+        with self._patched_dump(tmp_path) as section_mocks:
+            section_mocks['_dump_request_id_info'].return_value = {
+                'dumped': 1,
+                'not_found': 0,
+                'skipped_deadline': 0,
+            }
+            result = debug_utils.create_debug_dump(
+                request_ids=['req-1'], overall_deadline=time.time() + 3600)
+
+        summary, names = self._read_from_zip(result, 'summary.json')
+        # Self-accounting fields.
+        assert summary['collection_start_time'] > 0
+        assert summary['collection_end_time'] >= summary[
+            'collection_start_time']
+        assert summary['total_duration_s'] >= 0
+        assert summary['overall_deadline'] is not None
+        assert summary['overall_deadline'] > summary['collection_start_time']
+        assert summary['budget_remaining_at_start_s'] > 0
+        assert summary['total_size_bytes'] > 0
+        assert summary['file_count'] >= 1
+        assert summary['largest_files']
+        assert all(
+            'size_bytes' in f and 'path' in f for f in summary['largest_files'])
+        # The context-population phase is timed like a section, first.
+        assert summary['section_timings'][0]['section'] == 'context_population'
+        timings = {t['section']: t for t in summary['section_timings']}
+        assert 'size_bytes' in timings['request_ids']
+        assert 'size_bytes' in timings['server_info']
+
+        # manifest.json: a file inventory matching what was zipped. With all
+        # sections mocked, the inventory is exactly the two files written
+        # before the inventory is taken (errors.json + debug_dump.log).
+        manifest, _ = self._read_from_zip(result, 'manifest.json')
+        assert manifest['file_count'] == len(manifest['files'])
+        assert manifest['total_size_bytes'] == summary['total_size_bytes']
+        assert {f['path'] for f in manifest['files']} == {
+            'errors.json',
+            'debug_dump.log',
+        }
+        # Every inventoried file is really in the zip (arcnames carry the
+        # dump directory as their first component).
+        for entry in manifest['files']:
+            assert any(n.endswith('/' + entry['path']) for n in names)
+
+    def test_debug_dump_log_level_and_zip_stats(self, tmp_path):
+        """debug_dump.log captures the dump's INFO+ trail and the zip-stats
+        lines, but not per-item DEBUG noise; it appears exactly once in the
+        zip."""
+        noisy_marker = 'DEBUG-NOISE-SHOULD-NOT-BE-CAPTURED'
+        warn_marker = 'WARNING-SHOULD-BE-CAPTURED'
+
+        def _noisy_crosslink(debug_dump_context):
+            debug_utils.logger.debug(noisy_marker)
+            debug_utils.logger.warning(warn_marker)
+
+        with self._patched_dump(tmp_path):
+            with mock.patch('sky.utils.debug_utils._get_clusters_from_requests',
+                            side_effect=_noisy_crosslink):
+                result = debug_utils.create_debug_dump(request_ids=['req-1'])
+
+        with zipfile.ZipFile(result, 'r') as zf:
+            names = zf.namelist()
+            log_name = next(n for n in names if n.endswith('debug_dump.log'))
+            log_content = zf.read(log_name).decode('utf-8')
+        assert names.count(log_name) == 1
+        assert noisy_marker not in log_content
+        assert warn_marker in log_content
+        # The zip-stats lines are logged while the handler is still attached
+        # and reach the archived copy of the log.
+        assert 'collection done, zipping' in log_content
+        assert 'debug dump: created' in log_content

--- a/tests/unit_tests/test_sky/utils/test_debug_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_debug_utils.py
@@ -1,6 +1,7 @@
 """Tests for sky.utils.debug_utils module."""
 import concurrent.futures
 import contextlib
+import contextvars
 import datetime
 import json
 import os
@@ -24,6 +25,8 @@ from sky.server.requests import log_provider as log_provider_lib
 from sky.server.requests import request_names
 from sky.skylet import constants as skylet_constants
 from sky.utils import common
+from sky.utils import common_utils
+from sky.utils import context as sky_context
 from sky.utils import debug_dump_helpers
 from sky.utils import debug_utils
 from sky.utils import status_lib
@@ -1098,21 +1101,16 @@ class TestPopulateRecentContext:
 
         assert 'req-running' in ctx['request_ids']
 
-    @mock.patch('sky.utils.debug_utils.common_utils.is_in_request_context',
-                return_value=True)
-    @mock.patch('sky.utils.debug_utils.common_utils.get_current_request_id',
-                return_value='own-dump-request')
     @mock.patch('sky.jobs.server.core.queue_v2')
     @mock.patch('sky.utils.debug_utils.global_user_state.get_clusters')
     @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
-    def test_excludes_own_request(self, mock_get_tasks, mock_get_clusters,
-                                  mock_queue_v2, mock_get_own_id,
-                                  mock_in_request_context):
-        """The dump's own (running) request must not include itself.
+    def test_own_request_stays_in_scope(self, mock_get_tasks, mock_get_clusters,
+                                        mock_queue_v2):
+        """The dump's own (running) request stays in the recent-scan scope.
 
-        Without the exclusion, copying the dump request's own
-        request.log / request_debug.log ships the dump's output stream a
-        second time inside the artifact."""
+        Its request_info.json records who triggered the dump; the duplicate
+        of its own log stream is avoided later, at the log-copy level (see
+        test_skip_log_request_ids_keeps_metadata_skips_logs)."""
         own_request = _make_request(request_id='own-dump-request',
                                     finished_at=None)
         other_request = _make_request(request_id='req-other', finished_at=None)
@@ -1125,7 +1123,7 @@ class TestPopulateRecentContext:
                                              minutes=60.0,
                                              reachability=_StubReachability())
 
-        assert 'own-dump-request' not in ctx['request_ids']
+        assert 'own-dump-request' in ctx['request_ids']
         assert 'req-other' in ctx['request_ids']
 
     @mock.patch('sky.jobs.server.core.queue_v2')
@@ -1652,6 +1650,9 @@ class TestCreateDebugDump:
             assert collected['request_count'] == 3
             assert collected['cluster_count'] == 1
             assert collected['managed_job_count'] == 1
+            # The kubernetes_contexts section is mocked (returns a
+            # MagicMock, not a dict), so its count stays at 0.
+            assert collected['kubernetes_context_count'] == 0
 
             # System request IDs are always added to the scope
             scope = summary_data['scope']
@@ -3140,7 +3141,12 @@ class TestDumpRequestIdInfo:
         assert data['status'] == 'SUCCEEDED'
         assert data['cluster_name'] == 'my-cluster'
         assert not errors
-        assert stats == {'dumped': 1, 'not_found': 0, 'skipped_deadline': 0}
+        assert stats == {
+            'planned': 1,
+            'dumped': 1,
+            'not_found': 0,
+            'skipped_deadline': 0,
+        }
 
     @mock.patch('sky.utils.debug_utils.requests_lib.get_request')
     def test_request_not_found(self, mock_get_request, tmp_path):
@@ -3155,7 +3161,14 @@ class TestDumpRequestIdInfo:
         assert not errors
         info_path = tmp_path / 'requests' / 'req-missing' / 'request_info.json'
         assert not info_path.exists()
-        assert stats == {'dumped': 0, 'not_found': 1, 'skipped_deadline': 0}
+        # 'dumped' is disk-derived: the not-found request's directory is
+        # empty (no logs exist for it), so it is not counted.
+        assert stats == {
+            'planned': 1,
+            'dumped': 0,
+            'not_found': 1,
+            'skipped_deadline': 0,
+        }
 
     @mock.patch('sky.utils.debug_utils.requests_lib.get_request')
     def test_deadline_skip_stats(self, mock_get_request, tmp_path):
@@ -3173,7 +3186,12 @@ class TestDumpRequestIdInfo:
                                                   errors,
                                                   deadline=time.monotonic() - 1)
 
-        assert stats == {'dumped': 0, 'not_found': 0, 'skipped_deadline': 3}
+        assert stats == {
+            'planned': 3,
+            'dumped': 0,
+            'not_found': 0,
+            'skipped_deadline': 3,
+        }
         assert len(errors) == 3
         assert all(
             e['error'] == 'Skipped: overall debug-dump deadline exceeded.'
@@ -3221,6 +3239,85 @@ class TestDumpRequestIdInfo:
             call.args[2] for call in provider.copy_log_file.call_args_list
         ]
         assert any(p.name == 'request.log' for p in dest_paths)
+
+    @mock.patch('sky.utils.debug_utils.log_provider.get_log_provider')
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request')
+    def test_skip_log_request_ids_keeps_metadata_skips_logs(
+            self, mock_get_request, mock_get_provider, tmp_path):
+        """skip_log_request_ids keeps request_info.json but skips both log
+        copies for the listed request -- used for the dump's own request,
+        whose operational trail is already archived in debug_dump.log."""
+        mock_get_request.side_effect = (
+            lambda rid: _make_request(request_id=rid))
+        provider = mock.MagicMock()
+
+        def _fake_copy(request_id, log_type, dest_path):
+            if log_type == log_provider_lib.RequestLogType.REQUEST:
+                dest_path.write_text(f'log of {request_id}')
+                return True
+            return False
+
+        provider.copy_log_file.side_effect = _fake_copy
+        mock_get_provider.return_value = provider
+
+        errors: List[Dict[str, str]] = []
+        stats = debug_utils._dump_request_id_info(
+            {'own-dump-request', 'req-other'},
+            str(tmp_path),
+            errors,
+            skip_log_request_ids={'own-dump-request'})
+
+        # Metadata is written for both requests...
+        for request_id in ('own-dump-request', 'req-other'):
+            assert (tmp_path / 'requests' / request_id /
+                    'request_info.json').exists()
+        # ...but the listed request's logs are never requested from the
+        # provider, while the other request's are.
+        copied_ids = {
+            call.args[0] for call in provider.copy_log_file.call_args_list
+        }
+        assert 'req-other' in copied_ids
+        assert 'own-dump-request' not in copied_ids
+        assert not (tmp_path / 'requests' / 'own-dump-request' /
+                    'request.log').exists()
+        assert (tmp_path / 'requests' / 'req-other' / 'request.log').exists()
+        assert stats['planned'] == 2
+        assert stats['dumped'] == 2
+        assert not errors
+
+    @mock.patch('sky.utils.debug_utils.log_provider.get_log_provider')
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request')
+    def test_dumped_is_disk_derived_counts_db_failure_with_copied_log(
+            self, mock_get_request, mock_get_provider, tmp_path):
+        """'dumped' is disk-derived: a request whose DB fetch raised but
+        whose log copy landed still counts (it is also recorded in
+        errors.json) -- with the old in-loop counter it appeared in no
+        bucket."""
+        mock_get_request.side_effect = RuntimeError('DB is down')
+        provider = mock.MagicMock()
+
+        def _fake_copy(request_id, log_type, dest_path):
+            del request_id  # unused
+            if log_type == log_provider_lib.RequestLogType.REQUEST:
+                dest_path.write_text('log content')
+                return True
+            return False
+
+        provider.copy_log_file.side_effect = _fake_copy
+        mock_get_provider.return_value = provider
+
+        errors: List[Dict[str, str]] = []
+        stats = debug_utils._dump_request_id_info({'req-flaky'}, str(tmp_path),
+                                                  errors)
+
+        assert (tmp_path / 'requests' / 'req-flaky' / 'request.log').exists()
+        assert stats == {
+            'planned': 1,
+            'dumped': 1,
+            'not_found': 0,
+            'skipped_deadline': 0,
+        }
+        assert any(e['resource'] == 'req-flaky' for e in errors)
 
 
 # ---------------------------------------------------------------------------
@@ -4347,6 +4444,31 @@ class TestDumpKubeContextsInfo:
         assert not (tmp_path / 'kubernetes_contexts').exists()
         assert not errors
 
+    def test_batch_timeout_reports_partial_stats(self, tmp_path):
+        """A batch timeout must read as a partial: planned / dumped plus an
+        inferred skipped_deadline (= planned - dumped), so the section is
+        marked completed_partial by the runner.
+
+        Expectations are derived from the returned dict rather than
+        hard-coded: the in-cluster context is appended unconditionally when
+        running in-cluster, so the scoped context count depends on the
+        environment."""
+        errors: List[Dict[str, str]] = []
+        with self._patch_allowed(['ctx-a', 'ctx-b']), \
+             mock.patch('sky.utils.debug_utils._run_with_deadline',
+                        return_value=(False, None)), \
+             mock.patch('sky.provision.kubernetes.debug.dump_context_resources'
+                       ) as dump:
+            result = debug_utils._dump_kube_contexts_info(str(tmp_path), errors)
+
+        # The batch was abandoned before any worker ran.
+        dump.assert_not_called()
+        assert result is not None
+        assert result['planned'] >= 1
+        assert result['dumped'] == 0
+        assert (result['skipped_deadline'] == result['planned'] -
+                result['dumped'])
+
     def test_allowed_contexts_lookup_failure_is_recorded(self, tmp_path):
         errors: List[Dict[str, str]] = []
         with mock.patch.object(debug_utils.clouds.Kubernetes,
@@ -4633,12 +4755,29 @@ class TestSummaryTruth:
         scope."""
         with self._patched_dump(tmp_path) as section_mocks:
             section_mocks['_dump_request_id_info'].return_value = {
+                'planned': 10,
                 'dumped': 7,
                 'not_found': 1,
                 'skipped_deadline': 2,
             }
-            section_mocks['_dump_cluster_info'].return_value = {'dumped': 4}
-            section_mocks['_dump_managed_job_info'].return_value = {'dumped': 0}
+            section_mocks['_dump_cluster_info'].return_value = {
+                'planned': 4,
+                'dumped': 4,
+            }
+            section_mocks['_dump_managed_job_info'].return_value = {
+                # Controller-unreachable shape: nothing attempted, the
+                # failure lives in errors.json -- reads 'completed' with a
+                # planned/dumped disparity (not a partial).
+                'planned': 1,
+                'dumped': 0,
+            }
+            section_mocks['_dump_kube_contexts_info'].return_value = {
+                # Batch-timeout shape: skipped_deadline inferred as
+                # planned - dumped.
+                'planned': 5,
+                'dumped': 3,
+                'skipped_deadline': 2,
+            }
             result = debug_utils.create_debug_dump(request_ids=['req-1'],
                                                    cluster_names=['c1'],
                                                    managed_job_ids=[3])
@@ -4646,16 +4785,33 @@ class TestSummaryTruth:
         summary, _ = self._read_from_zip(result, 'summary.json')
         timings = {t['section']: t for t in summary['section_timings']}
         assert timings['request_ids']['status'] == 'completed_partial'
+        assert timings['request_ids']['planned'] == 10
         assert timings['request_ids']['dumped'] == 7
         assert timings['request_ids']['not_found'] == 1
         assert timings['request_ids']['skipped_deadline'] == 2
         assert timings['clusters']['status'] == 'completed'
+        assert timings['managed_jobs']['status'] == 'completed'
+        assert timings['managed_jobs']['planned'] == 1
+        assert timings['managed_jobs']['dumped'] == 0
+        assert timings['kubernetes_contexts']['status'] == 'completed_partial'
         assert summary['collected'] == {
             'request_count': 7,
             'cluster_count': 4,
             'managed_job_count': 0,
+            'kubernetes_context_count': 3,
         }
         assert summary['truncated'] is True
+        # Per-row reconciliation on the mocked sections: planned equals
+        # dumped + not_found + skipped_deadline for every row that reports
+        # a skip or a not-found. It deliberately does NOT hold for a
+        # not-found request whose logs were copied (the documented overlap)
+        # or for per-item failures recorded only in errors.json -- e.g. the
+        # managed-jobs controller-unreachable row above.
+        for row in timings.values():
+            if row.get('skipped_deadline', 0) or row.get('not_found', 0):
+                assert row['planned'] == (row['dumped'] +
+                                          row.get('not_found', 0) +
+                                          row['skipped_deadline'])
         # The planned scope still reports the full cross-linked context.
         assert summary['scope']['request_count'] >= 1
         assert 'req-1' in summary['scope']['request_ids']
@@ -4665,6 +4821,7 @@ class TestSummaryTruth:
         'truncated' is False."""
         with self._patched_dump(tmp_path) as section_mocks:
             section_mocks['_dump_request_id_info'].return_value = {
+                'planned': 5,
                 'dumped': 5,
                 'not_found': 0,
                 'skipped_deadline': 0,
@@ -4689,6 +4846,7 @@ class TestSummaryTruth:
             'request_count': 0,
             'cluster_count': 0,
             'managed_job_count': 0,
+            'kubernetes_context_count': 0,
         }
         assert summary['scope']['cluster_count'] == 1
         assert summary['scope']['cluster_names'] == ['c']
@@ -4714,8 +4872,7 @@ class TestSummaryTruth:
         summary, names = self._read_from_zip(result, 'summary.json')
         # Self-accounting fields.
         assert summary['collection_start_time'] > 0
-        assert summary['collection_end_time'] >= summary[
-            'collection_start_time']
+        assert summary['collection_end_time'] >= summary['collection_start_time']
         assert summary['total_duration_s'] >= 0
         assert summary['overall_deadline'] is not None
         assert summary['overall_deadline'] > summary['collection_start_time']
@@ -4746,6 +4903,17 @@ class TestSummaryTruth:
         for entry in manifest['files']:
             assert any(n.endswith('/' + entry['path']) for n in names)
 
+        # The manifest is the FINAL zip entry and carries the zip's own
+        # stats: entry_count is exact (it counts every entry in the zip,
+        # itself included) and the duration is non-negative.
+        manifest_names = [n for n in names if n.endswith('manifest.json')]
+        assert len(manifest_names) == 1
+        assert names[-1] == manifest_names[0]
+        assert manifest['zip']['entry_count'] == len(names)
+        assert manifest['zip']['zip_duration_s'] >= 0
+        assert manifest['zip']['compressed_size_bytes'] > 0
+        assert 'zip.entry_count' in manifest['note']
+
     def test_debug_dump_log_level_and_zip_stats(self, tmp_path):
         """debug_dump.log captures the dump's INFO+ trail and the zip-stats
         lines, but not per-item DEBUG noise; it appears exactly once in the
@@ -4773,3 +4941,134 @@ class TestSummaryTruth:
         # and reach the archived copy of the log.
         assert 'collection done, zipping' in log_content
         assert 'debug dump: created' in log_content
+
+    _OWN_REQUEST_ID = 'own-dump-request'
+    _OTHER_REQUEST_ID = 'req-other'
+
+    def _create_dump_as_own_request(self, tmp_path, **kwargs):
+        """Run create_debug_dump as the server-side request
+        ``own-dump-request`` and return the zip path.
+
+        The recent-scan DB calls are mocked so the own (running) request
+        and one other request land in scope; the requests section runs for
+        real (the others are mocked). The request context is set inside a
+        copied contextvars context backed by a fresh SkyPilot context, so
+        nothing leaks into other tests.
+        """
+        own_id = self._OWN_REQUEST_ID
+        other_id = self._OTHER_REQUEST_ID
+
+        def _fake_get_request(request_id):
+            if request_id in (own_id, other_id):
+                return _make_request(request_id=request_id, finished_at=None)
+            return None  # e.g. system daemon request IDs
+
+        provider = mock.MagicMock()
+
+        def _fake_copy(request_id, log_type, dest_path):
+            if log_type == log_provider_lib.RequestLogType.REQUEST:
+                dest_path.write_text(f'log of {request_id}')
+                return True
+            return False
+
+        provider.copy_log_file.side_effect = _fake_copy
+
+        def _fake_prefix_lookup(prefix, fields=None):
+            return [mock.MagicMock(request_id=prefix)]
+
+        def _runner():
+            sky_context.initialize()
+            common_utils.set_request_context(client_entrypoint=None,
+                                             client_command=None,
+                                             using_remote_api_server=False,
+                                             user=None,
+                                             request_id=own_id)
+            return debug_utils.create_debug_dump(**kwargs)
+
+        with contextlib.ExitStack() as stack:
+            for fn in self._CROSSLINK_FNS:
+                if fn == '_populate_recent_context':
+                    continue  # runs for real: puts the own request in scope
+                stack.enter_context(mock.patch(f'sky.utils.debug_utils.{fn}'))
+            for fn in ('_dump_server_info', '_dump_cluster_info',
+                       '_dump_managed_job_info', '_dump_kube_contexts_info'):
+                stack.enter_context(mock.patch(f'sky.utils.debug_utils.{fn}'))
+            stack.enter_context(
+                mock.patch('sky.utils.debug_utils.DEBUG_DUMP_DIR',
+                           str(tmp_path / 'debug_dumps')))
+            stack.enter_context(
+                mock.patch(
+                    'sky.utils.debug_utils.requests_lib'
+                    '.get_requests_with_prefix',
+                    side_effect=_fake_prefix_lookup))
+            stack.enter_context(
+                mock.patch('sky.utils.debug_utils.requests_lib.get_request',
+                           side_effect=_fake_get_request))
+            stack.enter_context(
+                mock.patch(
+                    'sky.utils.debug_utils.requests_lib'
+                    '.get_request_tasks',
+                    return_value=[
+                        _make_request(request_id=own_id, finished_at=None),
+                        _make_request(request_id=other_id, finished_at=None),
+                    ]))
+            stack.enter_context(
+                mock.patch(
+                    'sky.utils.debug_utils.global_user_state'
+                    '.get_clusters',
+                    return_value=[]))
+            stack.enter_context(
+                mock.patch('sky.jobs.server.core.queue_v2',
+                           return_value=([], 0, {}, 0, [])))
+            stack.enter_context(
+                mock.patch(
+                    'sky.utils.debug_utils.managed_job_utils'
+                    '.is_consolidation_mode',
+                    return_value=True))
+            stack.enter_context(
+                mock.patch(
+                    'sky.utils.debug_utils.log_provider'
+                    '.get_log_provider',
+                    return_value=provider))
+            return contextvars.copy_context().run(_runner)
+
+    def _assert_own_request_metadata_only(self, zip_path,
+                                          other_request_in_scope):
+        """The own request's request_info.json is in the dump, but neither
+        of its log files is."""
+        with zipfile.ZipFile(zip_path, 'r') as zf:
+            names = zf.namelist()
+        own_entries = [
+            n for n in names
+            if n.endswith(f'/{self._OWN_REQUEST_ID}/request_info.json') or
+            n.endswith(f'/{self._OWN_REQUEST_ID}/request.log') or
+            n.endswith(f'/{self._OWN_REQUEST_ID}/request_debug.log')
+        ]
+        assert any(
+            n.endswith(f'/{self._OWN_REQUEST_ID}/request_info.json')
+            for n in own_entries)
+        assert not any(
+            n.endswith((f'/{self._OWN_REQUEST_ID}/request.log',
+                        f'/{self._OWN_REQUEST_ID}/request_debug.log'))
+            for n in own_entries)
+        if other_request_in_scope:
+            # Another request in the same scope does ship its log.
+            assert any(
+                n.endswith(f'/{self._OTHER_REQUEST_ID}/request.log')
+                for n in names)
+
+    def test_own_request_metadata_kept_logs_skipped_recent_scan(self, tmp_path):
+        """Recent-scan path: the dump's own request lands in scope via the
+        scan (it is RUNNING while the dump executes); its metadata ships,
+        its log stream does not."""
+        result = self._create_dump_as_own_request(tmp_path, recent_minutes=60.0)
+        self._assert_own_request_metadata_only(result,
+                                               other_request_in_scope=True)
+
+    def test_own_request_metadata_kept_logs_skipped_explicit(self, tmp_path):
+        """Explicit path: same behavior when the dump's own request ID is
+        requested directly."""
+        result = self._create_dump_as_own_request(
+            tmp_path, request_ids=[self._OWN_REQUEST_ID])
+        self._assert_own_request_metadata_only(result,
+                                               other_request_in_scope=False)


### PR DESCRIPTION
## Summary

`create_debug_dump` produced artifacts that misdescribed themselves. The evidence below comes from a debug dump taken on a production API server with ~9.5k requests in scope and an overall deadline in effect.

### 1. summary.json misreported what was collected

- `collected` was computed from the planned cross-link context, not from what sections wrote: the dump reported `collected={request_count: 9546, cluster_count: 3610, managed_job_count: 794}` while the zip contained only 7198 request dirs and no clusters/managed-jobs data at all (those sections were deadline-skipped).
- The request_ids section read `status: completed` even though 2310 of its 9546 requests (24%) were internally skipped when the budget ran out.
- Three numbers disagreed for requests alone: 9546 "collected", 7236 `_timings.json` entries, 7198 dirs on disk.

Now:

- `scope` carries the planned cross-linked context (counts + ID lists); `collected` counts only what sections wrote, disk-derived (per-item dirs containing at least one file — what the zip's `os.walk` keeps), and now includes `kubernetes_context_count`.
- Every itemized section reports `{planned, dumped, skipped_deadline, not_found}`; the runner marks `completed_partial` whenever `skipped_deadline > 0`. The same dump would now read: request_ids `completed_partial`, planned=9546, dumped=7198, skipped_deadline=2310, not_found=38.
- `dumped` is disk-derived and can overlap `not_found` (a DB-pruned request whose logs survive on disk counts in both), so `planned == dumped + skipped_deadline + not_found` holds exactly when not-found requests leave no files; these semantics are documented once, at the section runner, rather than papered over.
- A kubernetes-contexts batch timeout (the fixed per-section cap or the overall deadline — either) reports `skipped_deadline = planned - dumped` and reads `completed_partial`.

### 2. The dump could not account for its own time, size, or contents

- summary.json had no budget/duration/size fields (the ~600s budget appeared only in the worker log); section_timings summed to ~600s while a 239s context-population phase had no entry at all; the total dump size was computed but only logged after the debug handler was detached, so it reached no artifact; there was no file inventory anywhere; and the dump was named by collection start while content spanned 14 minutes and server_info.json recorded a third, mid-collection timestamp.

Now:

- summary.json carries `collection_start/end_time` (+ human-readable), `total_duration_s`, `overall_deadline` (+ human), `budget_remaining_at_start_s`, `total_size_bytes`, `file_count`, the top-10 `largest_files`, and per-section `size_bytes`; `section_timings[0]` is a timed `context_population` entry, and summary/manifest record the authoritative collection window.
- manifest.json is written on disk and appended as the true FINAL zip entry, after the zip's own stats are known: the full path+size inventory, per-section byte totals, and a `zip` block (`entry_count` — exact, `zip_duration_s`, `compressed_size_bytes`). The append is best-effort — on failure the dump still returns a valid zip minus the manifest, with a warning in the worker log.
- The in-dump log handler stays attached through the zip step, so the "collection done, zipping N bytes" / "created ... (N files)" lines reach the archived debug_dump.log.

### 3. debug_dump.log was 25MB of per-item DEBUG noise, and the dump shipped the same stream twice

- 25.4MB / 109k lines, of which roughly 40 were informative: ~80% was repeated per-item noise ("cluster name might be invalid" x52,597, "Failed to read original user YAML" x17,418, "Recent: including request" x7,119, "Cross-link:" x8,572, and per-request "Dumped request" / "Request log not found" / "Copied request log" lines).
- Because the handler sat on the shared root `sky` logger, the same ~25MB stream was mirrored into the dump request's own request_debug.log — the dump shipped the same stream twice, plus a 1.1MB request.log of the same run.

Now:

- The in-dump handler is INFO: all five noise classes vanish from the artifact while the INFO+ trail (section start/done, skips, timeouts, warnings, zip stats) remains.
- The dump's own request stays in scope for its request_info.json (who triggered the dump, when, with what parameters), but its request.log / request_debug.log copies are structurally skipped on both the recent-scan and explicit paths: debug_dump.log already archives the dump's own operational trail, and the request's DEBUG stream is deliberately absent from the artifact at INFO level.

## Why one PR

The same functions are touched by interlocking concerns: the section-stats shape feeds both summary truth and the collected counts; the manifest and the log handler share the zip pipeline; the own-request skip and the handler log level are two halves of the same noise story.

## Commits

Two commits, add-then-refine: the first lands the scope/collected split, the self-accounting summary, the on-disk manifest and the INFO handler; the second makes the per-section outcome shape uniform (`planned` key everywhere, disk-derived requests `dumped`, kube-contexts timeout partial), appends manifest.json as the final zip entry with the zip stats, and moves the own-request exclusion from the recent-scan level to the log-copy level (the own request now stays in scope for its metadata; the corresponding test is inverted).

Note: this PR touches `sky/utils/debug_utils.py` and its test file, which other in-flight debug-dump changes also modify — expect and resolve conflicts there.

## Tested

- Unit: `tests/unit_tests/test_sky/utils/test_debug_utils.py` (227 tests) — all pass except 8 pre-existing kubernetes environment failures that reproduce identically on unmodified master in this devspace (TestDumpKubeContextsInfo / TestCollectClusterKubernetesResources; the local kubeconfig leaks a real in-cluster context into the mocked tests).
- In-process e2e with a real DB and a ~4s overall deadline landing inside the requests section: request_ids reads `completed_partial` with planned=69, dumped=34, skipped_deadline=31, not_found=4 (the per-row identity holds); later sections `skipped_deadline`; `collected` reflects only what ran; manifest.json is the final zip entry with entry_count == len(namelist()) == 40; debug_dump.log carries the zip-stats lines and none of the five noise classes.
- Real-server e2e: local API server running the branch, dumps triggered over HTTP — uncapped dump: all sections `completed`, `collected.request_count` reconciles with the request dirs in the zip (68 vs 68), and the dump's own request_info.json is present while its request.log/request_debug.log are not; 12s-capped dump: `truncated: true`, coherently self-describing partial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
