### PR TITLE
[Core] Add index on cluster_history.name

### DIFF
--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -241,6 +241,13 @@ cluster_history_table = sqlalchemy.Table(
     # point the clusters table row is gone and the join can no longer supply
     # the flag.
     sqlalchemy.Column('is_managed', sqlalchemy.Integer, server_default='0'),
+    # The table is keyed on cluster_hash, but readers that have to survive a
+    # cluster's teardown look history up by `name` instead -- see
+    # get_clusters_from_history(cluster_names=...) and
+    # get_cluster_history_provision_log_path. cluster_history is never
+    # pruned, so without this those lookups scan every row this server has
+    # ever written.
+    sqlalchemy.Index('ix_cluster_history_name', 'name'),
 )
 
 

--- a/sky/schemas/db/global_user_state/024_add_cluster_history_name_index.py
+++ b/sky/schemas/db/global_user_state/024_add_cluster_history_name_index.py
@@ -1,0 +1,58 @@
+"""Add an index for the cluster_history lookups keyed on the name column.
+
+cluster_history is keyed on cluster_hash, but the readers that have to
+survive a cluster's teardown filter on the ``name`` column instead, because
+the name -> hash mapping lives in the clusters table and is removed when the
+cluster goes away: get_clusters_from_history(cluster_names=...) and
+get_cluster_history_provision_log_path. The table is never pruned, so both
+were full-table scans over every cluster this server has ever launched.
+
+Revision ID: 024
+Revises: 023
+Create Date: 2026-09-12
+
+"""
+# pylint: disable=invalid-name
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '024'
+down_revision: Union[str, Sequence[str], None] = '023'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_INDEX_NAME = 'ix_cluster_history_name'
+
+
+def _existing_indexes(table_name: str) -> set:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return {ix['name'] for ix in inspector.get_indexes(table_name)}
+
+
+def upgrade():
+    """Create the index if it doesn't already exist.
+
+    Idempotent, and inside an autocommit block so PostgreSQL accepts the
+    implicit transactional DDL and SQLite runs the statement directly --
+    the same pattern as 023 and the spot_jobs index migrations.
+
+    The index is built non-concurrently, so it holds a write lock on
+    cluster_history for as long as the build takes, during the server-startup
+    migration. That was judged acceptable: it is the same shape as 023, which
+    indexes the larger cluster_events table, and a plain btree build over a
+    single text column takes a few seconds even at 10^5 rows -- well inside
+    the startup window, while nothing is writing to the table yet.
+    """
+    if _INDEX_NAME in _existing_indexes('cluster_history'):
+        return
+    with op.get_context().autocommit_block():
+        op.create_index(_INDEX_NAME, 'cluster_history', ['name'])
+
+
+def downgrade():
+    """No-op for backward compatibility."""
+    pass

--- a/sky/utils/db/migration_utils.py
+++ b/sky/utils/db/migration_utils.py
@@ -30,7 +30,7 @@ DB_INIT_LOCK_TIMEOUT_SECONDS = 10
 _alembic_thread_lock = threading.Lock()
 
 GLOBAL_USER_STATE_DB_NAME = 'state_db'
-GLOBAL_USER_STATE_VERSION = '023'  # index cluster_events by name
+GLOBAL_USER_STATE_VERSION = '024'  # index cluster_history by name
 GLOBAL_USER_STATE_LOCK_PATH = f'~/.sky/locks/.{GLOBAL_USER_STATE_DB_NAME}.lock'
 
 SPOT_JOBS_DB_NAME = 'spot_jobs_db'

--- a/tests/unit_tests/test_sky/test_global_user_state_cluster_history_index.py
+++ b/tests/unit_tests/test_sky/test_global_user_state_cluster_history_index.py
@@ -1,0 +1,104 @@
+"""Unit tests for the cluster_history indexes in global_user_state."""
+from typing import Dict, List
+
+import sqlalchemy
+
+from sky import global_user_state
+from sky.skylet import constants
+from sky.utils.db import db_utils
+
+
+def _fresh_db(tmp_path, monkeypatch):
+    """Point the global state DB at a tmp sqlite file (mirrors the helper in
+    test_global_user_state_cluster_events.py).
+
+    The database is built by running the alembic migrations from scratch, so
+    these tests exercise the migrations rather than the table metadata.
+    """
+    monkeypatch.setenv(constants.SKY_RUNTIME_DIR_ENV_VAR_KEY, str(tmp_path))
+    monkeypatch.setattr(
+        global_user_state,
+        '_db_manager',
+        db_utils.DatabaseManager(
+            'state',
+            global_user_state.create_table,
+            post_init_fn=lambda _: global_user_state._sqlite_supports_returning(
+            ),
+        ),
+    )
+
+
+def _indexes(table_name: str) -> Dict[str, List[str]]:
+    """Returns {index name: indexed columns} for a table of the state DB.
+
+    Reflected through a connection opened after the migrations ran: SQLite
+    answers PRAGMA index_list from the schema its connection loaded when it
+    was opened, and the state engine's pooled connection predates the
+    migration, so reflecting through that connection reports no indexes at
+    all.
+    """
+    url = global_user_state._db_manager.get_engine().url
+    engine = sqlalchemy.create_engine(url)
+    try:
+        indexes = sqlalchemy.inspect(engine).get_indexes(table_name)
+    finally:
+        engine.dispose()
+    return {index['name']: list(index['column_names']) for index in indexes}
+
+
+def test_fresh_db_indexes_cluster_history_name(tmp_path, monkeypatch):
+    """cluster_history is looked up by name and never pruned, so `name` must
+    be indexed on a freshly migrated database."""
+    _fresh_db(tmp_path, monkeypatch)
+
+    indexes = _indexes('cluster_history')
+    assert 'ix_cluster_history_name' in indexes, sorted(indexes)
+    assert indexes['ix_cluster_history_name'] == ['name']
+
+
+def _rewind_to_023(engine):
+    """Make the state DB look like one migrated before the index existed."""
+    with engine.begin() as connection:
+        connection.execute(
+            sqlalchemy.text(
+                'UPDATE alembic_version_state_db SET version_num = :version'),
+            {'version': '023'})
+
+
+def test_migration_adds_the_index_to_an_existing_db(tmp_path, monkeypatch):
+    """A database created before 024 gets the index from the migration.
+
+    A fresh database picks the index up from the table metadata (migration
+    001 creates every table from it), so the migration itself is only
+    reachable by taking the index away again.
+    """
+    _fresh_db(tmp_path, monkeypatch)
+    engine = global_user_state._db_manager.get_engine()
+    with engine.begin() as connection:
+        connection.execute(
+            sqlalchemy.text('DROP INDEX ix_cluster_history_name'))
+    _rewind_to_023(engine)
+    assert 'ix_cluster_history_name' not in _indexes('cluster_history')
+
+    global_user_state.create_table(engine)
+
+    indexes = _indexes('cluster_history')
+    assert indexes['ix_cluster_history_name'] == ['name'], sorted(indexes)
+
+
+def test_migration_skips_an_index_that_already_exists(tmp_path, monkeypatch):
+    """The migration must tolerate a database that already has the index.
+
+    Rewinding the alembic version makes the upgrade run a second time against
+    a database where the index is already present, which is the case the
+    guard in the migration exists for.
+    """
+    _fresh_db(tmp_path, monkeypatch)
+    engine = global_user_state._db_manager.get_engine()
+    _rewind_to_023(engine)
+
+    # Must not raise (the index already exists).
+    global_user_state.create_table(engine)
+
+    indexes = _indexes('cluster_history')
+    assert indexes['ix_cluster_history_name'] == ['name'], sorted(indexes)


### PR DESCRIPTION
## Summary

`cluster_history` is keyed on `cluster_hash`, but the readers that have to survive a cluster's teardown look rows up by `name` instead, because the name -> hash mapping lives in the `clusters` table and is deleted when the cluster goes away:

- `get_clusters_from_history(cluster_names=...)` — the by-name history lookups behind the dashboard's cluster detail view and `sky cost-report`-style queries.
- `get_cluster_history_provision_log_path` — the fallback that finds a terminated cluster's provision log.

Only `last_activity_time` and `launched_at` were indexed, so both of those scanned the table. `cluster_history` is never pruned, so that scan grows with every cluster the server has ever launched.

This adds an index on `name`, declared on the table so new databases get it, plus alembic migration `024` for existing ones. The migration is idempotent and runs inside an autocommit block, the same shape as `023` (the `cluster_events` name index) and the `spot_jobs` index migrations. `GLOBAL_USER_STATE_VERSION` is bumped to `024`.

No behaviour change beyond the index.

## Notes

- The index is built non-concurrently, so it holds a write lock on `cluster_history` for the duration of the build during the server-startup migration. The migration docstring records that this was judged acceptable and why: it is the same shape as `023`, which indexes the larger `cluster_events` table, and a plain btree build over one text column takes a few seconds even at 10^5 rows, inside the startup window while nothing is writing to the table.
- The tests run on SQLite. On PostgreSQL the migration is covered by the shape it shares verbatim with `023`, which is already in production: the same existence guard, the same `autocommit_block`, the same `op.create_index` call.
- `_existing_indexes` is a copy of the helper in `023` rather than a shared utility, matching the precedent set by the existing index migrations.

## Tested

New unit tests in `tests/unit_tests/test_sky/test_global_user_state_cluster_history_index.py`:

- a freshly migrated database has `ix_cluster_history_name` on `name`;
- a database rewound to revision `023` with the index dropped gets it back from the migration (a fresh database takes it from the table metadata, since migration `001` creates every table from it, so this is the only way to reach the migration body);
- re-running the migration when the index already exists does not raise.

```
cd <worktree> && PYTHONPATH=$PWD python -m pytest \
  tests/unit_tests/test_sky/test_global_user_state_cluster_history_index.py \
  tests/unit_tests/test_sky/test_global_user_state_cluster_events.py -n 0
# 16 passed
```

All three new tests were confirmed to fail with the index declaration and the version bump reverted.

`bash format.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

-Claude
