### PR TITLE
[Core] Redact secrets and trim noise in debug dumps (env vars, commands, task YAML)

### DIFF
--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -3744,11 +3744,14 @@ def _build_client_info() -> Dict[str, Any]:
         'python_version': platform.python_version(),
         'platform': platform.platform(),
         'user_hash': common_utils.get_user_hash(),
-        'environment': {
+        # Names are kept (which vars are set is diagnostic signal), but
+        # credential-shaped values are redacted -- this dict is persisted in
+        # the create_debug_dump request body and written to the dump.
+        'environment': debug_dump_helpers.redact_env_vars({
             k: v
             for k, v in sorted(os.environ.items())
             if k.startswith(('SKYPILOT_', 'SKY_'))
-        },
+        }),
         'user_config': user_config,
         'merged_config': merged_config,
     }

--- a/sky/utils/debug_dump_helpers.py
+++ b/sky/utils/debug_dump_helpers.py
@@ -7,6 +7,7 @@ Extracted to avoid a circular import:
 """
 import copy
 import datetime
+import re
 from typing import Any, Dict, List, Optional, Tuple
 
 from sky import global_user_state
@@ -14,12 +15,154 @@ from sky import task as task_lib
 from sky.utils import config_utils
 from sky.utils import yaml_utils
 
+REDACTED_VALUE = '<redacted>'
+
 # Sensitive config paths to redact in debug dumps, following the same
 # pattern as provision/common.py:ProvisionConfig.get_redacted_config().
 _SENSITIVE_CONFIG_KEYS: List[Tuple[str, ...]] = [
     ('api_server', 'endpoint'),
     ('api_server', 'service_account_token'),
 ]
+
+# Env var names whose values are always redacted in debug dumps. Kept as an
+# explicit list for names that do not match _SENSITIVE_ENV_VAR_NAME_RE (e.g.
+# AUTH-suffixed names); the pattern below covers the rest.
+_SENSITIVE_ENV_VAR_NAMES = frozenset({
+    'SKYPILOT_DB_CONNECTION_URI',
+    'SKYPILOT_INITIAL_BASIC_AUTH',
+    'SKYPILOT_SERVICE_ACCOUNT_TOKEN',
+    'SKYPILOT_DOCKER_PASSWORD',
+    'AWS_SECRET_ACCESS_KEY',
+    'AWS_SESSION_TOKEN',
+    'AWS_ACCESS_KEY_ID',
+    'AZURE_CLIENT_SECRET',
+})
+
+# Any env var whose NAME matches this pattern has its value redacted in debug
+# dumps. Dumps are meant to be shared (attached to issues, sent to support),
+# so this deliberately over-matches: a false positive (redacting a non-secret
+# value whose name merely contains e.g. 'KEY') only costs a little diagnostic
+# signal, while a false negative leaks a credential. This is what makes the
+# redaction robust to deployments injecting new secret-bearing env vars the
+# explicit list above never anticipated.
+_SENSITIVE_ENV_VAR_NAME_RE = re.compile(
+    r'TOKEN|SECRET|KEY|PASSWORD|PASSWD|CREDENTIAL|URI', re.IGNORECASE)
+
+
+def is_sensitive_env_var(name: str) -> bool:
+    """Whether an env var's value must be redacted in debug dumps."""
+    return (name in _SENSITIVE_ENV_VAR_NAMES or
+            _SENSITIVE_ENV_VAR_NAME_RE.search(name) is not None)
+
+
+def redact_env_vars(env_vars: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a copy of env_vars safe to include in a debug dump.
+
+    Names are kept (which vars are set is diagnostic signal); values of
+    sensitive names are replaced with '<redacted>'. Set-but-empty values stay
+    empty -- there is nothing to leak, and the emptiness itself is signal.
+    The input is not mutated.
+    """
+    redacted: Dict[str, Any] = {}
+    for name, value in env_vars.items():
+        if is_sensitive_env_var(name):
+            redacted[name] = REDACTED_VALUE if value else value
+        else:
+            redacted[name] = value
+    return redacted
+
+
+# Kubernetes injects service-discovery env vars for every Service visible to
+# a pod (see "Environment variables" in the Kubernetes Services docs): for a
+# service `foo`, kubelet sets FOO_SERVICE_HOST, FOO_SERVICE_PORT,
+# FOO_SERVICE_PORT_<NAME>, FOO_PORT (a tcp://host:port URL) and the
+# FOO_PORT_<PORT>_TCP{,_ADDR,_PORT,_PROTO} family. On an in-cluster API
+# server the chart's services are named skypilot-*, so all of these start
+# with SKYPILOT_ and land in every request body (request_body_env_vars keeps
+# all SKYPILOT_* vars) -- ~60 identical entries per request, 72MB across a
+# large production dump. Matching the shapes kubelet generates (rather
+# than enumerating today's services) means any newly added chart service is
+# filtered automatically. This only affects what debug dumps write, never
+# what the server persists or executes.
+_K8S_SERVICE_DISCOVERY_NAME_RE = re.compile(
+    r'(?:^|_)SERVICE_HOST$|'
+    r'(?:^|_)SERVICE_PORT(?:_.+)?$|'
+    r'_PORT_\d+_TCP(?:_(?:ADDR|PORT|PROTO))?$')
+# Value shape of the bare {SVC}_PORT injection; checked only for names ending
+# in _PORT, which alone is too generic to drop (e.g. a real config var).
+_K8S_TCP_URL_VALUE_RE = re.compile(r'^tcp://[^\s:]+:\d+$')
+
+
+def is_service_discovery_env_var(name: str, value: Any) -> bool:
+    """Whether an env var is a Kubernetes-injected service-discovery var."""
+    if _K8S_SERVICE_DISCOVERY_NAME_RE.search(name) is not None:
+        return True
+    return (name.endswith('_PORT') and isinstance(value, str) and
+            _K8S_TCP_URL_VALUE_RE.match(value) is not None)
+
+
+def drop_service_discovery_env_vars(env_vars: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a copy of env_vars without k8s service-discovery entries.
+
+    The dropped entries are machine-generated noise: identical in every
+    request created inside the same pod and useless for debugging client
+    requests. The input is not mutated.
+    """
+    return {
+        name: value
+        for name, value in env_vars.items()
+        if not is_service_discovery_env_var(name, value)
+    }
+
+
+# KEY=VALUE assignments to --env/--secret in a shell command string
+# (e.g. the persisted entrypoint_command). Commands are shlex.join output,
+# which produces three shapes (\x27/\x22 are the quote characters, escaped to
+# keep this file's single-quote style):
+#   --env KEY=VALUE / --env=KEY=VALUE        (value ends at whitespace)
+#   --env 'KEY=VALUE MIGHT HAVE SPACES'      (value ends at the closing quote)
+#   '--env=KEY=VALUE MIGHT HAVE SPACES'      (whole token quoted by shlex)
+_CMD_ENV_FLAG_QUOTED_RE = re.compile(
+    r'(?P<prefix>--(?:env|secret)(?:=|\s+))(?P<quote>[\x27\x22])'
+    r'(?P<key>[^=\s\x27\x22]+)=(?P<value>.*?)(?P=quote)')
+_CMD_ENV_FLAG_ATTACHED_QUOTED_RE = re.compile(
+    r'(?P<quote>[\x27\x22])(?P<prefix>--(?:env|secret)=)'
+    r'(?P<key>[^=\s\x27\x22]+)=(?P<value>.*?)(?P=quote)')
+_CMD_ENV_FLAG_BARE_RE = re.compile(
+    r'(?P<prefix>--(?:env|secret)(?:=|\s+))'
+    r'(?P<key>[^=\s\x27\x22]+)=(?P<value>[^\s\x27\x22]*)')
+
+
+def redact_command_secrets(command: str) -> str:
+    """Redact credential-bearing --env/--secret values in a command string.
+
+    Any `--env KEY=VALUE` / `--secret KEY=VALUE` (or `--env=KEY=VALUE`) whose
+    KEY matches the sensitive-env-var pattern has VALUE replaced with
+    '<redacted>'. Users do pass credentials via --env, and the persisted
+    entrypoint_command is copied verbatim into debug dumps (log-tail requests
+    even duplicate the outer command into many request records). Keys without
+    a value (`--env KEY`, whose value lives in the client's environment) and
+    empty values are left alone -- there is nothing to leak.
+    """
+
+    def _redact(match: 're.Match[str]') -> str:
+        key = match.group('key')
+        value = match.group('value')
+        if not value or not is_sensitive_env_var(key):
+            return match.group(0)
+        # Preserve the command's shape, swapping only the value. The
+        # attached-quoted form puts its opening quote before the flag, the
+        # split-quoted form between the flag and the key, and the bare form
+        # has no quote at all.
+        prefix = match.group('prefix')
+        quote = match.groupdict().get('quote') or ''
+        if match.re is _CMD_ENV_FLAG_ATTACHED_QUOTED_RE:
+            return f'{quote}{prefix}{key}={REDACTED_VALUE}{quote}'
+        return f'{prefix}{quote}{key}={REDACTED_VALUE}{quote}'
+
+    command = _CMD_ENV_FLAG_QUOTED_RE.sub(_redact, command)
+    command = _CMD_ENV_FLAG_ATTACHED_QUOTED_RE.sub(_redact, command)
+    return _CMD_ENV_FLAG_BARE_RE.sub(_redact, command)
 
 
 def redact_config(config: Dict[str, Any]) -> Dict[str, Any]:
@@ -32,7 +175,7 @@ def redact_config(config: Dict[str, Any]) -> Dict[str, Any]:
     for field_path in _SENSITIVE_CONFIG_KEYS:
         val = config_copy.get_nested(field_path, default_value=None)
         if val is not None:
-            config_copy.set_nested(field_path, '<redacted>')
+            config_copy.set_nested(field_path, REDACTED_VALUE)
     return dict(**config_copy)
 
 
@@ -107,7 +250,9 @@ def serialize_cluster_record(cluster_record: Dict[str, Any]) -> Dict[str, Any]:
         'last_use': cluster_record.get('last_use'),
         'owner': cluster_record.get('owner'),
         'metadata': cluster_record.get('metadata'),
-        'last_creation_command': cluster_record.get('last_creation_command'),
+        'last_creation_command':
+            (redact_command_secrets(cluster_record['last_creation_command']) if
+             cluster_record.get('last_creation_command') is not None else None),
         'last_creation_yaml':
             (redact_task_yaml(cluster_record['last_creation_yaml'])
              if cluster_record.get('last_creation_yaml') is not None else None),
@@ -141,7 +286,9 @@ def serialize_cluster_history_record(
         'workspace': history_record.get('workspace'),
         'last_event': history_record.get('last_event'),
         'node_names': history_record.get('node_names'),
-        'last_creation_command': history_record.get('last_creation_command'),
+        'last_creation_command':
+            (redact_command_secrets(history_record['last_creation_command']) if
+             history_record.get('last_creation_command') is not None else None),
         'last_creation_yaml':
             (redact_task_yaml(history_record['last_creation_yaml'])
              if history_record.get('last_creation_yaml') is not None else None),

--- a/sky/utils/debug_dump_helpers.py
+++ b/sky/utils/debug_dump_helpers.py
@@ -14,8 +14,7 @@ from sky import global_user_state
 from sky import task as task_lib
 from sky.utils import config_utils
 from sky.utils import yaml_utils
-
-REDACTED_VALUE = '<redacted>'
+from sky.utils.config_utils import REDACTED_VALUE
 
 # Sensitive config paths to redact in debug dumps, following the same
 # pattern as provision/common.py:ProvisionConfig.get_redacted_config().
@@ -61,11 +60,12 @@ def redact_env_vars(env_vars: Dict[str, Any]) -> Dict[str, Any]:
     Names are kept (which vars are set is diagnostic signal); values of
     sensitive names are replaced with '<redacted>'. Set-but-empty values stay
     empty -- there is nothing to leak, and the emptiness itself is signal.
-    The input is not mutated.
+    The input is not mutated. Non-string keys (possible in yaml-parsed docs)
+    pass through unredacted rather than raising.
     """
     redacted: Dict[str, Any] = {}
     for name, value in env_vars.items():
-        if is_sensitive_env_var(name):
+        if isinstance(name, str) and is_sensitive_env_var(name):
             redacted[name] = REDACTED_VALUE if value else value
         else:
             redacted[name] = value
@@ -122,33 +122,49 @@ def drop_service_discovery_env_vars(env_vars: Dict[str, Any]) -> Dict[str, Any]:
 #   --env KEY=VALUE / --env=KEY=VALUE        (value ends at whitespace)
 #   --env 'KEY=VALUE MIGHT HAVE SPACES'      (value ends at the closing quote)
 #   '--env=KEY=VALUE MIGHT HAVE SPACES'      (whole token quoted by shlex)
+# The flag name is captured so the callback can treat --env and --secret
+# differently.
 _CMD_ENV_FLAG_QUOTED_RE = re.compile(
-    r'(?P<prefix>--(?:env|secret)(?:=|\s+))(?P<quote>[\x27\x22])'
+    r'(?P<prefix>--(?P<flag>env|secret)(?:=|\s+))(?P<quote>[\x27\x22])'
     r'(?P<key>[^=\s\x27\x22]+)=(?P<value>.*?)(?P=quote)')
 _CMD_ENV_FLAG_ATTACHED_QUOTED_RE = re.compile(
-    r'(?P<quote>[\x27\x22])(?P<prefix>--(?:env|secret)=)'
+    r'(?P<quote>[\x27\x22])(?P<prefix>--(?P<flag>env|secret)=)'
     r'(?P<key>[^=\s\x27\x22]+)=(?P<value>.*?)(?P=quote)')
 _CMD_ENV_FLAG_BARE_RE = re.compile(
-    r'(?P<prefix>--(?:env|secret)(?:=|\s+))'
+    r'(?P<prefix>--(?P<flag>env|secret)(?:=|\s+))'
     r'(?P<key>[^=\s\x27\x22]+)=(?P<value>[^\s\x27\x22]*)')
 
 
 def redact_command_secrets(command: str) -> str:
     """Redact credential-bearing --env/--secret values in a command string.
 
-    Any `--env KEY=VALUE` / `--secret KEY=VALUE` (or `--env=KEY=VALUE`) whose
-    KEY matches the sensitive-env-var pattern has VALUE replaced with
-    '<redacted>'. Users do pass credentials via --env, and the persisted
-    entrypoint_command is copied verbatim into debug dumps (log-tail requests
-    even duplicate the outer command into many request records). Keys without
-    a value (`--env KEY`, whose value lives in the client's environment) and
-    empty values are left alone -- there is nothing to leak.
+    `--env KEY=VALUE` / `--env=KEY=VALUE` (any shlex quoting shape) whose KEY
+    matches the sensitive-env-var pattern has VALUE replaced with
+    '<redacted>'. Any non-empty `--secret KEY=VALUE` redacts regardless of
+    key name: the user already marked the value as a secret on the command
+    line, and key-gating that flag would repeat exactly the allowlist failure
+    this redaction exists to fix (a secret under an unforeseen name shipping
+    verbatim). This mirrors the client-side construction-time precedent
+    common_utils._redact_secrets_values, which also redacts every non-empty
+    --secret value; it diverges on empty values -- the client rewrites
+    `--secret KEY=` to '<redacted>' while we keep it empty, matching
+    redact_env_vars' empty-preserving convention (nothing to leak).
+
+    Keys without a value (`--env KEY`, whose value lives in the client's
+    environment) and empty values are left alone -- there is nothing to leak.
+
+    Limitation: values containing embedded single quotes (shlex `'\''`
+    escapes) are only partially redacted -- the regex stops at the first
+    closing quote, so a fragment after the escape can survive. A full
+    shlex-escape-consuming regex would be needed to cover that; not
+    evidenced in practice, so out of scope here.
     """
 
     def _redact(match: 're.Match[str]') -> str:
         key = match.group('key')
         value = match.group('value')
-        if not value or not is_sensitive_env_var(key):
+        if not value or (match.group('flag') == 'env' and
+                         not is_sensitive_env_var(key)):
             return match.group(0)
         # Preserve the command's shape, swapping only the value. The
         # attached-quoted form puts its opening quote before the flag, the
@@ -189,11 +205,57 @@ def epoch_to_human(epoch: Optional[float]) -> Optional[str]:
         return None
 
 
+def _redact_task_yaml_doc(doc: Dict[str, Any], depth: int = 0) -> None:
+    """Redact secrets, credentials and envs in a parsed task/dag doc in place.
+
+    Extends task_lib.redact_task_yaml_dict (the `secrets:` block and docker
+    password) with two dump-only steps: redacting envs values with sensitive
+    names, and recursing into the embedded '_user_specified_yaml' string (a
+    yaml-file task carries the user's original yaml verbatim, which re-embeds
+    the same envs). The envs redaction deliberately lives here and NOT in
+    task_lib.redact_task_yaml_dict: that function is on the functional
+    managed-job relaunch path (task.to_yaml_config(use_user_specified_yaml=
+    True) output is stored as the relaunch snapshot), where env values must
+    survive so relaunched jobs keep their environment.
+
+    The _user_specified_yaml recursion is gated at depth 0 so a hand-crafted
+    nested _user_specified_yaml cannot recurse infinitely. The embedded
+    string is replaced only when redaction changed its content, so a user
+    yaml without sensitive envs stays byte-identical; if it fails to parse it
+    is replaced with '<parse error, redacted>'.
+    """
+    task_lib.redact_task_yaml_dict(doc)
+    envs = doc.get('envs')
+    if isinstance(envs, dict):
+        doc['envs'] = redact_env_vars(envs)
+    if depth == 0:
+        user_yaml = doc.get('_user_specified_yaml')
+        if isinstance(user_yaml, str) and user_yaml:
+            try:
+                inner_docs = list(yaml_utils.safe_load_all(user_yaml))
+            except Exception:  # pylint: disable=broad-except
+                doc['_user_specified_yaml'] = '<parse error, redacted>'
+            else:
+                before = yaml_utils.dump_yaml_str(inner_docs)
+                for inner_doc in inner_docs:
+                    if isinstance(inner_doc, dict):
+                        _redact_task_yaml_doc(inner_doc, depth + 1)
+                after = yaml_utils.dump_yaml_str(inner_docs)
+                if after != before:
+                    doc['_user_specified_yaml'] = after
+
+
 def redact_task_yaml(yaml_str: str) -> str:
     """Parse a task/dag YAML string and redact secrets and credentials.
 
     Shared by the API server dump (debug_utils.py) and the controller
-    manifest (jobs/utils.py).
+    manifest (jobs/utils.py) -- both dump-side consumers. Redacts the
+    `secrets:` block and docker password (task_lib.redact_task_yaml_dict),
+    plus envs values with sensitive names and the same inside the embedded
+    _user_specified_yaml string (see _redact_task_yaml_doc). Note that
+    despite what the field routing suggests, task YAML envs were never
+    redacted before -- envs values shipped verbatim in dumps; this closes
+    that gap on the dump side only.
     """
     try:
         docs = list(yaml_utils.safe_load_all(yaml_str))
@@ -201,7 +263,7 @@ def redact_task_yaml(yaml_str: str) -> str:
         return '<parse error, redacted>'
     for doc in docs:
         if isinstance(doc, dict):
-            task_lib.redact_task_yaml_dict(doc)
+            _redact_task_yaml_doc(doc)
     return yaml_utils.dump_yaml_str(docs)
 
 

--- a/sky/utils/debug_utils.py
+++ b/sky/utils/debug_utils.py
@@ -1019,14 +1019,23 @@ def _sanitize_request_body(request) -> Optional[Dict[str, Any]]:
     # Redact sensitive env var values, after first dropping the k8s
     # service-discovery entries (identical machine-generated noise in every
     # request created inside this pod; 72MB across a large production
-    # dump) -- see debug_dump_helpers for both.
+    # dump) -- see debug_dump_helpers for both. When entries were dropped,
+    # note it next to the trimmed env_vars so the omission is self-describing.
     env_vars = data.get('env_vars')
     if isinstance(env_vars, dict):
-        data['env_vars'] = debug_dump_helpers.redact_env_vars(
-            debug_dump_helpers.drop_service_discovery_env_vars(env_vars))
+        kept_env_vars = debug_dump_helpers.drop_service_discovery_env_vars(
+            env_vars)
+        if len(kept_env_vars) != len(env_vars):
+            data['env_vars_omitted'] = (
+                f'{len(env_vars) - len(kept_env_vars)} Kubernetes '
+                'service-discovery env vars omitted (injected into the '
+                'client pod, not set by the client)')
+        data['env_vars'] = debug_dump_helpers.redact_env_vars(kept_env_vars)
     # Redact credentials passed on the command line (--env/--secret
     # KEY=VALUE); the persisted entrypoint_command is otherwise copied
-    # verbatim into the dump.
+    # verbatim into the dump. The separate 'entrypoint' string field (the
+    # usage-lib entrypoint, e.g. the CLI module name) was scanned in a
+    # large production dump and carries no credential-shaped values.
     entrypoint_command = data.get('entrypoint_command')
     if isinstance(entrypoint_command, str) and entrypoint_command:
         data['entrypoint_command'] = (

--- a/sky/utils/debug_utils.py
+++ b/sky/utils/debug_utils.py
@@ -185,19 +185,6 @@ def _log_timed_out_stragglers(orphans: List[Dict[str, Any]]) -> None:
 # Persistent location for debug dumps
 DEBUG_DUMP_DIR = '~/.sky/debug_dumps'
 
-# Env var names whose values should be redacted (show bool presence only).
-# Used for both server_info environment and request body sanitization.
-_SENSITIVE_ENV_VARS = {
-    'SKYPILOT_DB_CONNECTION_URI',
-    'SKYPILOT_INITIAL_BASIC_AUTH',
-    'SKYPILOT_SERVICE_ACCOUNT_TOKEN',
-    'SKYPILOT_DOCKER_PASSWORD',
-    'AWS_SECRET_ACCESS_KEY',
-    'AWS_SESSION_TOKEN',
-    'AWS_ACCESS_KEY_ID',
-    'AZURE_CLIENT_SECRET',
-}
-
 # Maps request name → field names containing task/dag YAML to redact.
 # Empty tuple means include body verbatim (no YAML fields).
 # Requests not in this dict have their body excluded entirely.
@@ -958,12 +945,14 @@ def _dump_server_info(dump_dir: str,
                 'traceback': _full_traceback()
             })
 
-    # Add all SKYPILOT_*/SKY_* environment variables, redacting sensitive ones
-    env = {}
-    for k, v in sorted(os.environ.items()):
-        if k.startswith(('SKYPILOT_', 'SKY_')):
-            env[k] = bool(v) if k in _SENSITIVE_ENV_VARS else v
-    server_info['environment'] = env
+    # Add all SKYPILOT_*/SKY_* environment variables. Names are kept (which
+    # vars are set is diagnostic signal), but credential-shaped values are
+    # redacted -- see debug_dump_helpers.redact_env_vars.
+    server_info['environment'] = debug_dump_helpers.redact_env_vars({
+        k: v
+        for k, v in sorted(os.environ.items())
+        if k.startswith(('SKYPILOT_', 'SKY_'))
+    })
 
     # Add cloud status (keyed by workspace name, each mapping cloud names
     # to a list of capability strings — already JSON-serializable).
@@ -1013,7 +1002,9 @@ def _sanitize_request_body(request) -> Optional[Dict[str, Any]]:
     """Sanitize a request body for inclusion in a debug dump.
 
     Returns None if the request type is not in the allowlist or has no body.
-    For allowed requests, redacts sensitive env vars and task/dag YAML fields.
+    For allowed requests, redacts sensitive env var values, drops k8s
+    service-discovery env vars, redacts credentials in entrypoint_command,
+    and redacts task/dag YAML fields.
     """
     task_fields = _REQUEST_BODY_ALLOWLIST.get(request.name)
     if task_fields is None:
@@ -1025,12 +1016,21 @@ def _sanitize_request_body(request) -> Optional[Dict[str, Any]]:
         data = body.model_dump()
     except Exception:  # pylint: disable=broad-except
         return None
-    # Redact sensitive env var values
+    # Redact sensitive env var values, after first dropping the k8s
+    # service-discovery entries (identical machine-generated noise in every
+    # request created inside this pod; 72MB across a large production
+    # dump) -- see debug_dump_helpers for both.
     env_vars = data.get('env_vars')
     if isinstance(env_vars, dict):
-        for k in env_vars:
-            if k in _SENSITIVE_ENV_VARS:
-                env_vars[k] = '<redacted>'
+        data['env_vars'] = debug_dump_helpers.redact_env_vars(
+            debug_dump_helpers.drop_service_discovery_env_vars(env_vars))
+    # Redact credentials passed on the command line (--env/--secret
+    # KEY=VALUE); the persisted entrypoint_command is otherwise copied
+    # verbatim into the dump.
+    entrypoint_command = data.get('entrypoint_command')
+    if isinstance(entrypoint_command, str) and entrypoint_command:
+        data['entrypoint_command'] = (
+            debug_dump_helpers.redact_command_secrets(entrypoint_command))
     # Redact task/dag YAML fields
     for field in task_fields:
         if field in data and isinstance(data[field], str):

--- a/tests/unit_tests/test_sky/utils/test_debug_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_debug_utils.py
@@ -18,6 +18,7 @@ import pytest
 from sky import clouds
 from sky import exceptions
 from sky.adaptors import kubernetes as adaptors_kubernetes
+from sky.client import sdk
 from sky.jobs import utils as managed_job_utils
 from sky.server import constants as server_constants
 from sky.server.requests import log_provider as log_provider_lib
@@ -2297,15 +2298,38 @@ class TestManifestPathTraversal:
 
 
 # ---------------------------------------------------------------------------
-# Tests for _SENSITIVE_ENV_VARS redaction
+# Tests for sensitive env var redaction
 # ---------------------------------------------------------------------------
 class TestSensitiveEnvVarRedaction:
     """Tests for sensitive environment variable redaction."""
 
-    def test_sensitive_env_vars_redacted(self):
-        """Sensitive env vars should have their values replaced with bool."""
-        assert 'SKYPILOT_DB_CONNECTION_URI' in debug_utils._SENSITIVE_ENV_VARS
-        assert 'SKYPILOT_INITIAL_BASIC_AUTH' in debug_utils._SENSITIVE_ENV_VARS
+    @pytest.mark.parametrize('name', [
+        'SKYPILOT_DEPLOY_TOKEN',
+        'SKYPILOT_CREDS_MASTER_KEY',
+        'SKYPILOT_SOME_TOKEN',
+        'SKY_API_KEY',
+        'SKYPILOT_ADMIN_PASSWORD',
+        'SKYPILOT_CLOUD_CREDENTIALS',
+        'SKYPILOT_DB_CONNECTION_URI',
+        'skypilot_lowercase_token',
+    ])
+    def test_credential_shaped_names_are_sensitive(self, name):
+        """Names containing TOKEN/KEY/SECRET/... match case-insensitively."""
+        assert debug_dump_helpers.is_sensitive_env_var(name)
+
+    @pytest.mark.parametrize('name', [
+        'SKYPILOT_DEBUG',
+        'SKY_NORMAL_VAR',
+        'SKYPILOT_CONFIG',
+        'SKYPILOT_USER_ID',
+    ])
+    def test_ordinary_names_are_not_sensitive(self, name):
+        assert not debug_dump_helpers.is_sensitive_env_var(name)
+
+    def test_exact_sensitive_names_still_covered(self):
+        """AUTH-suffixed names that miss the pattern stay redacted."""
+        assert debug_dump_helpers.is_sensitive_env_var(
+            'SKYPILOT_INITIAL_BASIC_AUTH')
 
     @mock.patch('sky.utils.debug_utils.sky_check.check', return_value={})
     @mock.patch('sky.utils.debug_utils.requests_lib.get_request',
@@ -2317,19 +2341,28 @@ class TestSensitiveEnvVarRedaction:
         env_patch = {
             'SKYPILOT_DEBUG': '1',
             'SKYPILOT_DB_CONNECTION_URI': 'postgresql://secret@host/db',
+            'SKYPILOT_DEPLOY_TOKEN': 'sky_live_token',
+            'SKYPILOT_CREDS_MASTER_KEY': 'master_key_value',
             'SKY_NORMAL_VAR': 'visible',
         }
         with mock.patch.dict(os.environ, env_patch, clear=False):
             debug_utils._dump_server_info(str(tmp_path))
 
         with open(os.path.join(str(tmp_path), 'server_info.json')) as f:
-            info = json.load(f)
+            raw = f.read()
+            info = json.loads(raw)
 
         env = info['environment']
         assert env['SKYPILOT_DEBUG'] == '1'
         assert env['SKY_NORMAL_VAR'] == 'visible'
-        # Sensitive var should be redacted to bool
-        assert env['SKYPILOT_DB_CONNECTION_URI'] is True
+        # Exact-name and credential-shaped names are redacted (names kept).
+        assert env['SKYPILOT_DB_CONNECTION_URI'] == '<redacted>'
+        assert env['SKYPILOT_DEPLOY_TOKEN'] == '<redacted>'
+        assert env['SKYPILOT_CREDS_MASTER_KEY'] == '<redacted>'
+        # No secret value ships anywhere in the file.
+        assert 'sky_live_token' not in raw
+        assert 'master_key_value' not in raw
+        assert 'postgresql://secret' not in raw
 
     @mock.patch('sky.utils.debug_utils.requests_lib.get_request',
                 return_value=None)
@@ -2384,6 +2417,31 @@ class TestSensitiveEnvVarRedaction:
             }
         }
         assert 'cloud_status_error' not in info
+
+
+# ---------------------------------------------------------------------------
+# Tests for the client-side client_info construction
+# ---------------------------------------------------------------------------
+class TestBuildClientInfo:
+    """The client_info sent with create_debug_dump redacts its environment.
+
+    The 'sky.create_debug_dump' request body is persisted verbatim in the
+    dump (the server-side sanitizer does not recurse into client_info), so
+    the redaction must happen client-side.
+    """
+
+    def test_environment_redacts_credential_shaped_values(self):
+        """Credential-shaped SKYPILOT_*/SKY_* values are redacted client-side;
+        benign values pass through unchanged."""
+        env_patch = {
+            'SKYPILOT_SOME_TOKEN': 'client_side_token',
+            'SKYPILOT_DEBUG': '1',
+        }
+        with mock.patch.dict(os.environ, env_patch, clear=False):
+            environment = sdk._build_client_info()['environment']
+        assert environment['SKYPILOT_SOME_TOKEN'] == '<redacted>'
+        assert environment['SKYPILOT_DEBUG'] == '1'
+        assert 'client_side_token' not in json.dumps(environment)
 
 
 # ---------------------------------------------------------------------------
@@ -2476,6 +2534,17 @@ class TestSerializeClusterRecord:
         assert result['last_creation_command'] is None
         assert result['last_creation_yaml'] is None
         assert result['last_event'] is None
+
+    def test_last_creation_command_secrets_redacted(self):
+        """Credential-bearing --env values in the creation command are
+        redacted."""
+        record = self._make_full_cluster_record(
+            last_creation_command=('sky launch --env MY_TOKEN=tok123 '
+                                   '--env NCCL_TIMEOUT=1800 test.yaml'))
+        result = debug_dump_helpers.serialize_cluster_record(record)
+        assert result['last_creation_command'] == (
+            'sky launch --env MY_TOKEN=<redacted> '
+            '--env NCCL_TIMEOUT=1800 test.yaml')
 
     def test_handle_fields_extracted(self):
         """Handle sub-fields should be correctly extracted."""
@@ -2876,6 +2945,91 @@ class TestRedactConfig:
 
 
 # ---------------------------------------------------------------------------
+# Tests for redact_command_secrets
+# ---------------------------------------------------------------------------
+class TestRedactCommandSecrets:
+    """Tests for credential redaction in command strings."""
+
+    @pytest.mark.parametrize(
+        'command,expected',
+        [
+            # Bare, =-attached and quoted sensitive pairs are redacted.
+            ('sky launch --env TOKEN=t1', 'sky launch --env TOKEN=<redacted>'),
+            ('sky launch --env=API_KEY=k1',
+             'sky launch --env=API_KEY=<redacted>'),
+            ('sky launch --secret \'MY_SECRET=s 1\'',
+             'sky launch --secret \'MY_SECRET=<redacted>\''),
+            ('sky launch --secret "API_KEY=k 2"',
+             'sky launch --secret "API_KEY=<redacted>"'),
+            # Whole attached token quoted by shlex (value has spaces).
+            ('sky launch \'--env=API_KEY=k 3\'',
+             'sky launch \'--env=API_KEY=<redacted>\''),
+            # Non-sensitive pairs and quoted values with spaces are kept.
+            ('sky launch --env NCCL_TIMEOUT=1800',
+             'sky launch --env NCCL_TIMEOUT=1800'),
+            ('sky launch --env \'ENTRYPOINT=a b c\'',
+             'sky launch --env \'ENTRYPOINT=a b c\''),
+            # Nothing to leak: empty value, bare key.
+            ('sky launch --env HF_TOKEN=', 'sky launch --env HF_TOKEN='),
+            ('sky launch --env HF_TOKEN', 'sky launch --env HF_TOKEN'),
+            # Later flags are not corrupted by an earlier redaction.
+            ('--env TOKEN=t1 --gpus L4:8 --dryrun',
+             '--env TOKEN=<redacted> --gpus L4:8 --dryrun'),
+        ])
+    def test_redaction_shapes(self, command, expected):
+        assert debug_dump_helpers.redact_command_secrets(command) == expected
+
+
+# ---------------------------------------------------------------------------
+# Tests for drop_service_discovery_env_vars
+# ---------------------------------------------------------------------------
+class TestDropServiceDiscoveryEnvVars:
+    """Kubernetes injects these for every Service visible to the pod."""
+
+    @pytest.mark.parametrize('name', [
+        'SKYPILOT_PROMETHEUS_SERVER_SERVICE_HOST',
+        'SKYPILOT_API_SERVICE_PORT',
+        'SKYPILOT_API_SERVICE_PORT_HTTP',
+        'SKYPILOT_KUBE_STATE_METRICS_PORT_8080_TCP',
+        'SKYPILOT_KUBE_STATE_METRICS_PORT_8080_TCP_ADDR',
+        'SKYPILOT_KUBE_STATE_METRICS_PORT_8080_TCP_PORT',
+        'SKYPILOT_KUBE_STATE_METRICS_PORT_8080_TCP_PROTO',
+        'NEW_CHART_SERVICE_SERVICE_HOST',
+    ])
+    def test_service_discovery_names_dropped(self, name):
+        env = {name: 'value'}
+        assert debug_dump_helpers.drop_service_discovery_env_vars(env) == {}
+
+    @pytest.mark.parametrize(
+        'name,value,kept',
+        [
+            # Bare {SVC}_PORT is dropped only with the k8s tcp:// URL value.
+            ('SKYPILOT_API_PORT', 'tcp://172.20.95.240:80', False),
+            # A _PORT name with a non-k8s value is kept.
+            ('SKYPILOT_SOME_PORT', '1234', True),
+        ])
+    def test_bare_port_value_gated(self, name, value, kept):
+        result = debug_dump_helpers.drop_service_discovery_env_vars(
+            {name: value})
+        assert result == ({name: value} if kept else {})
+
+    def test_meaningful_vars_kept(self):
+        env = {
+            'KUBECONFIG': '/root/.kube/config',
+            'SKYPILOT_USER_ID': 'e2e000e0',
+            'SKYPILOT_DB_POOL_HOSTPORT': '127.0.0.1:6432',
+            'SKYPILOT_RELEASE_NAME': 'skypilot',
+        }
+        result = debug_dump_helpers.drop_service_discovery_env_vars(env)
+        assert result == env
+
+    def test_does_not_mutate_original(self):
+        env = {'SKYPILOT_API_SERVICE_PORT': 'tcp://1.2.3.4:80'}
+        debug_dump_helpers.drop_service_discovery_env_vars(env)
+        assert env == {'SKYPILOT_API_SERVICE_PORT': 'tcp://1.2.3.4:80'}
+
+
+# ---------------------------------------------------------------------------
 # Tests for _REQUEST_BODY_ALLOWLIST coverage
 # ---------------------------------------------------------------------------
 class TestRequestBodyAllowlistCoverage:
@@ -2981,6 +3135,96 @@ class TestSanitizeRequestBody:
         assert result['env_vars']['NORMAL_VAR'] == 'visible'
         assert result['env_vars']['AWS_SECRET_ACCESS_KEY'] == '<redacted>'
         assert result['env_vars']['SKYPILOT_DB_CONNECTION_URI'] == '<redacted>'
+
+    def test_credential_shaped_env_vars_redacted(self):
+        """Env vars with credential-shaped names are redacted by pattern."""
+
+        class FakeBody:
+
+            def model_dump(self):
+                return {
+                    'cluster_name': 'test',
+                    'env_vars': {
+                        'ROBOT_DATA_AUTH_TOKEN': 'd458189e',
+                        'WANDB_API_KEY': 'local-78b7',
+                        'SKYPILOT_DEBUG': '1',
+                    }
+                }
+
+        request = _make_request(name='sky.stop', request_body=FakeBody())
+        result = debug_utils._sanitize_request_body(request)
+        assert result is not None
+        assert result['env_vars']['ROBOT_DATA_AUTH_TOKEN'] == '<redacted>'
+        assert result['env_vars']['WANDB_API_KEY'] == '<redacted>'
+        assert result['env_vars']['SKYPILOT_DEBUG'] == '1'
+
+    def test_service_discovery_env_vars_dropped(self):
+        """Kubernetes service-discovery env vars are dropped from the body."""
+        service_discovery = {
+            'SKYPILOT_PROMETHEUS_SERVER_SERVICE_HOST': '172.20.234.74',
+            'SKYPILOT_API_SERVICE_PORT': 'tcp://172.20.230.146:80',
+            'SKYPILOT_API_PORT': 'tcp://172.20.95.240:80',
+            'SKYPILOT_KUBE_STATE_METRICS_PORT_8080_TCP_PORT': '8080',
+        }
+        meaningful = {
+            'KUBECONFIG': '/root/.kube/config',
+            'SKYPILOT_USER_ID': 'e2e000e0',
+            # A _PORT name with a non-service value is kept.
+            'SKYPILOT_SOME_PORT': '1234',
+        }
+
+        class FakeBody:
+
+            def model_dump(self):
+                return {
+                    'cluster_name': 'test',
+                    'env_vars': {
+                        **service_discovery,
+                        **meaningful
+                    }
+                }
+
+        request = _make_request(name='sky.status', request_body=FakeBody())
+        result = debug_utils._sanitize_request_body(request)
+        assert result is not None
+        assert result['env_vars'] == meaningful
+
+    def test_entrypoint_command_secrets_redacted(self):
+        """Credential-bearing --env/--secret values are redacted."""
+
+        class FakeBody:
+
+            def model_dump(self):
+                return {
+                    'cluster_name': 'test',
+                    'entrypoint_command':
+                        ('sky exec --num-nodes 4 --gpus L4:8 '
+                         '--env ROBOT_DATA_AUTH_TOKEN=d458189e '
+                         '--env NCCL_TIMEOUT=1800 '
+                         '--secret \'WANDB_API_KEY=local-78b7\' '
+                         '--secret=HF_TOKEN=hf_value '
+                         '--env \'ENTRYPOINT=run.sh --seed 0\' '
+                         '--env SLACK_API_TOKEN= '
+                         '--env MY_TOKEN'),
+                }
+
+        request = _make_request(name='sky.exec', request_body=FakeBody())
+        result = debug_utils._sanitize_request_body(request)
+        assert result is not None
+        cmd = result['entrypoint_command']
+        assert '--env ROBOT_DATA_AUTH_TOKEN=<redacted>' in cmd
+        assert '--env NCCL_TIMEOUT=1800' in cmd
+        assert '--secret \'WANDB_API_KEY=<redacted>\'' in cmd
+        assert '--secret=HF_TOKEN=<redacted>' in cmd
+        # Non-secret quoted value and its structure are preserved.
+        assert '--env \'ENTRYPOINT=run.sh --seed 0\'' in cmd
+        # Empty values and bare keys (value lives in the client env) have
+        # nothing to leak and stay as-is.
+        assert '--env SLACK_API_TOKEN=' in cmd
+        assert '--env MY_TOKEN' in cmd
+        assert 'd458189e' not in cmd
+        assert 'local-78b7' not in cmd
+        assert 'hf_value' not in cmd
 
     def test_task_yaml_field_redacted(self):
         """Task YAML fields should have secrets redacted."""

--- a/tests/unit_tests/test_sky/utils/test_debug_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_debug_utils.py
@@ -14,6 +14,7 @@ from unittest import mock
 import zipfile
 
 import pytest
+import yaml
 
 from sky import clouds
 from sky import exceptions
@@ -2964,7 +2965,8 @@ class TestRedactCommandSecrets:
             # Whole attached token quoted by shlex (value has spaces).
             ('sky launch \'--env=API_KEY=k 3\'',
              'sky launch \'--env=API_KEY=<redacted>\''),
-            # Non-sensitive pairs and quoted values with spaces are kept.
+            # Non-sensitive --env pairs and quoted values with spaces are
+            # kept.
             ('sky launch --env NCCL_TIMEOUT=1800',
              'sky launch --env NCCL_TIMEOUT=1800'),
             ('sky launch --env \'ENTRYPOINT=a b c\'',
@@ -2975,9 +2977,65 @@ class TestRedactCommandSecrets:
             # Later flags are not corrupted by an earlier redaction.
             ('--env TOKEN=t1 --gpus L4:8 --dryrun',
              '--env TOKEN=<redacted> --gpus L4:8 --dryrun'),
+            # A non-empty --secret redacts regardless of key name: the user
+            # marked the value as a secret on the command line, and key-gating
+            # that flag would repeat the allowlist failure this redaction
+            # fixes.
+            ('sky launch --secret MY_PAT=abc123',
+             'sky launch --secret MY_PAT=<redacted>'),
+            ('sky launch --secret=MY_PAT=abc123',
+             'sky launch --secret=MY_PAT=<redacted>'),
+            ('sky launch --secret \'MY_PAT=abc 1\'',
+             'sky launch --secret \'MY_PAT=<redacted>\''),
+            ('sky launch \'--secret=MY_PAT=abc 2\'',
+             'sky launch \'--secret=MY_PAT=<redacted>\''),
+            # Empty --secret values stay empty (nothing to leak; the
+            # client-side _redact_secrets_values rewrites them to
+            # '<redacted>' -- a deliberate divergence documented in
+            # redact_command_secrets).
+            ('sky launch --secret MY_PAT=', 'sky launch --secret MY_PAT='),
+            ('sky launch --secret MY_PAT', 'sky launch --secret MY_PAT'),
+            # '=' inside a value is part of the value.
+            ('sky launch --env TOKEN=abc=def',
+             'sky launch --env TOKEN=<redacted>'),
+            # Lookalike flags do not match: the regex requires '=' or
+            # whitespace right after --env/--secret.
+            ('sky launch --environment TOKEN=foo',
+             'sky launch --environment TOKEN=foo'),
+            ('sky launch --envy KEY=v', 'sky launch --envy KEY=v'),
+            # Flag at end of string: no KEY=VALUE follows.
+            ('sky launch --env', 'sky launch --env'),
+            # Unbalanced quote: no closing quote to bound the value, so the
+            # pair is left as-is rather than mangled.
+            ('sky launch --env \'MY_TOKEN=abc',
+             'sky launch --env \'MY_TOKEN=abc'),
+            # --env-file/--secret-file take paths, not KEY=VALUE pairs.
+            ('sky launch --env-file /path/to/env',
+             'sky launch --env-file /path/to/env'),
+            ('sky launch --secret-file /path/to/secret',
+             'sky launch --secret-file /path/to/secret'),
         ])
     def test_redaction_shapes(self, command, expected):
         assert debug_dump_helpers.redact_command_secrets(command) == expected
+
+    def test_embedded_quote_partially_redacted(self):
+        """A value containing an embedded single quote (shlex `'\''` escape)
+        is only partially redacted: the first quoted segment is redacted and a
+        fragment after the escape survives. Pins the documented limitation."""
+        command = 'sky launch --env \'MY_TOKEN=abc\'\\\'\'def\''
+        result = debug_dump_helpers.redact_command_secrets(command)
+        assert result == 'sky launch --env \'MY_TOKEN=<redacted>\'\\\'\'def\''
+
+    def test_oversized_command_redacts_quickly(self):
+        """A very large command (~100KB) redacts without pathological
+        backtracking."""
+        pairs = ' '.join(f'--env VAR_{i}=value_{i}' for i in range(2500))
+        command = f'sky launch {pairs} --env TOKEN=secret {pairs}'
+        assert len(command) > 100_000
+        result = debug_dump_helpers.redact_command_secrets(command)
+        assert '--env TOKEN=<redacted>' in result
+        assert 'secret' not in result
+        assert '--env VAR_0=value_0' in result
 
 
 # ---------------------------------------------------------------------------
@@ -3145,8 +3203,8 @@ class TestSanitizeRequestBody:
                 return {
                     'cluster_name': 'test',
                     'env_vars': {
-                        'ROBOT_DATA_AUTH_TOKEN': 'd458189e',
-                        'WANDB_API_KEY': 'local-78b7',
+                        'DATASET_AUTH_TOKEN': 'synthtoken123',
+                        'WANDB_API_KEY': 'synthkey456',
                         'SKYPILOT_DEBUG': '1',
                     }
                 }
@@ -3154,7 +3212,7 @@ class TestSanitizeRequestBody:
         request = _make_request(name='sky.stop', request_body=FakeBody())
         result = debug_utils._sanitize_request_body(request)
         assert result is not None
-        assert result['env_vars']['ROBOT_DATA_AUTH_TOKEN'] == '<redacted>'
+        assert result['env_vars']['DATASET_AUTH_TOKEN'] == '<redacted>'
         assert result['env_vars']['WANDB_API_KEY'] == '<redacted>'
         assert result['env_vars']['SKYPILOT_DEBUG'] == '1'
 
@@ -3188,9 +3246,39 @@ class TestSanitizeRequestBody:
         result = debug_utils._sanitize_request_body(request)
         assert result is not None
         assert result['env_vars'] == meaningful
+        # The omission is self-describing: the drop count is noted next to
+        # the trimmed env_vars.
+        assert result['env_vars_omitted'] == (
+            '4 Kubernetes service-discovery env vars omitted (injected into '
+            'the client pod, not set by the client)')
+
+    def test_no_env_vars_omitted_when_nothing_dropped(self):
+        """env_vars_omitted is absent when no service-discovery vars were
+        dropped."""
+
+        class FakeBody:
+
+            def model_dump(self):
+                return {
+                    'cluster_name': 'test',
+                    'env_vars': {
+                        'KUBECONFIG': '/root/.kube/config',
+                        'SKYPILOT_DEBUG': '1',
+                    }
+                }
+
+        request = _make_request(name='sky.status', request_body=FakeBody())
+        result = debug_utils._sanitize_request_body(request)
+        assert result is not None
+        assert 'env_vars_omitted' not in result
 
     def test_entrypoint_command_secrets_redacted(self):
-        """Credential-bearing --env/--secret values are redacted."""
+        """Credential-bearing --env/--secret values are redacted.
+
+        Shaped like a real production launch command that leaked: a quoted
+        multi-word ENTRYPOINT, bare sensitive and insensitive --env pairs, an
+        empty value, and --secret forms. All values are synthetic.
+        """
 
         class FakeBody:
 
@@ -3199,32 +3287,54 @@ class TestSanitizeRequestBody:
                     'cluster_name': 'test',
                     'entrypoint_command':
                         ('sky exec --num-nodes 4 --gpus L4:8 '
-                         '--env ROBOT_DATA_AUTH_TOKEN=d458189e '
+                         '--env DATASET_AUTH_TOKEN=synthtoken123 '
                          '--env NCCL_TIMEOUT=1800 '
-                         '--secret \'WANDB_API_KEY=local-78b7\' '
-                         '--secret=HF_TOKEN=hf_value '
-                         '--env \'ENTRYPOINT=run.sh --seed 0\' '
-                         '--env SLACK_API_TOKEN= '
-                         '--env MY_TOKEN'),
+                         '--env COMMIT_TAG= '
+                         '--secret MY_PAT=synthpat789 '
+                         '--secret \'WANDB_API_KEY=synthkey456\' '
+                         '--secret=MY_PAT= '
+                         '--env \'ENTRYPOINT=python train.py --epochs 10\' '
+                         '--env MY_TOKEN '
+                         's3://synth-bucket/synth-data'),
                 }
 
         request = _make_request(name='sky.exec', request_body=FakeBody())
         result = debug_utils._sanitize_request_body(request)
         assert result is not None
         cmd = result['entrypoint_command']
-        assert '--env ROBOT_DATA_AUTH_TOKEN=<redacted>' in cmd
+        assert '--env DATASET_AUTH_TOKEN=<redacted>' in cmd
         assert '--env NCCL_TIMEOUT=1800' in cmd
+        # --secret redacts any non-empty value, regardless of key name.
+        assert '--secret MY_PAT=<redacted>' in cmd
         assert '--secret \'WANDB_API_KEY=<redacted>\'' in cmd
-        assert '--secret=HF_TOKEN=<redacted>' in cmd
         # Non-secret quoted value and its structure are preserved.
-        assert '--env \'ENTRYPOINT=run.sh --seed 0\'' in cmd
+        assert '--env \'ENTRYPOINT=python train.py --epochs 10\'' in cmd
         # Empty values and bare keys (value lives in the client env) have
         # nothing to leak and stay as-is.
-        assert '--env SLACK_API_TOKEN=' in cmd
+        assert '--env COMMIT_TAG=' in cmd
+        assert '--secret=MY_PAT=' in cmd
         assert '--env MY_TOKEN' in cmd
-        assert 'd458189e' not in cmd
-        assert 'local-78b7' not in cmd
-        assert 'hf_value' not in cmd
+        assert 'synthtoken123' not in cmd
+        assert 'synthkey456' not in cmd
+        assert 'synthpat789' not in cmd
+
+    def test_verbatim_request_entrypoint_command_redacted(self):
+        """Category-1 verbatim requests also get entrypoint_command redacted
+        (log-tail requests inherit the outer command's entrypoint_command)."""
+
+        class FakeBody:
+
+            def model_dump(self):
+                return {
+                    'cluster_name': 'test',
+                    'entrypoint_command': 'sky logs --env MY_TOKEN=tok123',
+                }
+
+        request = _make_request(name='sky.logs', request_body=FakeBody())
+        result = debug_utils._sanitize_request_body(request)
+        assert result is not None
+        assert result['entrypoint_command'] == (
+            'sky logs --env MY_TOKEN=<redacted>')
 
     def test_task_yaml_field_redacted(self):
         """Task YAML fields should have secrets redacted."""
@@ -3307,6 +3417,134 @@ class TestRedactTaskYaml:
         result = debug_dump_helpers.redact_task_yaml(yaml_str)
         assert 'val1' not in result
         assert 'val2' not in result
+
+    def test_redacts_envs(self):
+        """Envs with sensitive names are redacted; benign and empty values
+        are kept (names are always kept)."""
+        yaml_str = ('name: my-task\n'
+                    'envs:\n'
+                    '  MY_TOKEN: real_token\n'
+                    '  WANDB_API_KEY: real_key\n'
+                    '  NCCL_TIMEOUT: "1800"\n'
+                    '  EMPTY_TOKEN: ""\n')
+        result = debug_dump_helpers.redact_task_yaml(yaml_str)
+        assert 'real_token' not in result
+        assert 'real_key' not in result
+        docs = list(yaml.safe_load_all(result))
+        assert docs[0]['envs']['MY_TOKEN'] == '<redacted>'
+        assert docs[0]['envs']['WANDB_API_KEY'] == '<redacted>'
+        assert docs[0]['envs']['NCCL_TIMEOUT'] == '1800'
+        assert docs[0]['envs']['EMPTY_TOKEN'] == ''
+
+    def test_multi_doc_dag_envs_redacted(self):
+        """Multi-document YAML (dag) redacts each document's envs."""
+        yaml_str = ('name: task1\n'
+                    'envs:\n'
+                    '  MY_TOKEN: tok1\n'
+                    '---\n'
+                    'name: task2\n'
+                    'envs:\n'
+                    '  API_KEY: tok2\n')
+        result = debug_dump_helpers.redact_task_yaml(yaml_str)
+        assert 'tok1' not in result
+        assert 'tok2' not in result
+        docs = list(yaml.safe_load_all(result))
+        assert docs[0]['envs']['MY_TOKEN'] == '<redacted>'
+        assert docs[1]['envs']['API_KEY'] == '<redacted>'
+
+    def test_non_dict_or_missing_envs_do_not_crash(self):
+        """Non-dict envs, missing envs and non-string env keys pass through
+        instead of raising."""
+        yaml_str = ('name: t1\n'
+                    'envs:\n'
+                    '  - a\n'
+                    '  - b\n'
+                    '---\n'
+                    'name: t2\n'
+                    '---\n'
+                    'name: t3\n'
+                    'envs:\n'
+                    '  123: value\n')
+        result = debug_dump_helpers.redact_task_yaml(yaml_str)
+        docs = list(yaml.safe_load_all(result))
+        assert docs[0]['envs'] == ['a', 'b']
+        assert 'envs' not in docs[1]
+        assert docs[2]['envs'] == {123: 'value'}
+
+    def test_redacts_envs_in_embedded_user_yaml(self):
+        """A yaml-file task carries the secret twice: in the envs dict AND
+        verbatim inside the embedded _user_specified_yaml string (the user's
+        original yaml). Both are redacted."""
+        yaml_str = ('name: my-task\n'
+                    'envs:\n'
+                    '  MY_TOKEN: real_token\n'
+                    '  NCCL_TIMEOUT: "1800"\n'
+                    '_user_specified_yaml: |\n'
+                    '  name: my-task\n'
+                    '  envs:\n'
+                    '    MY_TOKEN: real_token\n'
+                    '    NCCL_TIMEOUT: "1800"\n')
+        result = debug_dump_helpers.redact_task_yaml(yaml_str)
+        assert 'real_token' not in result
+        docs = list(yaml.safe_load_all(result))
+        assert docs[0]['envs']['MY_TOKEN'] == '<redacted>'
+        assert docs[0]['envs']['NCCL_TIMEOUT'] == '1800'
+        inner = list(yaml.safe_load_all(docs[0]['_user_specified_yaml']))
+        assert inner[0]['envs']['MY_TOKEN'] == '<redacted>'
+        assert inner[0]['envs']['NCCL_TIMEOUT'] == '1800'
+
+    def test_embedded_user_yaml_without_secrets_stays_identical(self):
+        """An embedded user yaml with nothing to redact stays byte-identical
+        (the string is replaced only when redaction changed its content)."""
+        embedded = 'name: my-task\nenvs:\n  NORMAL: value\n'
+        yaml_str = ('name: my-task\n'
+                    'envs:\n'
+                    '  NORMAL: value\n'
+                    '_user_specified_yaml: |\n'
+                    '  name: my-task\n'
+                    '  envs:\n'
+                    '    NORMAL: value\n')
+        result = debug_dump_helpers.redact_task_yaml(yaml_str)
+        docs = list(yaml.safe_load_all(result))
+        assert docs[0]['_user_specified_yaml'] == embedded
+
+    def test_embedded_user_yaml_parse_error_redacted(self):
+        """An embedded _user_specified_yaml that fails to parse is replaced
+        with a redacted marker."""
+        yaml_str = ('name: my-task\n'
+                    'envs:\n'
+                    '  MY_TOKEN: real_token\n'
+                    '_user_specified_yaml: "key: [unclosed"\n')
+        result = debug_dump_helpers.redact_task_yaml(yaml_str)
+        docs = list(yaml.safe_load_all(result))
+        assert docs[0]['_user_specified_yaml'] == '<parse error, redacted>'
+
+    def test_nested_user_specified_yaml_depth_capped(self):
+        """A hand-crafted _user_specified_yaml nested inside an embedded user
+        yaml is not recursed into (depth cap at the first embedding level), so
+        a maliciously nested doc cannot recurse infinitely."""
+        innermost = 'name: deepest\nenvs:\n  MY_TOKEN: real_token\n'
+        user_yaml = ('name: user\n'
+                     'envs:\n'
+                     '  MY_TOKEN: real_token\n'
+                     '_user_specified_yaml: |\n'
+                     '  name: deepest\n'
+                     '  envs:\n'
+                     '    MY_TOKEN: real_token\n')
+        indented = ''.join(
+            '  ' + line for line in user_yaml.splitlines(keepends=True))
+        yaml_str = ('name: task\n'
+                    'envs:\n'
+                    '  MY_TOKEN: real_token\n'
+                    '_user_specified_yaml: |\n' + indented)
+        result = debug_dump_helpers.redact_task_yaml(yaml_str)
+        docs = list(yaml.safe_load_all(result))
+        assert docs[0]['envs']['MY_TOKEN'] == '<redacted>'
+        user_doc = list(yaml.safe_load_all(docs[0]['_user_specified_yaml']))[0]
+        assert user_doc['envs']['MY_TOKEN'] == '<redacted>'
+        # The second-level embedding is past the depth cap and stays
+        # verbatim (still carries its value) -- pinned depth-cap behavior.
+        assert user_doc['_user_specified_yaml'] == innermost
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Debug dumps are meant to be shared (attached to issues, sent to support), but replaying the dump sanitizer over every request body from a large production debug dump (~7200 requests, a server with many long-lived and stale unfinished requests) showed three gap classes:

- **Env redaction was an 8-name hardcoded allowlist**, so any secret-bearing env var not on the list shipped verbatim. In that dump, `server_info.json` contained a server auth token and an encryption key in plaintext — neither name was on the list, though both contain TOKEN/KEY. The client_info environment block had no redaction at all.
- **`_sanitize_request_body` never touched `entrypoint_command`**, so credentials passed as `--env KEY=VALUE` leaked verbatim (79 of ~7200 request files, with log-tail requests duplicating one token across 119 files since they inherit the outer command). The task/dag YAML fields also shipped `envs:` values verbatim — `redact_task_yaml` only ever covered the `secrets:` block and the docker password, never `envs`. A yaml-file task leaks twice: in the `envs` dict and again verbatim inside the embedded `_user_specified_yaml` string (the user's original yaml).
- **Every request body carried ~60 identical Kubernetes service-discovery env vars** (`*_SERVICE_HOST`, `*_PORT_<N>_TCP*`, ...) injected into the client pod — ~72MB of identical noise across the dump, drowning the useful per-request fields.

## What this PR does

All of it is dump-write-path only: the server still persists and executes the full request environment, and managed-job relaunch snapshots keep full env values.

- Replace the allowlist with **deny-by-pattern** redaction (any env var name containing TOKEN/SECRET/KEY/PASSWORD/PASSWD/CREDENTIAL/URI, case-insensitive, plus the explicit list), shared through one helper (`debug_dump_helpers`) and applied at every environment-serialization site: `server_info.json`, request bodies, and `client_info.json` — the same leak class found at the third environment-serialization site (client_info) while implementing the shared helper, closed in the same pass. Names are kept (which vars are set is diagnostic signal); set-but-empty values stay empty.
- Redact `--env/--secret KEY=VALUE` pairs in `entrypoint_command` (and cluster records' `last_creation_command`) in all shlex-quoted shapes. Any **non-empty `--secret` value redacts regardless of key name** — the user already marked it a secret; key-gating that flag would repeat the allowlist failure this fixes. Known limitation (documented and test-pinned): values containing embedded single quotes (shlex `'\''` escapes) are only partially redacted.
- Redact `envs:` values in the dumped task/dag YAML fields, **including inside the embedded `_user_specified_yaml` string** (replaced only when redaction changed its content, so unchanged user yaml stays byte-identical; parse errors become a redacted marker; depth-capped). `task_lib.redact_task_yaml_dict` is deliberately untouched — it is on the functional managed-job relaunch path where env values must survive.
- Drop the Kubernetes service-discovery env vars from request bodies by matching the exact shapes kubelet injects per Service (so newly added chart services are filtered automatically), keeping sensitive-name redaction on what remains, and note the drop count next to the trimmed `env_vars` (`env_vars_omitted`) when anything was dropped.

## Testing

- Unit tests in `tests/unit_tests/test_sky/utils/test_debug_utils.py`: sensitive-env redaction, client-info environment redaction (`_build_client_info`), command redaction shapes (including lookalike flags, unbalanced quotes, oversized commands), service-discovery dropping, task-YAML envs + embedded user yaml (redaction, byte-identity when unchanged, parse-error marker, depth cap), unconditional `--secret`, and `env_vars_omitted`. All token-like fixture values are synthetic. The 6 pre-existing `TestDumpKubeContextsInfo` failures in this devspace reproduce on unmodified master (missing kubernetes extras in the venv).
- `tests/unit_tests/test_jobs_utils.py` green — guards that the managed-job controller manifest and relaunch snapshot paths are unaffected.
- Replay over all ~7200 request bodies of that production dump with the integrated sanitizer: zero crashes, zero files retaining the known leaked token values (read from the dump at runtime), zero task/dag docs (or embedded user yaml) retaining a non-empty value under a sensitive-named `envs` key (204 docs / 132 embedded files were fixed), exactly 194 `entrypoint_command` files changed, `env_vars_omitted` present exactly where drops occurred (~97k entries dropped, ~37% fewer serialized body bytes), and the unconditional `--secret` rule changes 0 additional files (all `--secret KEY=VALUE` values in the dump were already construction-time redacted).
- Live end-to-end against a local API server: `sky launch --env SOME_AUTH_TOKEN=testvalue --secret MY_PAT=testvalue` with benign and quoted multi-word `--env`s, plus a yaml-file launch whose `envs:` carries a sensitive-named key — in the resulting debug dump `testvalue` appears nowhere (including the task YAML field and its embedded `_user_specified_yaml`), `<redacted>` appears at each redaction site, `env_vars` contains no service-discovery shapes with `env_vars_omitted` noting 60 drops, and benign values survive byte-for-byte.

No new configuration knobs; rollback is reverting this PR.

Note: this may conflict with other in-flight debug-dump changes touching `sky/utils/debug_utils.py` and `sky/utils/debug_dump_helpers.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
