### PR TITLE
[Core] Scope debug-dump managed-jobs scans to the fields they consume

### DIFF
--- a/sky/utils/debug_utils.py
+++ b/sky/utils/debug_utils.py
@@ -48,6 +48,8 @@ from sky.utils import subprocess_utils
 from sky.utils import tempstore
 from sky.utils import ux_utils
 from sky.utils import yaml_utils
+from sky.workspaces import constants as workspace_constants
+from sky.workspaces import core as workspaces_core
 
 logger = sky_logging.init_logger(__name__)
 
@@ -637,6 +639,58 @@ def _managed_job_cluster_names_from_records(
     return cluster_names
 
 
+# Exactly the keys _managed_job_cluster_names_from_records reads; must stay
+# in sync with it so the fetch does not drag in per-job work (e.g. the
+# original user YAML reads) for fields the scan never consumes.
+_JOB_CLUSTER_FIELDS = ['job_id', 'task_name', 'pool', 'current_cluster_name']
+
+# Exactly the recency keys the recent-jobs scan in _populate_recent_context
+# reads (job_id plus the submitted_at/end_at window check); must stay in sync
+# with it for the same reason.
+_RECENT_JOB_FIELDS = ['job_id', 'submitted_at', 'end_at']
+
+
+def _fetch_managed_job_records(job_ids: Optional[List[int]],
+                               fields: List[str]) -> List[Dict[str, Any]]:
+    """Fetch managed job records for the dump's cross-link scans.
+
+    Both callers are discovery scans over the whole job table (no job_ids to
+    seed -- finding those jobs is the point), so the request is scoped by
+    ``fields`` instead: exactly the keys the caller consumes, which keeps the
+    per-job payload small and skips per-job work the dump does not need (e.g.
+    the original user YAML reads). Controllers that predate ``fields``
+    simply return the wider records.
+
+    In consolidation mode the jobs controller shares this process and its
+    database, so the records are read from the DB directly -- a queue_v2
+    round-trip would still reach the controller (as a local subprocess even
+    in consolidation mode) and walk its full job table. Outside
+    consolidation mode the jobs live on the (possibly remote) controller, so
+    queue_v2 is used; it is the only path that reaches them.
+    """
+    if managed_job_utils.is_consolidation_mode():
+        logger.debug('Reading managed jobs from the local DB (consolidation '
+                     f'mode; skipping the controller round-trip), '
+                     f'fields={fields!r}')
+        result = managed_job_utils.get_managed_job_queue(
+            job_ids=job_ids,
+            # Same workspace visibility queue_v2 applies (see
+            # managed_jobs_core.queue_v2): read-only workspaces' jobs must
+            # still be listed.
+            accessible_workspaces=list(
+                workspaces_core.get_accessible_workspace_names(
+                    action=workspace_constants.WORKSPACE_ACTION_READ)),
+            fields=fields)
+        return result['jobs']
+    logger.debug(f'Fetching managed jobs from the jobs controller, '
+                 f'fields={fields!r}')
+    jobs, _, _, _, _ = managed_jobs_core.queue_v2(refresh=False,
+                                                  job_ids=job_ids,
+                                                  all_users=True,
+                                                  fields=fields)
+    return jobs
+
+
 def _get_managed_jobs_from_clusters(
         debug_dump_context: DebugDumpContext,
         reachability: '_KubeContextReachabilityChecker',
@@ -666,21 +720,24 @@ def _get_managed_jobs_from_clusters(
                                    dead_context))
         return
     try:
-        # Bound the queue_v2 call dump-side (see _MANAGED_JOB_QUEUE_TIMEOUT); on
-        # timeout the helper records it and we skip the expansion, mirroring the
-        # except-and-return degrade below.
-        ok, result = _run_with_deadline(
-            functools.partial(managed_jobs_core.queue_v2,
-                              refresh=False,
-                              all_users=True),
+        # Bound the managed-jobs fetch dump-side (see
+        # _MANAGED_JOB_QUEUE_TIMEOUT); on timeout the helper records it and we
+        # skip the expansion, mirroring the except-and-return degrade below.
+        # The fetch is fields-scoped to what
+        # _managed_job_cluster_names_from_records reads; job_ids cannot be
+        # seeded here because discovering which jobs run on the requested
+        # clusters is the point of this scan.
+        ok, jobs = _run_with_deadline(
+            functools.partial(_fetch_managed_job_records,
+                              job_ids=None,
+                              fields=_JOB_CLUSTER_FIELDS),
             _bounded_timeout(_MANAGED_JOB_QUEUE_TIMEOUT, deadline),
             component='cross_link',
             resource='managed_jobs_from_clusters',
             errors=debug_dump_context['errors'],
             orphans=debug_dump_context['timed_out_ops'])
-        if not ok or result is None:
+        if not ok or jobs is None:
             return
-        jobs, _, _, _, _ = result
         job_cluster_names = _managed_job_cluster_names_from_records(jobs)
     except Exception as e:  # pylint: disable=broad-except
         logger.warning(f'Failed to get managed jobs for clusters: {e}')
@@ -838,11 +895,12 @@ def _populate_recent_context(
             'traceback': _full_traceback()
         })
 
-    # Get recent managed jobs via queue_v2 (handles remote controllers
-    # via gRPC/SSH, unlike direct DB access which only works in
-    # consolidation mode). Skipped when the controller's kube context is
-    # unreachable -- the exec into the controller would just eat a kubectl
-    # connect timeout.
+    # Get recent managed jobs. In consolidation mode this reads the local DB
+    # (the jobs controller shares this process's database); otherwise
+    # queue_v2 handles remote controllers via gRPC/SSH, unlike direct DB
+    # access which only works in consolidation mode. Skipped when the
+    # controller's kube context is unreachable -- the exec into the
+    # controller would just eat a kubectl connect timeout.
     dead_context = _jobs_controller_unreachable_context(reachability)
     if dead_context is not None:
         logger.debug('Skipping recent managed jobs scan: controller '
@@ -852,20 +910,26 @@ def _populate_recent_context(
                                    dead_context))
     else:
         try:
-            # Bound the queue_v2 call dump-side (see
-            # _MANAGED_JOB_QUEUE_TIMEOUT); on timeout the helper records it and
-            # we skip the recent-jobs scan, mirroring the except degrade below.
-            ok, result = _run_with_deadline(
-                functools.partial(managed_jobs_core.queue_v2,
-                                  refresh=False,
-                                  all_users=True),
+            # Bound the managed-jobs fetch dump-side (see
+            # _MANAGED_JOB_QUEUE_TIMEOUT); on timeout the helper records it
+            # and we skip the recent-jobs scan, mirroring the except degrade
+            # below. The fetch is fields-scoped to the recency keys read
+            # below; job_ids cannot be seeded here because this is a
+            # discovery scan. Server-side submitted_after filtering is
+            # deliberately not used: it would silently drop recently-ended
+            # jobs submitted before the cutoff (exactly the incident-relevant
+            # ones), since the scan includes jobs with submitted_at OR end_at
+            # inside the window.
+            ok, jobs = _run_with_deadline(
+                functools.partial(_fetch_managed_job_records,
+                                  job_ids=None,
+                                  fields=_RECENT_JOB_FIELDS),
                 _bounded_timeout(_MANAGED_JOB_QUEUE_TIMEOUT, deadline),
                 component='recent_context',
                 resource='managed_jobs',
                 errors=debug_dump_context['errors'],
                 orphans=debug_dump_context['timed_out_ops'])
-            if ok and result is not None:
-                jobs, _, _, _, _ = result
+            if ok and jobs is not None:
                 for job in jobs:
                     submitted_at = job.get('submitted_at') or 0
                     end_at = job.get('end_at') or time.time()

--- a/tests/unit_tests/test_sky/utils/test_debug_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_debug_utils.py
@@ -687,6 +687,124 @@ class TestGetManagedJobsFromClusters:
         assert len(errors) == 1
         assert errors[0]['resource'] == 'managed_jobs_from_clusters'
 
+    @mock.patch('sky.utils.debug_utils.managed_jobs_core.queue_v2')
+    def test_queue_v2_call_is_fields_scoped(self, mock_queue):
+        """The remote-controller fetch asks queue_v2 for exactly the fields
+        the cluster-name resolution reads, not every job field (~1.4KB/job
+        with per-job controller work such as the original user YAML reads
+        on large job tables)."""
+        mock_queue.return_value = ([], 0, {}, 0, [])
+        ctx = _make_context(cluster_names={'c1'})
+
+        debug_utils._get_managed_jobs_from_clusters(ctx, _StubReachability())
+
+        mock_queue.assert_called_once_with(
+            refresh=False,
+            job_ids=None,
+            all_users=True,
+            fields=debug_utils._JOB_CLUSTER_FIELDS)
+
+    @mock.patch('sky.utils.debug_utils.workspaces_core.'
+                'get_accessible_workspace_names',
+                return_value={'ws'})
+    @mock.patch('sky.utils.debug_utils.managed_job_utils.'
+                'get_managed_job_queue')
+    @mock.patch('sky.utils.debug_utils.managed_job_utils.is_consolidation_mode')
+    def test_consolidation_mode_reads_local_db(self, mock_consolidation,
+                                               mock_local_queue, _mock_ws):
+        """In consolidation mode the jobs controller shares this process's
+        database, so the scan reads it directly instead of paying a queue_v2
+        controller round-trip (a local subprocess that walks the full job
+        table)."""
+        mock_consolidation.return_value = True
+        mock_local_queue.return_value = {
+            'jobs': [{
+                'job_id': 7,
+                'task_name': 'train',
+                'current_cluster_name': None,
+                'pool': None,
+            }],
+            'total': 1,
+        }
+        name = managed_job_utils.generate_managed_job_cluster_name('train', 7)
+        ctx = _make_context(cluster_names={name})
+
+        with mock.patch('sky.utils.debug_utils.managed_jobs_core.'
+                        'queue_v2') as mock_queue_v2:
+            debug_utils._get_managed_jobs_from_clusters(ctx,
+                                                        _StubReachability())
+
+        assert ctx['managed_job_ids'] == {7}
+        mock_queue_v2.assert_not_called()
+        _, kwargs = mock_local_queue.call_args
+        assert kwargs['job_ids'] is None
+        assert kwargs['fields'] == debug_utils._JOB_CLUSTER_FIELDS
+        # Same workspace visibility queue_v2 would apply.
+        assert kwargs['accessible_workspaces'] == ['ws']
+
+    @mock.patch('sky.utils.debug_utils.managed_jobs_core.queue_v2')
+    def test_fetch_timeout_records_error_and_orphan(self, mock_queue):
+        """A fetch that overruns its deadline is bounded: the wrapper
+        records the timeout, the expansion is skipped, and the abandoned
+        worker is left as an orphan entry for the straggler log. The same
+        _run_with_deadline wrapper bounds BOTH transports (a wedged local
+        DB read in consolidation mode is bounded identically), so exercising
+        one transport suffices."""
+        release = threading.Event()
+
+        def _blocked_queue(*args, **kwargs):
+            release.wait()
+            return ([], 0, {}, 0, [])
+
+        mock_queue.side_effect = _blocked_queue
+        errors: List[Dict[str, str]] = []
+        ctx = _make_context(cluster_names={'c1'}, errors=errors)
+
+        try:
+            debug_utils._get_managed_jobs_from_clusters(
+                ctx, _StubReachability(), deadline=time.monotonic() + 0.1)
+        finally:
+            # Let the abandoned worker thread exit; it must not linger in
+            # the pytest process.
+            release.set()
+
+        assert ctx['managed_job_ids'] == set()
+        assert len(errors) == 1
+        assert errors[0]['component'] == 'cross_link'
+        assert errors[0]['resource'] == 'managed_jobs_from_clusters'
+        assert len(ctx['timed_out_ops']) == 1
+        assert ctx['timed_out_ops'][0]['resource'] == (
+            'managed_jobs_from_clusters')
+
+    @mock.patch('sky.utils.debug_utils.workspaces_core.'
+                'get_accessible_workspace_names',
+                return_value={'ws'})
+    @mock.patch('sky.utils.debug_utils.managed_job_utils.'
+                'get_managed_job_queue',
+                side_effect=RuntimeError('db down'))
+    @mock.patch('sky.utils.debug_utils.managed_job_utils.is_consolidation_mode')
+    def test_consolidation_mode_db_failure_records_error(
+            self, mock_consolidation, _mock_local_queue, _mock_ws):
+        """A local-DB failure in consolidation mode degrades exactly like a
+        queue_v2 failure on the remote path: the call site's except records
+        the error and the expansion is skipped (the remote-path degrade is
+        pinned by test_queue_failure_records_error above)."""
+        mock_consolidation.return_value = True
+        errors: List[Dict[str, str]] = []
+        ctx = _make_context(cluster_names={'c1'}, errors=errors)
+
+        with mock.patch('sky.utils.debug_utils.managed_jobs_core.'
+                        'queue_v2') as mock_queue_v2:
+            debug_utils._get_managed_jobs_from_clusters(ctx,
+                                                        _StubReachability())
+
+        assert ctx['managed_job_ids'] == set()
+        assert len(errors) == 1
+        assert errors[0]['component'] == 'cross_link'
+        assert errors[0]['resource'] == 'managed_jobs_from_clusters'
+        assert 'db down' in errors[0]['error']
+        mock_queue_v2.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # Tests for _get_job_clusters_from_managed_jobs
@@ -1141,6 +1259,72 @@ class TestPopulateRecentContext:
                                              reachability=_StubReachability())
 
         assert 'newly-launched' in ctx['cluster_names']
+
+    @mock.patch('sky.jobs.server.core.queue_v2')
+    @mock.patch('sky.utils.debug_utils.global_user_state.get_clusters')
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_queue_v2_call_is_fields_scoped(self, mock_get_tasks,
+                                            mock_get_clusters, mock_queue_v2):
+        """The remote-controller fetch asks queue_v2 for exactly the recency
+        fields the scan reads, not every job field (~1.4KB/job with per-job
+        controller work such as the original user YAML reads on large job
+        tables)."""
+        mock_get_tasks.return_value = []
+        mock_get_clusters.return_value = []
+        mock_queue_v2.return_value = ([], 0, {}, 0, [])
+
+        ctx = _make_context()
+        debug_utils._populate_recent_context(ctx,
+                                             minutes=60.0,
+                                             reachability=_StubReachability())
+
+        mock_queue_v2.assert_called_once_with(
+            refresh=False,
+            job_ids=None,
+            all_users=True,
+            fields=debug_utils._RECENT_JOB_FIELDS)
+
+    @mock.patch('sky.utils.debug_utils.workspaces_core.'
+                'get_accessible_workspace_names',
+                return_value={'ws'})
+    @mock.patch('sky.utils.debug_utils.managed_job_utils.'
+                'get_managed_job_queue')
+    @mock.patch('sky.utils.debug_utils.managed_job_utils.is_consolidation_mode')
+    @mock.patch('sky.utils.debug_utils.global_user_state.get_clusters')
+    @mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks')
+    def test_consolidation_mode_reads_local_db(self, mock_get_tasks,
+                                               mock_get_clusters,
+                                               mock_consolidation,
+                                               mock_local_queue, _mock_ws):
+        """In consolidation mode the jobs controller shares this process's
+        database, so the recent-jobs scan reads it directly instead of
+        paying a queue_v2 controller round-trip (a local subprocess that
+        walks the full job table)."""
+        mock_consolidation.return_value = True
+        now = time.time()
+        mock_get_tasks.return_value = []
+        mock_get_clusters.return_value = []
+        mock_local_queue.return_value = {
+            'jobs': [{
+                'job_id': 1,
+                'submitted_at': now - 1800,
+                'end_at': None,
+            }],
+            'total': 1,
+        }
+
+        ctx = _make_context()
+        with mock.patch('sky.jobs.server.core.queue_v2') as mock_queue_v2:
+            debug_utils._populate_recent_context(
+                ctx, minutes=60.0, reachability=_StubReachability())
+
+        assert 1 in ctx['managed_job_ids']
+        mock_queue_v2.assert_not_called()
+        _, kwargs = mock_local_queue.call_args
+        assert kwargs['job_ids'] is None
+        assert kwargs['fields'] == debug_utils._RECENT_JOB_FIELDS
+        # Same workspace visibility queue_v2 would apply.
+        assert kwargs['accessible_workspaces'] == ['ws']
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The debug dump's two discovery scans over the managed-jobs table — the cluster -> job expansion (`_get_managed_jobs_from_clusters`) and the recent-jobs scan (`_populate_recent_context`) — called `queue_v2(refresh=False, all_users=True)` with no `job_ids`, no `fields`, and no `limit`: the controller's complete job table, every field, every user. `queue_v2` contacts the jobs controller even with `refresh=False`, so its cost scales with the controller's full table size regardless of refresh.

On a production server with ~17k historical jobs, the recent-jobs scan burned its entire 120s budget: the controller subprocess walked the full job table doing per-job work for fields the dump never reads — each job's original user YAML was re-read from disk (17k+ "Failed to read original user YAML" lines in the controller log, ~7ms/job) — and returned zero jobs within the budget, so 14% of the dump's total wall budget was spent for nothing. Job-ID-filtered `queue_v2` calls (794 jobs from the dump's own context) against the same server completed in ~6s. In consolidation mode the round-trip is avoidable entirely: managed jobs live in the API server's own database (the dump's request-body scan already reads them from there quickly).

## What this PR does

Entirely dump-side (`sky/utils/debug_utils.py`); no changes to shared jobs code:

- New private helper `_fetch_managed_job_records(job_ids, fields)` used by both scans:
  - **Consolidation mode**: reads the records in-process via `get_managed_job_queue`, passing the same workspace visibility `queue_v2` applies (`get_accessible_workspace_names(action=READ)`, `user_hashes=None`) — no controller round-trip, no subprocess, no per-job YAML reads. The existing `_run_with_deadline(_bounded_timeout(_MANAGED_JOB_QUEUE_TIMEOUT, deadline))` bound, error/orphan record shapes, and degrade paths at both call sites are unchanged.
  - **Remote-controller setups**: keeps `queue_v2` (the only path that reaches those jobs) but passes `fields=` scoped to exactly the keys each scan consumes — `user_yaml` is never requested, so the controller-side per-job original-user-YAML reads never trigger.
- The two field lists live as named constants next to their consumers (`_JOB_CLUSTER_FIELDS`, `_RECENT_JOB_FIELDS`) with must-stay-in-sync comments; tests assert the call kwargs equal the constants, so adding a consumed key without updating the constant fails a test.
- One `logger.debug` line per fetch names the transport taken and the fields requested, so an engineer reading `debug_dump.log` from a sick server can tell which path ran.

### Intended consolidation-mode behavior deltas

- These reads no longer go through `_maybe_restart_controller`: the dump can no longer trigger a controller restart as a side effect, and a down controller no longer fails these context reads (the DB rows are still there) — strictly better for a dump.
- The consolidation branch reads the jobs DB directly and therefore bypasses any registered `ManagedJobRunner` row enrichment. Safe today: both scans consume only raw DB columns.
- `get_managed_job_queue` still pays its three unconditional aggregate queries (total / status counts / infra options) on the local DB — the same aggregates the controller pays today.

### Rejected alternatives

- **Seeding `job_ids`**: both are discovery scans — finding which jobs match is the point, and the context has no job IDs to seed at that stage.
- **`limit`**: would silently truncate discovery — a job beyond the limit is indistinguishable from a job that does not exist.
- **Server-side `submitted_after` filtering**: would silently drop recently-ended jobs submitted before the cutoff (exactly the incident-relevant ones), since the scan includes jobs with `submitted_at` OR `end_at` inside the window.

### Old-controller back-compat

Controllers at managed-job version >= 12 honor `fields` (the controller-side codegen passes it from that version on). Older controllers silently drop the kwarg and return the wider-but-correct full-field records, still bounded by the existing 120s cap — never an error.

## Testing

Unit tests (`tests/unit_tests/test_sky/utils/test_debug_utils.py`):
- The two fields-scoping tests and the two consolidation-mode tests now compare against the named constants (invariant enforced, not duplicated).
- New timeout-path test: a fetch that blocks past its deadline records exactly one `cross_link`/`managed_jobs_from_clusters` error plus one orphan entry, adds no job IDs, and the abandoned worker is released. The shared `_run_with_deadline` wrapper bounds both transports, so one transport suffices.
- New consolidation-exception test: a local-DB failure in consolidation mode degrades through the call site's existing except-and-record path (same error shape as the remote path), and `queue_v2` is not called.
- `pytest tests/unit_tests/test_sky/utils/test_debug_utils.py -n 2 -q`: only the 8 known devspace-environment failures in `TestDumpKubeContextsInfo`/`TestCollectClusterKubernetesResources` (pre-existing on master here; the pod's live kubeconfig) — all affected classes pass.
- `format.sh --files` on both changed files: yapf/isort/mypy clean; pylint reports the same pre-existing protected-access warnings the file already carries on master.

End-to-end against a local API server running this branch, seeded with a recent managed job:
- Consolidation mode: `sky debug-dump --recent-minutes 60` collected the seeded job and its cluster; `debug_dump.log` shows the new "Reading managed jobs from the local DB" line immediately before the "Found N requests, M clusters, K managed jobs" line, with no controller subprocess inside the scan window (the earlier A/B for the core change measured the scan at ~23s via the controller subprocess on master vs ~30ms via the local read here, with byte-identical collected content).
- Non-consolidation mode (no jobs controller): the log shows `queue_v2` invoked with the `fields` kwarg ("Fetching managed jobs from the jobs controller, fields=[...]"), the missing controller degrades exactly as on master (`ClusterNotUpError` recorded under `recent_context/managed_jobs`), and the dump still completes and zips.

## Notes for reviewers

- The two job-ID-filtered `queue_v2` call sites (`_get_managed_job_details` and `_dump_managed_job_queue_info`, which intentionally consumes all fields for `job_info.json`) are deliberately untouched; each still pays a controller round-trip in consolidation mode and could route through the same helper in a follow-up.
- This may conflict with other in-flight debug-dump changes touching `sky/utils/debug_utils.py` (e.g. #10722, #10733, which add deadline caps at these same call sites); happy to rebase once those land.
- No new user-facing configuration knobs; reverting the PR restores pre-fix behavior exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
