### PR TITLE
[Jobs] Exclude cluster events after task completion from the timeline

### DIFF
--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -1594,6 +1594,7 @@ def get_cluster_events_by_name(
     cluster_name: str,
     event_types: List[ClusterEventType],
     limit: Optional[int] = None,
+    until: Optional[float] = None,
 ) -> List[Dict[str, Union[str, int]]]:
     """Returns cluster events looked up by the persisted cluster name.
 
@@ -1608,6 +1609,10 @@ def get_cluster_events_by_name(
         event_types: Event types to include.
         limit: If specified, returns at most this many events (most recent),
             across all the requested event types.
+        until: If specified, only events that happened at or before this unix
+            timestamp are returned. Applied before ``limit``, so a caller
+            asking for the most recent N events within a window still gets N
+            of them.
 
     Returns:
         List of dicts with 'reason' and 'transitioned_at' (unix timestamp)
@@ -1622,8 +1627,10 @@ def get_cluster_events_by_name(
             cluster_event_table.c.reason,
             cluster_event_table.c.transitioned_at,
         ).filter(cluster_event_table.c.name == cluster_name,
-                 cluster_event_table.c.type.in_(type_values)).order_by(
-                     cluster_event_table.c.transitioned_at.desc())
+                 cluster_event_table.c.type.in_(type_values))
+        if until is not None:
+            query = query.filter(cluster_event_table.c.transitioned_at <= until)
+        query = query.order_by(cluster_event_table.c.transitioned_at.desc())
         if limit is not None:
             query = query.limit(limit)
         rows = query.all()

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -1973,6 +1973,7 @@ def pool_sync_down_logs(
 
 def _get_job_clusters(
         job_id: int,
+        tasks: List[Dict[str, Any]],
         task_id: Optional[int] = None) -> List[Tuple[str, Optional[int]]]:
     """Reconstruct the underlying cluster name(s) for a managed job.
 
@@ -1985,12 +1986,21 @@ def _get_job_clusters(
     skipped, since their cluster is shared across jobs and its events are not
     attributable to a single job.
 
-    Returns de-duplicated ``(cluster_name, task_id)`` pairs (a multi-task
-    pipeline uses one cluster per task), so a caller merging the clusters'
-    events can attribute each one to the task that owns it.
+    Args:
+        job_id: The managed job id whose cluster name(s) to reconstruct.
+        tasks: The job's rows as returned by
+            ``managed_job_state.get_managed_job_tasks``, passed in so the
+            caller's single read of them is reused here as well as for the
+            per-task event cutoffs it computes from the same rows.
+        task_id: If given, only the cluster of that task is returned.
+
+    Returns:
+        De-duplicated ``(cluster_name, task_id)`` pairs (a multi-task pipeline
+        uses one cluster per task), so a caller merging the clusters' events
+        can attribute each one to the task that owns it.
     """
     clusters: List[Tuple[str, Optional[int]]] = []
-    for task in managed_job_state.get_managed_job_tasks(job_id):
+    for task in tasks:
         if task_id is not None and task.get('task_id') != task_id:
             continue
         if task.get('pool') is not None:
@@ -2005,6 +2015,36 @@ def _get_job_clusters(
             task_name, job_id), task.get('task_id')))
     # De-duplicate while preserving order.
     return list(dict.fromkeys(clusters))
+
+
+def _task_end_timestamps(
+        tasks: List[Dict[str, Any]]) -> Dict[Optional[int], float]:
+    """{task_id: end time} for the tasks of a managed job that have finished.
+
+    The cutoff is per task, not per job: each task of a pipeline launches its
+    own cluster, and that cluster is torn down when its task ends, so task 0
+    of a pipeline whose task 1 is still running already has post-completion
+    cluster events to leave out.
+
+    A task that is not terminal, or that is terminal with no end_at (an old
+    row), is left out of the mapping and so gets no cutoff -- a missing
+    timestamp never cuts anything out.
+
+    Args:
+        tasks: The job's rows as returned by
+            ``managed_job_state.get_managed_job_tasks``.
+
+    Returns:
+        A mapping from task id to the task's end time, as a unix timestamp.
+    """
+    end_at_by_task: Dict[Optional[int], float] = {}
+    for task in tasks:
+        status = task.get('status')
+        task_end_at = task.get('end_at')
+        if status is None or not status.is_terminal() or task_end_at is None:
+            continue
+        end_at_by_task[task.get('task_id')] = task_end_at
+    return end_at_by_task
 
 
 def _resolve_task_id(job_id: int, task: Union[str, int]) -> int:
@@ -2089,7 +2129,10 @@ def _job_events(
         include_cluster_events: When True, merge launch-progress events from
             the job's underlying cluster (e.g. image pulling) into the
             timeline so provisioning milestones between STARTING and RUNNING
-            are visible.
+            are visible. A cluster event later than the end time of the task
+            that owns the cluster is left out, since a finished task's cluster
+            is only being cleaned up by then; a task that has not finished, or
+            that has no recorded end time, cuts off nothing.
 
     Returns:
         List of task event records, ordered newest first.
@@ -2103,12 +2146,21 @@ def _job_events(
         return events
 
     try:
-        clusters = _get_job_clusters(job_id, task_id)
+        tasks = managed_job_state.get_managed_job_tasks(job_id)
+        clusters = _get_job_clusters(job_id, tasks, task_id)
     except Exception as e:  # pylint: disable=broad-except
         # The merge is best-effort: never fail the job-events request because
         # the cluster name(s) could not be reconstructed.
         logger.debug(f'Failed to resolve cluster name(s) for job {job_id}: {e}')
         return events
+
+    # Anything a task's cluster recorded after that task finished did not
+    # happen to the job: it is the cluster being cleaned up (teardown of
+    # leftover resources, a final status refresh). Merging it would append a
+    # fabricated STARTING row after the task's terminal row. The cutoff is per
+    # task, since each task has its own cluster and its own end time; a task
+    # that has not finished has no cutoff.
+    end_at_by_task = _task_end_timestamps(tasks)
 
     # STATUS_CHANGE carries the launch/setup milestone sequence (provisioning,
     # runtime setup, file-mount syncing, ...); LAUNCH_PROGRESS carries the
@@ -2124,7 +2176,10 @@ def _job_events(
             cluster_events.extend(
                 (event, cluster_task_id)
                 for event in global_user_state.get_cluster_events_by_name(
-                    cluster_name, event_types, limit=limit))
+                    cluster_name,
+                    event_types,
+                    limit=limit,
+                    until=end_at_by_task.get(cluster_task_id)))
         except Exception as e:  # pylint: disable=broad-except
             # Best-effort: skip a cluster whose events cannot be read.
             logger.debug(f'Failed to read cluster events for job {job_id} '

--- a/tests/unit_tests/test_jobs_events_merge.py
+++ b/tests/unit_tests/test_jobs_events_merge.py
@@ -27,16 +27,25 @@ def _job_event(reason, status, ts):
     }
 
 
-def _task(task_name='my-task', pool=None, task_id=0, job_name='my-pipeline'):
+def _task(task_name='my-task',
+          pool=None,
+          task_id=0,
+          job_name='my-pipeline',
+          status=managed_job_state.ManagedJobStatus.RUNNING,
+          end_at=None):
     # 'task_name' is the per-task name the controller uses to build the
     # cluster name; 'job_name' is the job-level/DAG name (shared across a
     # pipeline's tasks). They are deliberately different so a test fails if
     # the wrong field is used to reconstruct the cluster name.
+    # 'status'/'end_at' default to a task that is still running, i.e. no
+    # cutoff on the cluster events that get merged in.
     return {
         'task_name': task_name,
         'job_name': job_name,
         'pool': pool,
         'task_id': task_id,
+        'status': status,
+        'end_at': end_at,
     }
 
 
@@ -85,7 +94,7 @@ def test_merge_orders_newest_first_and_truncates(monkeypatch):
     ]
     captured = {}
 
-    def _fake_cluster_events(name, event_types, limit=None):
+    def _fake_cluster_events(name, event_types, limit=None, until=None):
         captured['name'] = name
         captured['event_types'] = event_types
         captured['limit'] = limit
@@ -235,7 +244,7 @@ def test_pipeline_uses_per_task_cluster_name(monkeypatch):
 
     queried_names = []
 
-    def _fake_cluster_events(name, event_types, limit=None):
+    def _fake_cluster_events(name, event_types, limit=None, until=None):
         queried_names.append(name)
         return [{'reason': f'Provisioning {name}', 'transitioned_at': 100}]
 
@@ -277,10 +286,10 @@ def test_merged_cluster_events_carry_their_task_id(monkeypatch):
             'transitioned_at': 120
         }],
     }
-    monkeypatch.setattr(
-        global_user_state,
-        'get_cluster_events_by_name',
-        lambda name, event_types, limit=None: by_cluster.get(name, []))
+    monkeypatch.setattr(global_user_state,
+                        'get_cluster_events_by_name',
+                        lambda name, event_types, limit=None, until=None:
+                        by_cluster.get(name, []))
 
     events = core.get_job_events(job_id=1,
                                  limit=None,
@@ -346,7 +355,7 @@ def test_the_newest_row_wins_when_the_job_is_chatty(monkeypatch):
                         lambda name, job_id: f'{name}-{job_id}')
     monkeypatch.setattr(global_user_state,
                         'get_cluster_events_by_name',
-                        lambda name, event_types, limit=None: [{
+                        lambda name, event_types, limit=None, until=None: [{
                             'reason': 'Launching (pending: Resources)',
                             'transitioned_at': 500
                         }])
@@ -378,7 +387,7 @@ def test_the_window_is_exactly_the_most_recent_rows(monkeypatch):
                         lambda job_id: [_task()])
     monkeypatch.setattr(global_user_state,
                         'get_cluster_events_by_name',
-                        lambda name, event_types, limit=None: [{
+                        lambda name, event_types, limit=None, until=None: [{
                             'reason': f'Launching (step {i})',
                             'transitioned_at': 100 + i
                         } for i in range(4)])
@@ -404,7 +413,7 @@ def test_limit_one_returns_the_newest_event_of_either_source(monkeypatch):
                         lambda name, job_id: f'{name}-{job_id}')
     monkeypatch.setattr(global_user_state,
                         'get_cluster_events_by_name',
-                        lambda name, event_types, limit=None: [{
+                        lambda name, event_types, limit=None, until=None: [{
                             'reason': 'Launching (pending: Resources)',
                             'transitioned_at': 500
                         }])
@@ -470,7 +479,7 @@ def test_limit_one_prefers_the_newest_even_when_it_is_the_job_s_own(
                         lambda job_id: [_task()])
     monkeypatch.setattr(global_user_state,
                         'get_cluster_events_by_name',
-                        lambda name, event_types, limit=None: [{
+                        lambda name, event_types, limit=None, until=None: [{
                             'reason': 'Launching (pending: Resources)',
                             'transitioned_at': 100
                         }])
@@ -506,3 +515,280 @@ def test_a_runner_without_events_falls_back_to_the_default(monkeypatch):
     monkeypatch.setattr(managed_job_runner, '_current', _OldRunner())
     assert core.get_job_events(job_id=1,
                                include_cluster_events=False) == job_events
+
+
+def _cluster_events_reader(events):
+    """A stand-in for get_cluster_events_by_name that honors `until`.
+
+    The real one does the cutoff in SQL, before the limit; this mirrors that
+    so a test can tell the difference between "filtered in the query" and
+    "filtered after the window was already spent".
+    """
+
+    def _read(name, event_types, limit=None, until=None):
+        del name, event_types  # Unused.
+        rows = [
+            event for event in events
+            if until is None or event['transitioned_at'] <= until
+        ]
+        rows.sort(key=lambda event: event['transitioned_at'], reverse=True)
+        return rows if limit is None else rows[:limit]
+
+    return _read
+
+
+def _per_cluster_events_reader(events_by_cluster):
+    """Like _cluster_events_reader, but each cluster has its own events.
+
+    The cutoff is per task, and a pipeline's tasks each have their own
+    cluster, so a test can only tell the cutoffs apart if the clusters return
+    different rows.
+    """
+
+    def _read(name, event_types, limit=None, until=None):
+        del event_types  # Unused.
+        rows = [
+            event for event in events_by_cluster.get(name, [])
+            if until is None or event['transitioned_at'] <= until
+        ]
+        rows.sort(key=lambda event: event['transitioned_at'], reverse=True)
+        return rows if limit is None else rows[:limit]
+
+    return _read
+
+
+def _cluster(task_name):
+    """The cluster name the controller gives task `task_name` of job 1."""
+    return managed_job_utils.generate_managed_job_cluster_name(task_name, 1)
+
+
+def _merge_pipeline(monkeypatch, tasks, events_by_cluster, task_id=None):
+    """Merge a pipeline's cluster events; returns the merged reasons."""
+    job_events = [
+        _job_event('Job is starting',
+                   managed_job_state.ManagedJobStatus.STARTING, 100)
+    ]
+    monkeypatch.setattr(managed_job_state, 'get_job_events',
+                        lambda **kwargs: list(job_events))
+    monkeypatch.setattr(managed_job_state, 'get_managed_job_tasks',
+                        lambda job_id: list(tasks))
+    monkeypatch.setattr(global_user_state, 'get_cluster_events_by_name',
+                        _per_cluster_events_reader(events_by_cluster))
+    events = core.get_job_events(job_id=1,
+                                 task_id=task_id,
+                                 limit=None,
+                                 include_cluster_events=True)
+    return [event['reason'] for event in events]
+
+
+def _finished_job(monkeypatch,
+                  cluster_events,
+                  end_at,
+                  job_events=None,
+                  tasks=None,
+                  limit=None):
+    """Set up a job whose only task finished at `end_at`, and merge."""
+    job_events = job_events or [
+        _job_event('Job finished', managed_job_state.ManagedJobStatus.SUCCEEDED,
+                   end_at)
+    ]
+    monkeypatch.setattr(managed_job_state, 'get_job_events',
+                        lambda **kwargs: list(job_events))
+    monkeypatch.setattr(
+        managed_job_state, 'get_managed_job_tasks', lambda job_id: tasks or [
+            _task(status=managed_job_state.ManagedJobStatus.SUCCEEDED,
+                  end_at=end_at)
+        ])
+    monkeypatch.setattr(global_user_state, 'get_cluster_events_by_name',
+                        _cluster_events_reader(cluster_events))
+    return core.get_job_events(job_id=1,
+                               limit=limit,
+                               include_cluster_events=True)
+
+
+def test_cluster_events_after_the_job_ended_are_excluded(monkeypatch):
+    """A cluster event written after the job reached a terminal status did not
+    happen to the job -- it is the cluster being cleaned up. Merging it would
+    show a fabricated 'starting' row after the job ended.
+    """
+    result = _finished_job(monkeypatch,
+                           cluster_events=[{
+                               'reason': 'Terminating leftover resources',
+                               'transitioned_at': 400
+                           }],
+                           end_at=300)
+    assert [event['reason'] for event in result] == ['Job finished']
+
+
+def test_cluster_events_before_the_job_ended_are_included(monkeypatch):
+    """The cutoff must not throw away the provisioning milestones, which are
+    the reason the merge exists."""
+    result = _finished_job(monkeypatch,
+                           cluster_events=[{
+                               'reason': 'Launching (Pulling image)',
+                               'transitioned_at': 200
+                           }, {
+                               'reason': 'Terminating leftover resources',
+                               'transitioned_at': 400
+                           }],
+                           end_at=300)
+    assert [event['reason'] for event in result] == [
+        'Job finished',
+        'Launching (Pulling image)',
+    ]
+
+
+def test_an_event_exactly_at_the_end_time_is_kept(monkeypatch):
+    """The cutoff is inclusive: the last thing that happened to a cluster
+    often shares the second the job ended in."""
+    result = _finished_job(monkeypatch,
+                           cluster_events=[{
+                               'reason': 'Launching (Pulling image)',
+                               'transitioned_at': 300
+                           }],
+                           end_at=300)
+    assert 'Launching (Pulling image)' in [event['reason'] for event in result]
+
+
+def test_a_running_job_keeps_every_cluster_event(monkeypatch):
+    """A job that has not finished has no cutoff: the newest cluster event is
+    exactly what a user asks the timeline about."""
+    job_events = [
+        _job_event('Job is starting',
+                   managed_job_state.ManagedJobStatus.STARTING, 100)
+    ]
+    monkeypatch.setattr(managed_job_state, 'get_job_events',
+                        lambda **kwargs: list(job_events))
+    monkeypatch.setattr(managed_job_state, 'get_managed_job_tasks',
+                        lambda job_id: [_task()])
+    captured = {}
+
+    def _read(name, event_types, limit=None, until=None):
+        del name, event_types, limit  # Unused.
+        captured['until'] = until
+        return [{
+            'reason': 'Launching (pending: Resources)',
+            'transitioned_at': 900
+        }]
+
+    monkeypatch.setattr(global_user_state, 'get_cluster_events_by_name', _read)
+    result = core.get_job_events(job_id=1, include_cluster_events=True)
+    assert captured['until'] is None
+    assert [event['reason'] for event in result] == [
+        'Launching (pending: Resources)',
+        'Job is starting',
+    ]
+
+
+def test_a_finished_task_of_a_running_pipeline_is_cut_off(monkeypatch):
+    """Task 0's cluster is torn down when task 0 ends, even though task 1 is
+    still running, so task 0's post-completion rows must still be left out --
+    while task 1, which has not finished, keeps everything."""
+    reasons = _merge_pipeline(
+        monkeypatch,
+        tasks=[
+            _task(task_name='pipe-0',
+                  task_id=0,
+                  status=managed_job_state.ManagedJobStatus.SUCCEEDED,
+                  end_at=300),
+            _task(task_name='pipe-1', task_id=1),
+        ],
+        events_by_cluster={
+            _cluster('pipe-0'): [{
+                'reason': 'Terminating leftover resources',
+                'transitioned_at': 900
+            }],
+            _cluster('pipe-1'): [{
+                'reason': 'Launching (pending: Resources)',
+                'transitioned_at': 900
+            }],
+        })
+    assert 'Terminating leftover resources' not in reasons
+    assert 'Launching (pending: Resources)' in reasons
+
+
+def test_each_task_is_cut_off_at_its_own_end_time(monkeypatch):
+    """With every task finished, an earlier task's end must not cut the later
+    task's events off, and the later task's end must not keep the earlier
+    task's post-completion rows in."""
+    reasons = _merge_pipeline(
+        monkeypatch,
+        tasks=[
+            _task(task_name='pipe-0',
+                  task_id=0,
+                  status=managed_job_state.ManagedJobStatus.SUCCEEDED,
+                  end_at=300),
+            _task(task_name='pipe-1',
+                  task_id=1,
+                  status=managed_job_state.ManagedJobStatus.CANCELLED,
+                  end_at=500),
+        ],
+        events_by_cluster={
+            _cluster('pipe-0'): [{
+                'reason': 'Task 0 launching',
+                'transitioned_at': 200
+            }, {
+                'reason': 'Task 0 cleanup',
+                'transitioned_at': 400
+            }],
+            _cluster('pipe-1'): [{
+                'reason': 'Task 1 launching',
+                'transitioned_at': 450
+            }, {
+                'reason': 'Task 1 cleanup',
+                'transitioned_at': 600
+            }],
+        })
+    assert 'Task 0 launching' in reasons
+    assert 'Task 1 launching' in reasons
+    assert 'Task 0 cleanup' not in reasons
+    assert 'Task 1 cleanup' not in reasons
+
+
+def test_a_task_scoped_request_uses_that_task_s_cutoff(monkeypatch):
+    """Asking for one task of a still-running pipeline must still cut that
+    task's cluster off at the task's own end time."""
+    reasons = _merge_pipeline(
+        monkeypatch,
+        tasks=[
+            _task(task_name='pipe-0',
+                  task_id=0,
+                  status=managed_job_state.ManagedJobStatus.SUCCEEDED,
+                  end_at=300),
+            _task(task_name='pipe-1', task_id=1),
+        ],
+        events_by_cluster={
+            _cluster('pipe-0'): [{
+                'reason': 'Task 0 launching',
+                'transitioned_at': 200
+            }, {
+                'reason': 'Terminating leftover resources',
+                'transitioned_at': 900
+            }],
+            _cluster('pipe-1'): [{
+                'reason': 'Launching (pending: Resources)',
+                'transitioned_at': 900
+            }],
+        },
+        task_id=0)
+    assert 'Task 0 launching' in reasons
+    assert 'Terminating leftover resources' not in reasons
+    # Only task 0's cluster is in scope.
+    assert 'Launching (pending: Resources)' not in reasons
+
+
+def test_a_terminal_task_without_an_end_time_keeps_everything(monkeypatch):
+    """A missing end_at (an old row) must never shorten the window: without a
+    time to cut at, the old behavior is the safe one."""
+    result = _finished_job(
+        monkeypatch,
+        cluster_events=[{
+            'reason': 'Launching (pending: Resources)',
+            'transitioned_at': 900
+        }],
+        end_at=300,
+        tasks=[
+            _task(status=managed_job_state.ManagedJobStatus.SUCCEEDED,
+                  end_at=None)
+        ])
+    assert 'Launching (pending: Resources)' in [e['reason'] for e in result]

--- a/tests/unit_tests/test_sky/test_global_user_state_cluster_events.py
+++ b/tests/unit_tests/test_sky/test_global_user_state_cluster_events.py
@@ -455,3 +455,41 @@ def test_latest_cluster_events_chunks_the_name_list(tmp_path, monkeypatch):
     assert events == {
         f'chunk-{i}': (f'Launching (pending: r{i})', 1000 + i) for i in range(5)
     }
+
+
+def test_get_cluster_events_by_name_until_cuts_before_the_limit(
+        tmp_path, monkeypatch):
+    """`until` drops events newer than the cutoff, and does so in the query:
+    a caller asking for the most recent N events within the window gets N of
+    them, not N minus however many newer rows exist."""
+    _fresh_db(tmp_path, monkeypatch)
+    _add_cluster('c-until')
+
+    for reason, ts in [('e100', 100), ('e200', 200), ('e300', 300),
+                       ('e400', 400), ('e500', 500)]:
+        global_user_state.add_cluster_event(
+            'c-until',
+            new_status=None,
+            reason=reason,
+            event_type=global_user_state.ClusterEventType.STATUS_CHANGE,
+            transitioned_at=ts)
+
+    types = [global_user_state.ClusterEventType.STATUS_CHANGE]
+    # No cutoff: newest first, as before.
+    assert [
+        event['reason']
+        for event in global_user_state.get_cluster_events_by_name(
+            'c-until', types)
+    ] == ['e500', 'e400', 'e300', 'e200', 'e100']
+    # With a cutoff, the two newer rows are gone; the boundary is inclusive.
+    assert [
+        event['reason']
+        for event in global_user_state.get_cluster_events_by_name(
+            'c-until', types, until=300)
+    ] == ['e300', 'e200', 'e100']
+    # The limit is spent on rows inside the window, not on the excluded ones.
+    assert [
+        event['reason']
+        for event in global_user_state.get_cluster_events_by_name(
+            'c-until', types, limit=2, until=300)
+    ] == ['e300', 'e200']


### PR DESCRIPTION
## What

When `include_cluster_events` is set, `sky jobs events` / the job timeline merges the task cluster's `STATUS_CHANGE` and `LAUNCH_PROGRESS` events into the job's own events as synthetic `STARTING` rows. This drops the cluster events that happened after the task that owns the cluster finished.

The cutoff is per task, not per job: each task of a pipeline launches its own cluster, and that cluster is torn down when the task ends, so task 0 of a pipeline whose task 1 is still running already has post-completion cluster events to leave out. Each `(cluster, task)` pair is cut off at that task's `end_at`. Two cases keep the old behavior:

* a task that has not finished has no cutoff, so a running or recovering task's timeline is unchanged;
* a terminal task with no `end_at` (an old row) also gets no cutoff, so a missing timestamp never drops events.

The cutoff is passed down to `global_user_state.get_cluster_events_by_name` as a new optional `until` argument, so the database applies it before the limit. Filtering after the query would let post-completion rows eat the window: a caller asking for the 10 most recent events would get 10 minus however many were then thrown away.

## Why

A cluster can record events after the task that owned it reached a terminal status, for example while its leftover resources are being cleaned up. Those events are not the job starting, but the merge labels every cluster event `STARTING`, so the timeline ends with a fabricated "starting" row dated after the task's own terminal row. It reads as if the job started again after it finished.

## How tested

From the worktree root, with only the touched test files:

```
PYTHONPATH=$PWD python -m pytest tests/unit_tests/test_jobs_events_merge.py \
    tests/unit_tests/test_sky/test_global_user_state_cluster_events.py -n 0 -q
```

40 passed, 0 failed. New cases: an event after the end is excluded, an event before the end is included, one exactly at the end is kept, a running task keeps everything, a finished task of a still-running pipeline is cut off while the running task's cluster is not, each task is cut off at its own end time (an earlier task's end does not truncate a later task, and a later task's end does not keep an earlier task's cleanup rows), a task-scoped (`task_id=`) request honours that task's own cutoff, and a terminal task without an `end_at` keeps everything. The `until` argument itself is covered against real SQLite in `test_global_user_state_cluster_events.py`, including that the cutoff is applied before the limit. The three per-task cases were confirmed to fail against a job-wide cutoff.

`bash format.sh` run on the worktree (yapf/isort/pylint/mypy clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

-Claude
