### PR TITLE
[Jobs] Add a `code` parameter to the sync add_job_event

### DIFF
--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -4040,6 +4040,8 @@ def add_job_event(job_id: int,
                   task_id: Optional[int],
                   new_status: ManagedJobStatus,
                   reason: str,
+                  *,
+                  code: Optional[str] = None,
                   timestamp: Optional[datetime.datetime] = None) -> None:
     """Add a job event record to the audit log.
 
@@ -4050,6 +4052,9 @@ def add_job_event(job_id: int,
         new_status: The new status being transitioned to. Can be a
             ManagedJobStatus enum.
         reason: A description of why the event occurred.
+        code: Optional error category code for failures. Keyword-only, so
+            that inserting it ahead of timestamp cannot shift a positional
+            argument of an out-of-tree caller.
         timestamp: The timestamp of the event. If None, uses current time.
     """
     if timestamp is None:
@@ -4063,6 +4068,7 @@ def add_job_event(job_id: int,
             spot_job_id=job_id,
             task_id=task_id,  # Can be None for job-level events
             new_status=status_value,
+            code=code,
             reason=reason,
             timestamp=timestamp,
         ))

--- a/tests/unit_tests/test_sky/jobs/test_jobs_state.py
+++ b/tests/unit_tests/test_sky/jobs/test_jobs_state.py
@@ -1882,3 +1882,50 @@ class TestInfraFilterCodegenCompatibility:
         with pytest.raises(RuntimeError,
                            match=jobs_utils.INFRA_FILTER_UNSUPPORTED_MARKER):
             self._run_branch(code, one_older)
+
+
+class TestAddJobEventCode:
+    """The sync add_job_event writes `code`, like the async variant."""
+
+    def test_code_is_persisted(self, _mock_managed_jobs_db_conn):
+        state.add_job_event(1,
+                            0,
+                            state.ManagedJobStatus.FAILED,
+                            'boom',
+                            code=state.USER_JOB_FAILURE_EVENT_CODE)
+        assert [(e['reason'], e['code']) for e in state.get_job_events(1)
+               ] == [('boom', state.USER_JOB_FAILURE_EVENT_CODE)]
+
+    def test_code_is_keyword_only(self, _mock_managed_jobs_db_conn):
+        """`code` is inserted ahead of `timestamp`, so it must be
+        keyword-only: an out-of-tree caller passing `timestamp` as the fifth
+        positional argument would otherwise write a datetime into `code`."""
+        with pytest.raises(TypeError):
+            state.add_job_event(1, 0, state.ManagedJobStatus.RUNNING, 'running',
+                                datetime.datetime(2026, 1, 1, 0, 0, 0))
+
+    def test_code_defaults_to_none(self, _mock_managed_jobs_db_conn):
+        state.add_job_event(1, 0, state.ManagedJobStatus.RUNNING, 'running')
+        assert [e['code'] for e in state.get_job_events(1)] == [None]
+
+    @pytest.mark.asyncio
+    async def test_matches_async_variant(self, _mock_managed_jobs_db_conn):
+        early = datetime.datetime(2026, 1, 1, 0, 0, 0)
+        late = datetime.datetime(2026, 1, 1, 0, 5, 0)
+        state.add_job_event(1,
+                            0,
+                            state.ManagedJobStatus.FAILED,
+                            'sync',
+                            code=state.USER_JOB_FAILURE_EVENT_CODE,
+                            timestamp=early)
+        await state.add_job_event_async(1,
+                                        0,
+                                        state.ManagedJobStatus.FAILED,
+                                        'async',
+                                        code=state.USER_JOB_FAILURE_EVENT_CODE,
+                                        timestamp=late)
+        codes = {e['reason']: e['code'] for e in state.get_job_events(1)}
+        assert codes == {
+            'sync': state.USER_JOB_FAILURE_EVENT_CODE,
+            'async': state.USER_JOB_FAILURE_EVENT_CODE,
+        }


### PR DESCRIPTION
`add_job_event_async` accepts a `code` (the error category stamped on failure events) and writes it to the
`job_events` row; the sync `add_job_event` does not, so a caller on a synchronous path cannot record one.
The argument is for callers that record a categorised event after a job has already completed, which the
async recovery path can do today and a synchronous one cannot.

This adds `code: Optional[str] = None` to the sync variant and writes it to the row, in the same position
as the async signature. It is **keyword-only**: `code` sits ahead of `timestamp` to match the column
order, and `add_job_event` is a module-level function in an importable module, so a caller outside this
repo passing `timestamp` as the fifth positional argument would otherwise silently bind a `datetime` to
`code`. No in-repo caller passes `timestamp` positionally (checked with an AST scan over `sky/` and
`tests/`), so nothing in the repo changes.

`recovery_source`, the other field the async variant has and the sync one does not, is intentionally left
async-only: it is written by the recovery path, which is async, and nothing synchronous records it.

## Tested

`pytest tests/unit_tests/test_sky/jobs/test_jobs_state.py -n 0` -> 133 passed, including four new tests:
a sync insert with `code` is read back by `get_job_events`, a fifth positional argument raises
`TypeError`, `code` defaults to `None`, and the sync and async variants store the same value.

`bash format.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

-Claude
