### PR TITLE
[API] Index cluster request history across finished statuses

### DIFF
--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -618,6 +618,12 @@ def create_table(cursor, conn):
     cursor.execute(f"""\
         CREATE INDEX IF NOT EXISTS created_at_idx ON {REQUEST_TABLE} (created_at);
     """)
+    # Cluster history includes finished requests, which the active-only cluster
+    # index cannot cover. Index the sort key too so a bounded history read does
+    # not scan every unrelated request when the cluster has fewer than LIMIT.
+    cursor.execute(f"""\
+        CREATE INDEX IF NOT EXISTS cluster_created_at_idx ON {REQUEST_TABLE} ({COL_CLUSTER_NAME}, created_at);
+    """)
 
 
 _DB = None

--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -624,6 +624,10 @@ def create_table(cursor, conn):
     cursor.execute(f"""\
         CREATE INDEX IF NOT EXISTS cluster_created_at_idx ON {REQUEST_TABLE} ({COL_CLUSTER_NAME}, created_at);
     """)
+    # Owner-scoped reads must also skip peers' history on a shared cluster.
+    cursor.execute(f"""\
+        CREATE INDEX IF NOT EXISTS cluster_user_created_at_idx ON {REQUEST_TABLE} ({COL_CLUSTER_NAME}, {COL_USER_ID}, created_at);
+    """)
 
 
 _DB = None

--- a/tests/unit_tests/test_sky/server/requests/test_request_history_index.py
+++ b/tests/unit_tests/test_sky/server/requests/test_request_history_index.py
@@ -6,15 +6,18 @@ import pytest
 from sky.server.requests import requests
 
 
+@pytest.mark.parametrize('shared', [False, True])
 @pytest.mark.parametrize('upgrade', [False, True])
 @pytest.mark.parametrize('cluster_name', ['target', 'missing'])
 @pytest.mark.parametrize('user_id', [None, 'owner'])
-def test_cluster_history_query_work_is_bounded(upgrade, cluster_name, user_id):
+def test_cluster_history_query_work_is_bounded(shared, upgrade, cluster_name,
+                                               user_id):
     with sqlite3.connect(':memory:') as conn:
         requests.create_table(conn.cursor(), conn)
         if upgrade:
             # Simulate the old schema, including its active-only cluster index.
             conn.execute('DROP INDEX IF EXISTS cluster_created_at_idx')
+            conn.execute('DROP INDEX IF EXISTS cluster_user_created_at_idx')
         conn.executemany(
             'INSERT INTO requests '
             '(request_id, name, status, created_at, cluster_name, user_id) '
@@ -28,6 +31,13 @@ def test_cluster_history_query_work_is_bounded(upgrade, cluster_name, user_id):
                 ('hidden', 'sky.status', 'SUCCEEDED', 10002, 'target', 'owner'),
                 ('peer', 'sky.launch', 'SUCCEEDED', 10003, 'target', 'peer'),
             ])
+        if shared:
+            conn.executemany(
+                'INSERT INTO requests '
+                '(request_id, name, status, created_at, cluster_name, user_id) '
+                'VALUES (?, ?, ?, ?, ?, ?)',
+                [(f'bulk-{i}', 'sky.launch', 'SUCCEEDED', i, 'target', 'peer')
+                 for i in range(10000)])
         conn.commit()
         # Startup upgrades an existing populated database and is idempotent.
         requests.create_table(conn.cursor(), conn)
@@ -57,4 +67,8 @@ def test_cluster_history_query_work_is_bounded(upgrade, cluster_name, user_id):
             expected = [('active',), ('new',), ('old',)]
             if user_id is None:
                 expected.insert(0, ('peer',))
+                if shared:
+                    expected = [('peer',), ('active',)] + [
+                        (f'bulk-{i}',) for i in range(9999, 9901, -1)
+                    ]
         assert rows == expected

--- a/tests/unit_tests/test_sky/server/requests/test_request_history_index.py
+++ b/tests/unit_tests/test_sky/server/requests/test_request_history_index.py
@@ -1,0 +1,60 @@
+"""Cluster history reads must not scan unrelated finished requests."""
+import sqlite3
+
+import pytest
+
+from sky.server.requests import requests
+
+
+@pytest.mark.parametrize('upgrade', [False, True])
+@pytest.mark.parametrize('cluster_name', ['target', 'missing'])
+@pytest.mark.parametrize('user_id', [None, 'owner'])
+def test_cluster_history_query_work_is_bounded(upgrade, cluster_name, user_id):
+    with sqlite3.connect(':memory:') as conn:
+        requests.create_table(conn.cursor(), conn)
+        if upgrade:
+            # Simulate the old schema, including its active-only cluster index.
+            conn.execute('DROP INDEX IF EXISTS cluster_created_at_idx')
+        conn.executemany(
+            'INSERT INTO requests '
+            '(request_id, name, status, created_at, cluster_name, user_id) '
+            'VALUES (?, ?, ?, ?, ?, ?)',
+            [(f'other-{i}', 'sky.launch', 'SUCCEEDED', i, 'other', 'owner')
+             for i in range(10000)] +
+            [
+                ('old', 'sky.launch', 'SUCCEEDED', -2, 'target', 'owner'),
+                ('new', 'sky.stop', 'SUCCEEDED', -1, 'target', 'owner'),
+                ('active', 'sky.start', 'RUNNING', 10001, 'target', 'owner'),
+                ('hidden', 'sky.status', 'SUCCEEDED', 10002, 'target', 'owner'),
+                ('peer', 'sky.launch', 'SUCCEEDED', 10003, 'target', 'peer'),
+            ])
+        conn.commit()
+        # Startup upgrades an existing populated database and is idempotent.
+        requests.create_table(conn.cursor(), conn)
+        requests.create_table(conn.cursor(), conn)
+        query, params = requests.RequestTaskFilter(
+            cluster_names=[cluster_name],
+            user_id=user_id,
+            exclude_request_names=['sky.status'],
+            fields=['request_id'],
+            sort=True,
+            limit=100).build_query()
+        steps = 0
+
+        def limit_work():
+            nonlocal steps
+            steps += 1
+            return steps >= 10
+
+        # A full-history scan exceeds this deterministic instruction budget.
+        conn.set_progress_handler(limit_work, 1000)
+        try:
+            rows = conn.execute(query, params).fetchall()
+        finally:
+            conn.set_progress_handler(None, 0)
+        expected = []
+        if cluster_name == 'target':
+            expected = [('active',), ('new',), ('old',)]
+            if user_id is None:
+                expected.insert(0, ('peer',))
+        assert rows == expected


### PR DESCRIPTION
`GET /api/status?cluster_name=...&all_status=true&limit=100` can scan the entire request history when a cluster has fewer than 100 matching requests. The existing cluster index is partial (active statuses only), so SQLite instead scans `created_at_idx` and filters unrelated finished requests.

Add idempotent `(cluster_name, created_at)` and `(cluster_name, user_id, created_at)` indexes at request-database initialization. The owner-aware index also skips other users' requests on shared clusters. Existing active-only and global-history indexes remain available. No request filtering, serialization or retention behavior changes.

Tests cover fresh and populated legacy schemas, existing and absent clusters, completed and active requests, hidden request names, user filtering and descending order. A SQLite instruction budget rejects the full-history scan without wall-clock assertions: the original eight cases fail before the cluster index, and two shared-cluster owner cases fail without the owner index. All 16 cases pass with both indexes.

Tested:
- `python -m pytest -c /dev/null --noconftest -p no:cacheprovider tests/unit_tests/test_sky/server/requests/test_request_history_index.py -q` — 16 passed. This standalone file requires no repository fixtures; the local environment lacks the configured collector plugins.
- Pinned YAPF 0.32.0 with Python 3.11 passed for both files.
- `bash format.sh --files ...` was attempted but stopped because local `pylint` is unavailable; the full formatting/lint pipeline is not claimed as passed.

Manual verification: on an isolated controller with populated finished-request history, run `EXPLAIN QUERY PLAN` for the cluster-filtered status query. Expect `SEARCH ... USING INDEX cluster_created_at_idx` (or `cluster_user_created_at_idx` with an owner predicate), without a global history scan or temporary sort. Then request `/api/status?cluster_name=<cluster>&all_status=true&limit=100` and confirm ordered completed/active summaries. Repeat for an absent cluster and after a second startup.

Deployment note: creating the index scans existing rows and takes SQLite's writer lock. Measure first-start migration on a representative isolated database and allow for the migration during a controlled restart.
