### PR TITLE
[Core] Allow passing an explicit user hash to make_cluster_name_on_cloud

### DIFF
--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -262,7 +262,8 @@ def check_workspace_name_is_valid(workspace_name: Optional[str]) -> None:
 
 def make_cluster_name_on_cloud(display_name: str,
                                max_length: Optional[int] = 15,
-                               add_user_hash: bool = True) -> str:
+                               add_user_hash: bool = True,
+                               user_hash: Optional[str] = None) -> str:
     """Generate valid cluster name on cloud that is unique to the user.
 
     This is to map the cluster name to a valid length and character set for
@@ -281,22 +282,52 @@ def make_cluster_name_on_cloud(display_name: str,
         max_length: The maximum length of the cluster name. If None, no
             truncation is performed.
         add_user_hash: Whether to append user hash to the cluster name.
+        user_hash: The user hash to append. Defaults to the current user's
+            hash. Only used when add_user_hash is True. Pass this to
+            reconstruct the name of a cluster that belongs to another user,
+            which the current process' user hash would not reproduce.
+
+    Raises:
+        ValueError: an explicit user_hash was given that is empty, or that is
+            too long to leave room for a name within max_length.
     """
+    if add_user_hash and user_hash is not None:
+        # Validate a caller-supplied hash before it is spent on the length
+        # budget below: an oversized one would make the truncation length
+        # negative and silently yield a name that no cloud accepts.
+        if not user_hash:
+            with ux_utils.print_exception_no_traceback():
+                raise ValueError(
+                    'user_hash must be a non-empty string when add_user_hash '
+                    'is set.')
+        if max_length is not None:
+            # -1 for the dash before the user hash, -1 for the dash before the
+            # display name hash, and at least one character of display name.
+            max_user_hash_length = (max_length - CLUSTER_NAME_HASH_LENGTH - 3)
+            if len(user_hash) > max_user_hash_length:
+                with ux_utils.print_exception_no_traceback():
+                    raise ValueError(
+                        f'user_hash {user_hash!r} is {len(user_hash)} '
+                        'characters, which does not fit a cluster name on '
+                        f'cloud limited to {max_length} characters: at most '
+                        f'{max_user_hash_length} characters are available for '
+                        'it.')
 
     cluster_name_on_cloud = re.sub(r'[._]', '-', display_name).lower()
     if display_name != cluster_name_on_cloud:
         logger.debug(
             f'The user specified cluster name {display_name} might be invalid '
             f'on the cloud, we convert it to {cluster_name_on_cloud}.')
-    user_hash = ''
+    user_hash_suffix = ''
     if add_user_hash:
-        user_hash = get_user_hash()
-        user_hash = f'-{user_hash}'
-    user_hash_length = len(user_hash)
+        if user_hash is None:
+            user_hash = get_user_hash()
+        user_hash_suffix = f'-{user_hash}'
+    user_hash_length = len(user_hash_suffix)
 
     if (max_length is None or
             len(cluster_name_on_cloud) <= max_length - user_hash_length):
-        return f'{cluster_name_on_cloud}{user_hash}'
+        return f'{cluster_name_on_cloud}{user_hash_suffix}'
     # -1 is for the dash between cluster name and cluster name hash.
     truncate_cluster_name_length = (max_length - CLUSTER_NAME_HASH_LENGTH - 1 -
                                     user_hash_length)
@@ -310,7 +341,8 @@ def make_cluster_name_on_cloud(display_name: str,
     # Use base36 to reduce the length of the hash.
     display_name_hash = base36_encode(display_name_hash)
     return (f'{truncate_cluster_name}'
-            f'-{display_name_hash[:CLUSTER_NAME_HASH_LENGTH]}{user_hash}')
+            f'-{display_name_hash[:CLUSTER_NAME_HASH_LENGTH]}'
+            f'{user_hash_suffix}')
 
 
 def cluster_name_in_hint(cluster_name: str, cluster_name_on_cloud: str) -> str:

--- a/tests/unit_tests/test_sky/utils/test_common_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_common_utils.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextvars
 import os
+import re
 import tempfile
 from unittest import mock
 
@@ -8,6 +9,7 @@ import pytest
 
 from sky import exceptions
 from sky import models
+from sky.skylet import constants
 from sky.utils import common_utils
 from sky.utils import context
 
@@ -148,6 +150,106 @@ class TestMakeClusterNameOnCloud:
             "Cuda_11.8")
         assert "cuda-11-8-ab12cd34" == common_utils.make_cluster_name_on_cloud(
             "Cuda_11.8", max_length=20)
+
+    # (display_name, max_length, user_hash). The 'cluster-xxx...' names are
+    # 33 and 34 characters: with an 8-character user hash the first still
+    # fits in max_length=42 and the second is truncated with the 2-character
+    # infix.
+    @pytest.mark.parametrize(
+        'display_name,max_length,user_hash',
+        [
+            ('lora', 15, 'ab12cd34'),
+            ('lora', 42, 'sa-0123456789abcdef'),
+            ('Cuda_11.8', 15, 'ab12cd34'),
+            ('Cuda_11.8', 42, 'sa-0123456789abcdef'),
+            ('My.Cluster_Name', 42, 'ab12cd34'),
+            ('My.Cluster_Name', 42, 'sa-0123456789abcdef'),
+            ('cluster-' + 'x' * 25, 42, 'ab12cd34'),
+            ('cluster-' + 'x' * 26, 42, 'ab12cd34'),
+            ('cluster-' + 'x' * 25, 42, 'sa-0123456789abcdef'),
+            ('cluster-' + 'x' * 26, 42, 'sa-0123456789abcdef'),
+        ],
+    )
+    def test_explicit_user_hash_matches_env(self, display_name, max_length,
+                                            user_hash, monkeypatch):
+        """An explicit user hash gives what the same hash in the environment
+        would have given."""
+        monkeypatch.setenv(constants.USER_ID_ENV_VAR, user_hash)
+        from_env = common_utils.make_cluster_name_on_cloud(
+            display_name, max_length=max_length)
+
+        # A different identity in the environment must not be used.
+        monkeypatch.setenv(constants.USER_ID_ENV_VAR, 'ff99ff99')
+        explicit = common_utils.make_cluster_name_on_cloud(
+            display_name, max_length=max_length, user_hash=user_hash)
+
+        assert explicit == from_env
+        assert explicit.endswith(f'-{user_hash}')
+        assert len(explicit) <= max_length
+
+    def test_omitted_user_hash_still_reads_the_environment(self, monkeypatch):
+        """Existing callers are unaffected."""
+        monkeypatch.setenv(constants.USER_ID_ENV_VAR, MOCKED_USER_HASH)
+        assert common_utils.make_cluster_name_on_cloud(
+            'lora') == f'lora-{MOCKED_USER_HASH}'
+        assert common_utils.make_cluster_name_on_cloud(
+            'lora', user_hash=None) == f'lora-{MOCKED_USER_HASH}'
+
+    def test_user_hash_ignored_when_not_added(self, monkeypatch):
+        monkeypatch.setenv(constants.USER_ID_ENV_VAR, MOCKED_USER_HASH)
+        assert common_utils.make_cluster_name_on_cloud(
+            'lora', add_user_hash=False, user_hash='ff99ff99') == 'lora'
+
+    def test_long_name_is_truncated_with_the_infix(self, monkeypatch):
+        """Pins the shape the equality tests above compare against: the 34
+        character name does not merely fit."""
+        monkeypatch.setenv(constants.USER_ID_ENV_VAR, 'ff99ff99')
+        fits = common_utils.make_cluster_name_on_cloud('cluster-' + 'x' * 25,
+                                                       max_length=42,
+                                                       user_hash='ab12cd34')
+        assert fits == 'cluster-' + 'x' * 25 + '-ab12cd34'
+
+        truncated = common_utils.make_cluster_name_on_cloud(
+            'cluster-' + 'x' * 26, max_length=42, user_hash='ab12cd34')
+        assert len(truncated) == 42
+        # 42 - 9 (user hash) - 3 (infix and its dash) = 30 name characters.
+        assert truncated.startswith('cluster-' + 'x' * 22)
+        assert truncated.endswith('-ab12cd34')
+
+    # (max_length, user_hash) pairs where the hash cannot fit: 15 is the
+    # default limit and 24 is the smallest one that still rejects a 20
+    # character service-account style hash.
+    @pytest.mark.parametrize('max_length,user_hash', [
+        (15, 'sa-0123456789abcdef'),
+        (15, 'ab12cd34ab12cd34'),
+        (24, 'sa-0123456789abcdefgh'),
+    ])
+    def test_user_hash_that_does_not_fit_raises(self, max_length, user_hash,
+                                                monkeypatch):
+        """A hash longer than the budget used to slice the name with a
+        negative length, producing a name no cloud accepts."""
+        monkeypatch.setenv(constants.USER_ID_ENV_VAR, MOCKED_USER_HASH)
+        with pytest.raises(ValueError, match=re.escape(user_hash)):
+            common_utils.make_cluster_name_on_cloud('lora',
+                                                    max_length=max_length,
+                                                    user_hash=user_hash)
+
+    @pytest.mark.parametrize('max_length', [15, 42, None])
+    def test_empty_user_hash_raises(self, max_length, monkeypatch):
+        """An empty hash would yield a name ending in a dash."""
+        monkeypatch.setenv(constants.USER_ID_ENV_VAR, MOCKED_USER_HASH)
+        with pytest.raises(ValueError, match='non-empty'):
+            common_utils.make_cluster_name_on_cloud('lora',
+                                                    max_length=max_length,
+                                                    user_hash='')
+
+    def test_a_long_user_hash_is_allowed_without_a_max_length(
+            self, monkeypatch):
+        """No max_length means no budget to bust."""
+        monkeypatch.setenv(constants.USER_ID_ENV_VAR, MOCKED_USER_HASH)
+        assert common_utils.make_cluster_name_on_cloud(
+            'lora', max_length=None,
+            user_hash='sa-0123456789abcdef') == 'lora-sa-0123456789abcdef'
 
 
 class TestCgroupFunctions:


### PR DESCRIPTION
## Summary

`make_cluster_name_on_cloud` appends the current process' user hash, which `get_user_hash()` reads from the `SKYPILOT_USER_ID` environment variable. So reconstructing the name on cloud of a cluster that belongs to a *different* user — e.g. to match a cluster's on-cloud resources back to a history record written by someone else — meant mutating the environment around the call, which is not safe in a server process serving several users.

This adds an optional `user_hash` argument:

- omitted (or `None`): the function reads the environment exactly as before, so no existing caller changes behaviour;
- given, with `add_user_hash=True`: it is used in place of `get_user_hash()`, including in the length budget that decides whether the display name is truncated and given the 2-character hash infix;
- given, with `add_user_hash=False`: ignored, as before.

An explicit hash comes from the caller rather than from the environment, so it is validated before it is spent on that budget. An empty hash, or one long enough that no display-name character would be left within `max_length`, raises `ValueError` naming the hash and the limit. Without the check the truncation length goes negative and the function returns a name that is longer than `max_length` and starts with a dash — invalid on every cloud. The implicit (environment) hash keeps its existing assertion path, unchanged.

## Tested

New unit tests in `tests/unit_tests/test_sky/utils/test_common_utils.py` (next to the existing `TestMakeClusterNameOnCloud` cases) assert that the explicit-argument result equals the result the same hash in the environment would have produced, while a *different* hash is in the environment at the time of the explicit call. Covered: an 8-hex id, a service-account id (`sa-` + 16 hex), a mixed-case name containing `.` and `_`, a 33-character name that still fits `max_length=42`, and a 34-character name that is truncated with the 2-character infix. Plus: omitting the argument still reads the environment, the argument is ignored when `add_user_hash=False`, an empty hash raises, a hash too long for `max_length` raises (three parametrized cases), and a long hash is still accepted when `max_length` is `None`.

```
cd <worktree> && PYTHONPATH=$PWD python -m pytest \
  tests/unit_tests/test_sky/utils/test_common_utils.py -n 0
# 2 failed, 117 passed
```

The two failures are `TestCgroupFunctions::test_get_cpu_count` and `::test_get_mem_size_gb`; both fail identically on unmodified master in this environment (they depend on the host's cgroup files) and are unrelated to this change.

`bash format.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

-Claude
