### PR TITLE
[Core] Allow recording cluster events by hash after teardown

### DIFF
--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -1125,7 +1125,8 @@ def add_cluster_event(cluster_name: str,
                       nop_if_duplicate: bool = False,
                       duplicate_regex: Optional[str] = None,
                       expose_duplicate_error: bool = False,
-                      transitioned_at: Optional[int] = None) -> None:
+                      transitioned_at: Optional[int] = None,
+                      cluster_hash: Optional[str] = None) -> None:
     """Add a cluster event.
 
     Args:
@@ -1139,13 +1140,33 @@ def add_cluster_event(cluster_name: str,
         expose_duplicate_error: If True, raise an error if the event is a
             duplicate. Only used if nop_if_duplicate is True.
         transitioned_at: If provided, use this timestamp for the event.
+        cluster_hash: If provided, the event is recorded against this hash and
+            the `clusters` table is not consulted at all: the name is not
+            resolved to a hash, and the event's starting_status is left empty,
+            since whichever row owns the name now may belong to a different
+            cluster. This lets a caller record an event for a cluster whose row
+            is already gone (e.g. after teardown); without it such an event is
+            silently dropped.
+
+    Note:
+        The event is still stored with the given cluster_name in the `name`
+        column, and the by-name readers (`get_cluster_events_by_name` and
+        `get_latest_cluster_events`) filter on that column, so they will return
+        an explicit-hash event for a later cluster that reuses the name. A
+        caller recording a post-teardown event for a name that may be reused
+        should pick an event type those readers do not select (they select
+        STATUS_CHANGE and LAUNCH_PROGRESS).
     """
     engine = _db_manager.get_engine()
-    cluster_hash = _get_hash_for_existing_cluster(cluster_name)
+    # An explicit hash identifies a cluster that may no longer own its name, so
+    # the clusters table must not be consulted for it at all.
+    explicit_cluster_hash = cluster_hash is not None
     if cluster_hash is None:
-        logger.debug(f'Hash for cluster {cluster_name} not found. '
-                     'Skipping event.')
-        return
+        cluster_hash = _get_hash_for_existing_cluster(cluster_name)
+        if cluster_hash is None:
+            logger.debug(f'Hash for cluster {cluster_name} not found. '
+                         'Skipping event.')
+            return
     if transitioned_at is None:
         transitioned_at = int(time.time())
     with orm.Session(engine) as session:
@@ -1158,9 +1179,13 @@ def add_cluster_event(cluster_name: str,
             session.rollback()
             raise ValueError('Unsupported database dialect')
 
-        cluster_row = session.query(cluster_table).filter_by(name=cluster_name)
-        last_status = cluster_row.first(
-        ).status if cluster_row and cluster_row.first() is not None else None
+        if explicit_cluster_hash:
+            last_status = None
+        else:
+            cluster_row = session.query(cluster_table).filter_by(
+                name=cluster_name)
+            last_status = cluster_row.first().status if (
+                cluster_row and cluster_row.first() is not None) else None
         if nop_if_duplicate:
             last_event = get_last_cluster_event(cluster_hash,
                                                 event_type=event_type)

--- a/tests/unit_tests/test_sky/test_global_user_state_cluster_events.py
+++ b/tests/unit_tests/test_sky/test_global_user_state_cluster_events.py
@@ -1,6 +1,8 @@
 """Unit tests for cluster_event accessors in global_user_state."""
 import time
 
+from sqlalchemy import orm
+
 from sky import global_user_state
 from sky.skylet import constants
 from sky.utils import status_lib
@@ -455,3 +457,154 @@ def test_latest_cluster_events_chunks_the_name_list(tmp_path, monkeypatch):
     assert events == {
         f'chunk-{i}': (f'Launching (pending: r{i})', 1000 + i) for i in range(5)
     }
+
+
+def _starting_status(cluster_hash: str, reason: str):
+    """Read back the starting_status column of a single event row."""
+    events = global_user_state.cluster_event_table
+    engine = global_user_state._db_manager.get_engine()
+    with orm.Session(engine) as session:
+        row = session.query(events).filter(
+            events.c.cluster_hash == cluster_hash,
+            events.c.reason == reason,
+        ).one()
+    return row.starting_status
+
+
+def test_add_cluster_event_with_explicit_hash_for_removed_cluster(
+        tmp_path, monkeypatch):
+    """A caller that already knows the hash can record an event after the
+    clusters row is gone (e.g. post-teardown cleanup)."""
+    _fresh_db(tmp_path, monkeypatch)
+    cluster_hash = _add_cluster('removed-1')
+    global_user_state.remove_cluster('removed-1', terminate=True)
+    assert global_user_state._get_hash_for_existing_cluster('removed-1') is None
+
+    global_user_state.add_cluster_event(
+        'removed-1',
+        new_status=None,
+        reason='cleaned up after teardown',
+        event_type=global_user_state.ClusterEventType.STATUS_CHANGE,
+        transitioned_at=10,
+        cluster_hash=cluster_hash,
+    )
+
+    assert global_user_state.get_cluster_events(
+        cluster_name=None,
+        cluster_hash=cluster_hash,
+        event_type=global_user_state.ClusterEventType.STATUS_CHANGE,
+    ) == ['cleaned up after teardown']
+    # No clusters row left, so there is no status to start from.
+    assert _starting_status(cluster_hash, 'cleaned up after teardown') is None
+
+
+def test_add_cluster_event_without_hash_still_skips_removed_cluster(
+        tmp_path, monkeypatch):
+    """Without the explicit hash, the old silent-skip behaviour is kept."""
+    _fresh_db(tmp_path, monkeypatch)
+    cluster_hash = _add_cluster('removed-2')
+    global_user_state.remove_cluster('removed-2', terminate=True)
+
+    global_user_state.add_cluster_event(
+        'removed-2',
+        new_status=None,
+        reason='dropped on the floor',
+        event_type=global_user_state.ClusterEventType.STATUS_CHANGE,
+        transitioned_at=10,
+    )
+
+    assert not global_user_state.get_cluster_events(
+        cluster_name=None,
+        cluster_hash=cluster_hash,
+        event_type=global_user_state.ClusterEventType.STATUS_CHANGE,
+    )
+
+
+def test_add_cluster_event_explicit_hash_ignores_relaunched_cluster(
+        tmp_path, monkeypatch):
+    """An explicit hash must not pick up whichever row owns the name now.
+
+    A teardown-time event for the old cluster is recorded after a new cluster
+    has already been launched under the same name. It must be keyed by the
+    explicit (old) hash, and it must not take the live cluster's status.
+    """
+    _fresh_db(tmp_path, monkeypatch)
+    old_hash = _add_cluster('reused')
+    global_user_state.remove_cluster('reused', terminate=True)
+    # Relaunch under the same name: a new row, a new hash, and it is UP.
+    global_user_state.add_or_update_cluster(
+        cluster_name='reused',
+        cluster_handle=_MinimalHandle(),
+        requested_resources=set(),
+        ready=True,
+    )
+    new_hash = global_user_state._get_hash_for_existing_cluster('reused')
+    assert new_hash is not None and new_hash != old_hash
+
+    status_change = global_user_state.ClusterEventType.STATUS_CHANGE
+    global_user_state.add_cluster_event(
+        'reused',
+        new_status=None,
+        reason='old cluster teardown leftovers',
+        event_type=status_change,
+        transitioned_at=10,
+        cluster_hash=old_hash,
+    )
+
+    # Keyed by the explicit hash, and not attributed to the live cluster.
+    assert global_user_state.get_cluster_events(
+        cluster_name=None,
+        cluster_hash=old_hash,
+        event_type=status_change,
+    ) == ['old cluster teardown leftovers']
+    assert 'old cluster teardown leftovers' not in (
+        global_user_state.get_cluster_events(
+            cluster_name=None,
+            cluster_hash=new_hash,
+            event_type=status_change,
+        ))
+    # The live cluster's status must not leak into the old cluster's event.
+    assert _starting_status(old_hash, 'old cluster teardown leftovers') is None
+
+
+def test_add_cluster_event_explicit_hash_nop_if_duplicate(
+        tmp_path, monkeypatch):
+    """nop_if_duplicate (and duplicate_regex) work off the explicit hash."""
+    _fresh_db(tmp_path, monkeypatch)
+    cluster_hash = _add_cluster('removed-3')
+    global_user_state.remove_cluster('removed-3', terminate=True)
+
+    status_change = global_user_state.ClusterEventType.STATUS_CHANGE
+    for transitioned_at in (10, 20):
+        # Different timestamps, so the primary key does not dedupe for us.
+        global_user_state.add_cluster_event(
+            'removed-3',
+            new_status=None,
+            reason='same reason',
+            event_type=status_change,
+            nop_if_duplicate=True,
+            transitioned_at=transitioned_at,
+            cluster_hash=cluster_hash,
+        )
+    assert global_user_state.get_cluster_events(
+        cluster_name=None,
+        cluster_hash=cluster_hash,
+        event_type=status_change,
+    ) == ['same reason']
+
+    # duplicate_regex matches the last event, so this one is a nop too.
+    global_user_state.add_cluster_event(
+        'removed-3',
+        new_status=None,
+        reason='a different reason',
+        event_type=status_change,
+        nop_if_duplicate=True,
+        duplicate_regex='same.*',
+        transitioned_at=30,
+        cluster_hash=cluster_hash,
+    )
+    assert global_user_state.get_cluster_events(
+        cluster_name=None,
+        cluster_hash=cluster_hash,
+        event_type=status_change,
+    ) == ['same reason']


### PR DESCRIPTION
`global_user_state.add_cluster_event` resolves the cluster hash from the `clusters` row, and silently
returns when that row is gone. Code that runs after a cluster is torn down (post-teardown cleanup and
reconciliation) usually already knows the hash it cares about, e.g. from cluster history, but has no way
to record what happened: the event is dropped with only a debug log.

This adds an optional `cluster_hash` keyword. When it is given, the `clusters` table is not consulted at
all and the event is recorded against that hash.

Details:
- Existing callers are unchanged: without the new argument the hash is still resolved from the row, and a
  missing row still skips the event.
- With an explicit hash, the event's `starting_status` is left `NULL`. The cluster the hash refers to may
  no longer own its name -- a relaunch can already have taken the name over -- so reading the status off
  whichever `clusters` row holds the name now would attribute an unrelated cluster's status to the event.
- The event row still stores the name it was given, and the by-name readers
  (`get_cluster_events_by_name`, `get_latest_cluster_events`) filter on the name column, so they will
  return such an event for a later cluster that reuses the name. Those readers are unchanged; the
  docstring says so and points callers recording post-teardown events for a reusable name at an event
  type the readers do not select (they select `STATUS_CHANGE` and `LAUNCH_PROGRESS`).
- `nop_if_duplicate`, `duplicate_regex`, `expose_duplicate_error`, `transitioned_at` and the request id
  behave exactly as before.

## Tested

`pytest tests/unit_tests/test_sky/test_global_user_state_cluster_events.py -n 0` -> 17 passed, including
four new tests: event for a removed cluster with an explicit hash is written and readable via
`get_cluster_events(cluster_hash=...)`; without the hash the removed cluster is still skipped; an
explicit-hash event written while a relaunched same-name cluster is live is keyed by the explicit hash
and does not take the live cluster's status; `nop_if_duplicate` and `duplicate_regex` work off the
explicit hash.

`bash format.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

-Claude
