### PR TITLE
[Server] Cap and dedup request-log copies in debug dumps

### DIFF
--- a/sky/server/requests/log_provider.py
+++ b/sky/server/requests/log_provider.py
@@ -1,8 +1,10 @@
 """Provider for request logs."""
 import abc
 import enum
+import os
 import pathlib
 import shutil
+import tempfile
 from typing import AsyncGenerator, Optional
 
 from sky import sky_logging
@@ -10,6 +12,16 @@ from sky.server import constants as server_constants
 from sky.server import stream_utils
 
 logger = sky_logging.init_logger(__name__)
+
+# Cap for a single request-log copy (e.g. for a debug dump). A log-follow
+# request's log can hold a full copy of a tailed log that lives elsewhere,
+# and such copies have been observed at hundreds of MB in production
+# (dominating dump size), while the vast majority of request logs are far
+# below this cap -- so oversized copies keep only the trailing bytes.
+_MAX_LOG_COPY_BYTES = 10 * 1024 * 1024
+# Prefix of the one-line header prepended to a truncated log copy. Doubles
+# as the idempotence marker for cap_log_file_in_place.
+_TRUNCATION_HEADER_PREFIX = '[sky debug-dump] Truncated log:'
 
 
 class RequestLogType(enum.Enum):
@@ -40,6 +52,71 @@ def local_log_path(request_id: str, log_type: RequestLogType) -> pathlib.Path:
     except ValueError:
         raise ValueError(f'Invalid request_id: {request_id!r}') from None
     return log_path
+
+
+def _truncation_header(original_size: int, kept_bytes: int) -> str:
+    """One-line header recording what a truncated log copy is missing."""
+    return (f'{_TRUNCATION_HEADER_PREFIX} original size {original_size} '
+            f'bytes; kept the trailing {kept_bytes} bytes.\n')
+
+
+def _copy_log_tail(src_path: pathlib.Path, dest_path: pathlib.Path,
+                   src_size: int) -> None:
+    """Copy only the trailing _MAX_LOG_COPY_BYTES of an oversized log.
+
+    The header records the original size so a reader can tell a truncated
+    copy from a complete one. The read is bounded by an explicit remaining
+    counter, so a source still being appended to mid-copy cannot push the
+    copy past the cap; a source that shrank since the stat above just
+    yields a shorter tail.
+    """
+    cap = _MAX_LOG_COPY_BYTES
+    with open(src_path, 'rb') as src, open(dest_path, 'wb') as dest:
+        dest.write(_truncation_header(src_size, cap).encode('utf-8'))
+        src.seek(max(0, src_size - cap))
+        remaining = cap
+        while remaining > 0:
+            chunk = src.read(min(1024 * 1024, remaining))
+            if not chunk:
+                break
+            dest.write(chunk)
+            remaining -= len(chunk)
+    # mtime parity with shutil.copy2's forensic semantics.
+    shutil.copystat(src_path, dest_path)
+
+
+def cap_log_file_in_place(path: pathlib.Path) -> None:
+    """Truncate an oversized log file in place to the trailing cap bytes.
+
+    Backstop for providers that override copy_log_file without a size
+    cap: whatever wrote ``path``, it ends up as truncation header +
+    trailing _MAX_LOG_COPY_BYTES bytes. Best-effort -- any OSError is
+    logged at debug level and never raised.
+
+    Idempotent: a file already carrying the truncation header (header +
+    cap bytes, slightly over the cap) is left alone, so a provider-capped
+    copy is not re-truncated.
+    """
+    try:
+        size = path.stat().st_size
+        if size <= _MAX_LOG_COPY_BYTES:
+            return
+        with open(path, 'rb') as f:
+            prefix = f.read(len(_TRUNCATION_HEADER_PREFIX))
+        if prefix == _TRUNCATION_HEADER_PREFIX.encode('utf-8'):
+            return
+        with tempfile.NamedTemporaryFile(dir=path.parent,
+                                         prefix=path.name + '.',
+                                         suffix='.tmp',
+                                         delete=False) as tmp:
+            tmp_path = pathlib.Path(tmp.name)
+        try:
+            _copy_log_tail(path, tmp_path, size)
+            os.replace(tmp_path, path)
+        finally:
+            tmp_path.unlink(missing_ok=True)
+    except OSError as e:
+        logger.debug(f'Failed to cap log file {path}: {e}')
 
 
 class LogProvider(abc.ABC):
@@ -76,17 +153,25 @@ class LogProvider(abc.ABC):
                       dest_path: pathlib.Path) -> bool:
         """Copy a request's log file to dest_path (e.g. for a debug dump).
 
-        The default implementation copies from the local filesystem.
-        Providers backed by other log stores may override this to fetch
-        the log from wherever it lives.
+        The default implementation copies from the local filesystem;
+        copies larger than _MAX_LOG_COPY_BYTES keep only the trailing
+        bytes, prefixed with a truncation header naming the original
+        size. Providers backed by other log stores may override this to
+        fetch the log from wherever it lives (and should apply the same
+        cap, or rely on the dump-side cap_log_file_in_place backstop).
 
         Returns:
             True if the log file was found and copied, False otherwise.
         """
         src_path = local_log_path(request_id, log_type)
-        if not src_path.exists():
+        try:
+            src_size = src_path.stat().st_size
+        except FileNotFoundError:
             return False
-        shutil.copy2(src_path, dest_path)
+        if src_size > _MAX_LOG_COPY_BYTES:
+            _copy_log_tail(src_path, dest_path, src_size)
+        else:
+            shutil.copy2(src_path, dest_path)
         return True
 
     def discard_log(self, request_id: str) -> None:

--- a/sky/utils/debug_utils.py
+++ b/sky/utils/debug_utils.py
@@ -302,6 +302,50 @@ _MANAGED_JOB_REQUEST_NAMES = frozenset({
     request_names.RequestName.JOBS_LOGS.value,
 })
 
+# Request names whose whole output is a tail of a log that lives elsewhere:
+# exactly the requests streamed to the client via
+# stream_utils.stream_response_for_long_request (call sites: sky/logs and
+# sky/hook_logs in sky/server/server.py, sky/serve/logs in
+# sky/serve/server/server.py, sky/jobs/logs and sky/jobs/pool_logs in
+# sky/jobs/server/server.py). Their request.log is by definition a bridge
+# copy of that tail, so a client polling the same log (e.g. a jobs-logs
+# poller) produces many near-duplicate copies -- kept in check by the
+# per-group dedup in _dump_request_id_info.
+# NOTE: keep in sync with TestLogTailRequestNamesCoverage in
+# tests/unit_tests/test_sky/utils/test_debug_utils.py, which fails when a
+# new log-tail endpoint is added without updating this set.
+_LOG_TAIL_REQUEST_NAMES = frozenset({
+    server_constants.REQUEST_NAME_PREFIX +
+    request_names.RequestName.CLUSTER_JOB_LOGS.value,
+    server_constants.REQUEST_NAME_PREFIX +
+    request_names.RequestName.CLUSTER_HOOK_LOGS.value,
+    server_constants.REQUEST_NAME_PREFIX +
+    request_names.RequestName.SERVE_LOGS.value,
+    server_constants.REQUEST_NAME_PREFIX +
+    request_names.RequestName.JOBS_LOGS.value,
+    server_constants.REQUEST_NAME_PREFIX +
+    request_names.RequestName.JOBS_POOL_LOGS.value,
+})
+
+# How many request-log copies to keep per (name, cluster_name, user_id)
+# group of log-tail requests (see _LOG_TAIL_REQUEST_NAMES). The newest N
+# are kept -- enough to see how the tailed log evolved, cheap now that
+# each copy is size-capped.
+_LOG_COPIES_PER_GROUP = 3
+
+# Total-bytes budget for the requests section's log copies. Backstops
+# unique-but-huge logs (e.g. large exec outputs) that survive the
+# per-file cap and the dedup; once exceeded, remaining requests skip
+# their log copies (recorded per-request in errors.json). Iteration is
+# newest-first, so the skip biases to the oldest requests.
+_REQUEST_LOG_BUDGET_BYTES = 1024**3
+
+# Chunk size for the request-metadata pre-pass in _dump_request_id_info.
+# Mirrors requests.py's _ORPHAN_LOG_QUERY_CHUNK_SIZE rationale: avoid
+# oversized IN clauses against a DB that may itself be part of the
+# sickness being dumped.
+_REQUEST_METADATA_QUERY_CHUNK_SIZE = 500
+
 
 class DebugDumpContext(TypedDict):
     """The context for a debug dump."""
@@ -1046,9 +1090,15 @@ def _copy_request_log_file(request_id: str, request_dir: str,
     Standalone (not a per-iteration closure) so the deadline wrapper can call it
     via functools.partial without capturing the loop variable.
     """
-    return log_provider.get_log_provider().copy_log_file(
-        request_id, log_type,
-        pathlib.Path(request_dir) / filename)
+    dest_path = pathlib.Path(request_dir) / filename
+    copied = log_provider.get_log_provider().copy_log_file(
+        request_id, log_type, dest_path)
+    if copied:
+        # Backstop: cap the copy no matter which provider wrote it, so a
+        # provider that overrides copy_log_file without a size cap cannot
+        # dominate dump size (covers request.log AND request_debug.log).
+        log_provider.cap_log_file_in_place(dest_path)
+    return copied
 
 
 # Per-log-copy cap. A copy is normally instant, but copy_log_file on a
@@ -1059,12 +1109,54 @@ def _copy_request_log_file(request_id: str, request_dir: str,
 _REQUEST_LOG_COPY_TIMEOUT = 30
 
 
+def _prefetch_request_metadata(
+    request_ids: Set[str],
+    deadline: Optional[float] = None,
+    errors: Optional[List[Dict[str, str]]] = None,
+) -> Dict[str, requests_lib.Request]:
+    """Fetch Request metadata for all ids in chunked DB queries.
+
+    One query per _REQUEST_METADATA_QUERY_CHUNK_SIZE ids instead of one
+    per id, so a dump with thousands of requests does not hammer a
+    possibly-sick DB with thousands of round trips. Ids a chunk fails to
+    return (chunk error, or deadline hit between chunks) are simply
+    absent from the result; the caller falls back to the per-id fetch
+    for those, preserving the pre-fetch semantics.
+    """
+    metadata: Dict[str, requests_lib.Request] = {}
+    ids = sorted(request_ids)
+    for start in range(0, len(ids), _REQUEST_METADATA_QUERY_CHUNK_SIZE):
+        if _deadline_exceeded(deadline):
+            break
+        chunk = ids[start:start + _REQUEST_METADATA_QUERY_CHUNK_SIZE]
+        try:
+            chunk_requests = requests_lib.get_request_tasks(
+                requests_lib.RequestTaskFilter(request_ids=chunk))
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning(f'Failed to prefetch metadata for {len(chunk)} '
+                           f'requests: {e}; falling back to per-request '
+                           f'lookup')
+            if errors is not None:
+                errors.append({
+                    'component': 'requests',
+                    'resource': 'request_metadata',
+                    'error': (f'{e}; falling back to per-request lookup '
+                              'for these requests'),
+                    'traceback': _full_traceback(),
+                })
+            continue
+        for request in chunk_requests:
+            metadata[request.request_id] = request
+    return metadata
+
+
 def _dump_request_id_info(
         request_ids: Set[str],
         dump_dir: str,
         errors: Optional[List[Dict[str, str]]] = None,
         deadline: Optional[float] = None,
-        orphans: Optional[List[Dict[str, Any]]] = None) -> None:
+        orphans: Optional[List[Dict[str, Any]]] = None,
+        exempt_request_ids: Optional[Set[str]] = None) -> None:
     """Collect request logs and metadata.
 
     ``deadline`` (absolute monotonic) bounds the section two ways: each
@@ -1073,6 +1165,16 @@ def _dump_request_id_info(
     budget is gone we stop starting new requests and skip the rest -- so the
     dump still zips what it gathered. Per-request wall-clock is written to
     ``requests/_timings.json``.
+
+    Requests are visited newest-first (via a chunked metadata pre-pass;
+    ids the pre-pass misses fall back to the per-id fetch and are visited
+    last). Log-tail requests (see _LOG_TAIL_REQUEST_NAMES) are
+    deduplicated per (name, cluster_name, user_id) group: only the
+    _LOG_COPIES_PER_GROUP most recent contribute log copies, so a client
+    polling the same log does not flood the dump with near-duplicates.
+    ``exempt_request_ids`` (the request ids the dump was explicitly
+    filtered to) are never deduplicated. The section's total log bytes
+    are bounded by _REQUEST_LOG_BUDGET_BYTES.
     """
     if not request_ids:
         logger.debug('No requests to dump')
@@ -1083,8 +1185,29 @@ def _dump_request_id_info(
     requests_dir = os.path.join(dump_dir, 'requests')
     os.makedirs(requests_dir, exist_ok=True)
 
+    # Metadata pre-pass: one chunked query instead of a per-id round trip
+    # per request, and the source of the newest-first iteration order.
+    metadata_cache = _prefetch_request_metadata(request_ids,
+                                                deadline=deadline,
+                                                errors=errors)
+    exempt_ids = exempt_request_ids or set()
+    # Cached ids first, newest (created_at desc) to oldest, then the ids
+    # the pre-pass missed (sorted for determinism; their age relative to
+    # the cached ids is unknown, so they are exempt from dedup below).
+    ordered_ids = sorted((rid for rid in request_ids if rid in metadata_cache),
+                         key=lambda rid: (-metadata_cache[rid].created_at, rid))
+    ordered_ids += sorted(
+        rid for rid in request_ids if rid not in metadata_cache)
+
+    # (name, cluster_name, user_id) -> how many log copies the group has
+    # contributed so far / which request ids were kept or skipped in it.
+    kept_counts: Dict[Tuple[str, Optional[str], str], int] = {}
+    group_skipped: Dict[Tuple[str, Optional[str], str], List[str]] = {}
+    group_kept_ids: Dict[Tuple[str, Optional[str], str], List[str]] = {}
+    section_log_bytes = 0
+
     timings: List[Dict[str, Any]] = []
-    for request_id in request_ids:
+    for request_id in ordered_ids:
         if _deadline_exceeded(deadline):
             if errors is not None:
                 errors.append({
@@ -1097,9 +1220,15 @@ def _dump_request_id_info(
         request_dir = os.path.join(requests_dir, request_id)
         os.makedirs(request_dir, exist_ok=True)
 
-        # Get request metadata from DB
+        # Get request metadata from DB: from the pre-pass cache when
+        # present, else today's per-id fetch.
+        from_cache = request_id in metadata_cache
+        request = metadata_cache.get(request_id)
+        log_tail_key: Optional[Tuple[str, Optional[str], str]] = None
+        dedup_skipped = False
         try:
-            request = requests_lib.get_request(request_id)
+            if request is None:
+                request = requests_lib.get_request(request_id)
             if request is not None:
                 request_info: Dict[str, Any] = {
                     'request_id': request.request_id,
@@ -1130,6 +1259,27 @@ def _dump_request_id_info(
                 except Exception:  # pylint: disable=broad-except
                     pass
 
+                # Dedup decision, before the request_info write so the
+                # skip is visible there. Only cached requests participate:
+                # an id the pre-pass missed has no known age relative to
+                # the cached ones, and an explicitly-requested id is never
+                # deduplicated.
+                if (from_cache and request.name in _LOG_TAIL_REQUEST_NAMES and
+                        request_id not in exempt_ids):
+                    log_tail_key = (request.name, request.cluster_name,
+                                    request.user_id)
+                if (log_tail_key is not None and kept_counts.get(
+                        log_tail_key, 0) >= _LOG_COPIES_PER_GROUP):
+                    request_info['log_copy_skipped'] = (
+                        f'Skipped log copy: {_LOG_COPIES_PER_GROUP} more '
+                        f'recent copies of this {request.name} request '
+                        f'for cluster {request.cluster_name!r} were '
+                        f'already collected (near-duplicate log tails).')
+                    group_skipped.setdefault(log_tail_key,
+                                             []).append(request_id)
+                    log_tail_key = None
+                    dedup_skipped = True
+
                 request_info_path = os.path.join(request_dir,
                                                  'request_info.json')
                 with open(request_info_path, 'w', encoding='utf-8') as f:
@@ -1151,6 +1301,37 @@ def _dump_request_id_info(
                     'traceback': _full_traceback()
                 })
 
+        request_log_bytes: Optional[int] = None
+        request_debug_log_bytes: Optional[int] = None
+
+        if dedup_skipped:
+            timings.append({
+                'request_id': request_id,
+                'duration_s': round(time.monotonic() - request_start, 2),
+                'request_log_bytes': None,
+                'request_debug_log_bytes': None,
+            })
+            continue
+
+        # Total-bytes budget for the section's log copies: once exceeded,
+        # remaining requests skip their copies. Iteration is newest-first,
+        # so the skip biases to the oldest requests.
+        if section_log_bytes >= _REQUEST_LOG_BUDGET_BYTES:
+            if errors is not None:
+                errors.append({
+                    'component': 'requests',
+                    'resource': request_id,
+                    'error': ('Skipped: request log copy budget exceeded '
+                              f'({_REQUEST_LOG_BUDGET_BYTES} bytes).'),
+                })
+            timings.append({
+                'request_id': request_id,
+                'duration_s': round(time.monotonic() - request_start, 2),
+                'request_log_bytes': None,
+                'request_debug_log_bytes': None,
+            })
+            continue
+
         # Copy request log file. Routed through the LogProvider so that
         # deployments whose request logs are not on the local filesystem
         # can fetch them from wherever they live. Deadline-bounded: a
@@ -1168,6 +1349,37 @@ def _dump_request_id_info(
                 orphans=orphans)
             if ok and copied:
                 logger.debug(f'Copied request log for {request_id}')
+                try:
+                    request_log_bytes = os.path.getsize(
+                        os.path.join(request_dir, 'request.log'))
+                except OSError:
+                    request_log_bytes = None
+                if request_log_bytes is not None:
+                    section_log_bytes += request_log_bytes
+                    if request_log_bytes == 0:
+                        # Visible emptiness: a 0-byte copy is either a
+                        # genuinely empty log or an intake placeholder
+                        # from a deployment whose log provider routes
+                        # logs elsewhere; record it so the two are
+                        # distinguishable without opening the file.
+                        if errors is not None:
+                            errors.append({
+                                'component': 'requests',
+                                'resource': f'{request_id}/log',
+                                'error': ('Copied request log is empty '
+                                          '(0 bytes); it is either genuinely '
+                                          'empty or an intake placeholder '
+                                          'written before execution.'),
+                            })
+                    elif log_tail_key is not None:
+                        # The group's allowance is consumed only by a
+                        # successful non-empty copy: a missing or empty
+                        # newest log must not shadow older surviving
+                        # copies.
+                        kept_counts[log_tail_key] = (
+                            kept_counts.get(log_tail_key, 0) + 1)
+                        group_kept_ids.setdefault(log_tail_key,
+                                                  []).append(request_id)
             elif ok:
                 logger.debug(f'Request log not found for {request_id}')
         except Exception as e:  # pylint: disable=broad-except
@@ -1195,6 +1407,13 @@ def _dump_request_id_info(
                 orphans=orphans)
             if ok and copied:
                 logger.debug(f'Copied debug log for {request_id}')
+                try:
+                    request_debug_log_bytes = os.path.getsize(
+                        os.path.join(request_dir, 'request_debug.log'))
+                except OSError:
+                    request_debug_log_bytes = None
+                if request_debug_log_bytes is not None:
+                    section_log_bytes += request_debug_log_bytes
         except Exception as e:  # pylint: disable=broad-except
             logger.warning(
                 f'Failed to copy debug log for request {request_id}: {e}')
@@ -1209,7 +1428,25 @@ def _dump_request_id_info(
         timings.append({
             'request_id': request_id,
             'duration_s': round(time.monotonic() - request_start, 2),
+            'request_log_bytes': request_log_bytes,
+            'request_debug_log_bytes': request_debug_log_bytes,
         })
+
+    # One aggregate record per deduplicated group, so the pattern is
+    # visible in errors.json without one record per skipped request.
+    if errors is not None:
+        for ((name, cluster_name, user_id),
+             skipped_ids) in sorted(group_skipped.items()):
+            kept_ids = sorted(
+                group_kept_ids.get((name, cluster_name, user_id), []))
+            errors.append({
+                'component': 'requests',
+                'resource': f'log_dedup/{name}/{cluster_name}',
+                'error': (f'Skipped log copies for {len(skipped_ids)} '
+                          f'near-duplicate {name} requests (cluster '
+                          f'{cluster_name!r}, user {user_id}); kept '
+                          f'request ids: {kept_ids}.'),
+            })
 
     try:
         with open(os.path.join(requests_dir, '_timings.json'),
@@ -2212,6 +2449,7 @@ def _build_debug_dump(
     client_info: Optional[Dict[str, Any]],
     requested: Dict[str, Any],
     deadline: Optional[float] = None,
+    explicit_request_ids: Optional[Set[str]] = None,
 ) -> None:
     """Build the debug dump contents in dump_dir.
 
@@ -2225,6 +2463,11 @@ def _build_debug_dump(
     timeouts are clamped to the remaining budget. The client-info / errors /
     summary writes below always run so the partial dump is self-describing.
     ``None`` (the default) keeps the previous behavior exactly.
+
+    ``explicit_request_ids`` are the request ids the dump was explicitly
+    filtered to (prefix-resolved); they are exempt from the request-log
+    dedup in the requests section, so a targeted dump never drops a
+    named request's log.
     """
     # Populate the context and cross-link related resources. Each helper
     # runs exactly once, and the order is load-bearing:
@@ -2310,7 +2553,9 @@ def _build_debug_dump(
                                        dump_dir,
                                        errors=errors,
                                        deadline=deadline,
-                                       orphans=orphans)),
+                                       orphans=orphans,
+                                       exempt_request_ids=explicit_request_ids)
+        ),
         ('clusters',
          lambda: _dump_cluster_info(debug_dump_context['cluster_names'],
                                     dump_dir,
@@ -2528,12 +2773,17 @@ def create_debug_dump(
                 'managed_job_ids': sorted(managed_job_ids or []),
                 'recent_minutes': recent_minutes,
             }
+            # Snapshot BEFORE _build_debug_dump: the context aliases and
+            # expands this same set in place (cross-linking adds ids and
+            # the system daemons), which would otherwise make the exempt
+            # set grow to the whole context and disable the dedup.
             _build_debug_dump(dump_dir,
                               debug_dump_context,
                               recent_minutes,
                               client_info,
                               requested=original_requested,
-                              deadline=deadline)
+                              deadline=deadline,
+                              explicit_request_ids=set(resolved_request_ids))
             # Report any op whose worker thread is still running (before we
             # detach the handler, so it lands in debug_dump.log too).
             _log_timed_out_stragglers(debug_dump_context['timed_out_ops'])

--- a/tests/unit_tests/test_sky/server/requests/test_log_provider.py
+++ b/tests/unit_tests/test_sky/server/requests/test_log_provider.py
@@ -70,3 +70,98 @@ class TestCopyLogFile:
         # The request log prefix is under ~, so with HOME patched it must
         # resolve inside tmp_path.
         assert str(src).startswith(str(tmp_path))
+
+    def test_oversized_log_capped_to_trailing_bytes(self, tmp_path):
+        """An oversized source copies as header + exactly the trailing cap."""
+        cap = 1024
+        src_dir = tmp_path / 'request_logs'
+        src_dir.mkdir()
+        src = src_dir / 'req-big.log'
+        content = b'A' * 500 + b'B' * cap
+        src.write_bytes(content)
+        dest = tmp_path / 'request.log'
+
+        with mock.patch.object(log_provider, '_MAX_LOG_COPY_BYTES',
+                               cap), mock.patch.object(log_provider,
+                                                       'local_log_path',
+                                                       return_value=src):
+            provider = log_provider.LocalLogProvider()
+            copied = provider.copy_log_file('req-big',
+                                            log_provider.RequestLogType.REQUEST,
+                                            dest)
+
+        assert copied
+        data = dest.read_bytes()
+        header, _, body = data.partition(b'\n')
+        # The header records the original size; the body is exactly the
+        # trailing cap bytes (also bounds a source growing mid-copy).
+        assert header.startswith(b'[sky debug-dump] Truncated log:')
+        assert str(len(content)).encode() in header
+        assert str(cap).encode() in header
+        assert body == b'B' * cap
+
+    def test_copy_at_cap_is_verbatim_with_mtime(self, tmp_path):
+        """A source at exactly the cap copies byte-identically (no header)."""
+        cap = 1024
+        src_dir = tmp_path / 'request_logs'
+        src_dir.mkdir()
+        src = src_dir / 'req-at.log'
+        src.write_bytes(b'x' * cap)
+        dest = tmp_path / 'request.log'
+
+        with mock.patch.object(log_provider, '_MAX_LOG_COPY_BYTES',
+                               cap), mock.patch.object(log_provider,
+                                                       'local_log_path',
+                                                       return_value=src):
+            provider = log_provider.LocalLogProvider()
+            copied = provider.copy_log_file('req-at',
+                                            log_provider.RequestLogType.REQUEST,
+                                            dest)
+
+        assert copied
+        assert dest.read_bytes() == b'x' * cap
+        assert dest.stat().st_mtime == src.stat().st_mtime
+
+
+class TestCapLogFileInPlace:
+
+    def test_noop_at_or_below_cap(self, tmp_path):
+        path = tmp_path / 'small.log'
+        path.write_bytes(b'small')
+        log_provider.cap_log_file_in_place(path)
+        assert path.read_bytes() == b'small'
+
+    def test_noop_when_missing(self, tmp_path):
+        # Best-effort: a missing file is not an error.
+        log_provider.cap_log_file_in_place(tmp_path / 'nope.log')
+
+    def test_truncates_oversized_file_to_trailing_cap(self, tmp_path):
+        cap = 100
+        path = tmp_path / 'big.log'
+        path.write_bytes(b'C' * 400 + b'D' * cap)
+
+        with mock.patch.object(log_provider, '_MAX_LOG_COPY_BYTES', cap):
+            log_provider.cap_log_file_in_place(path)
+
+        data = path.read_bytes()
+        header, _, body = data.partition(b'\n')
+        assert header.startswith(b'[sky debug-dump] Truncated log:')
+        assert str(400 + cap).encode() in header
+        assert body == b'D' * cap
+        # No temp residue.
+        assert list(tmp_path.iterdir()) == [path]
+
+    def test_noop_on_already_capped_file(self, tmp_path):
+        """A provider-capped file (header + cap bytes, slightly over the
+        cap) must not be re-truncated."""
+        cap = 100
+        path = tmp_path / 'capped.log'
+        original = (log_provider._truncation_header(500, cap).encode() +
+                    b'E' * cap)
+        path.write_bytes(original)
+        assert len(original) > cap  # over the cap on purpose
+
+        with mock.patch.object(log_provider, '_MAX_LOG_COPY_BYTES', cap):
+            log_provider.cap_log_file_in_place(path)
+
+        assert path.read_bytes() == original

--- a/tests/unit_tests/test_sky/utils/test_debug_utils.py
+++ b/tests/unit_tests/test_sky/utils/test_debug_utils.py
@@ -4,7 +4,9 @@ import contextlib
 import datetime
 import json
 import os
+import pathlib
 import posixpath
+import re
 import subprocess
 import threading
 import time
@@ -1403,6 +1405,45 @@ class TestCreateDebugDump:
         assert result.exists()
         assert result.suffix == '.zip'
         assert zipfile.is_zipfile(result)
+
+    @mock.patch('sky.utils.debug_utils._dump_managed_job_info')
+    @mock.patch('sky.utils.debug_utils._dump_cluster_info')
+    @mock.patch('sky.utils.debug_utils._dump_request_id_info')
+    @mock.patch('sky.utils.debug_utils._dump_server_info')
+    @mock.patch('sky.utils.debug_utils._get_clusters_from_managed_jobs')
+    @mock.patch('sky.utils.debug_utils._get_clusters_from_requests')
+    @mock.patch('sky.utils.debug_utils._get_managed_jobs_from_requests')
+    @mock.patch('sky.utils.debug_utils._get_requests_from_managed_jobs')
+    @mock.patch('sky.utils.debug_utils._get_requests_from_clusters')
+    def test_exempt_request_ids_is_a_snapshot(
+            self, mock_req_from_clusters, mock_req_from_jobs,
+            mock_jobs_from_req, mock_clusters_from_req, mock_clusters_from_jobs,
+            mock_dump_server, mock_dump_requests, mock_dump_clusters,
+            mock_dump_jobs, tmp_path):
+        """The dedup-exempt set must be a snapshot of the resolved ids.
+
+        The context's request_ids set starts as the same object as the
+        resolved ids and is expanded in place by cross-linking and the
+        system-daemon update. If the exempt set aliased it, every request
+        in the dump would become dedup-exempt and the log-tail dedup
+        would silently never fire.
+        """
+        del mock_req_from_clusters, mock_req_from_jobs, mock_jobs_from_req
+        del mock_clusters_from_req, mock_clusters_from_jobs
+        del mock_dump_server, mock_dump_clusters, mock_dump_jobs
+        with mock.patch('sky.utils.debug_utils.DEBUG_DUMP_DIR',
+                        str(tmp_path / 'debug_dumps')):
+            debug_utils.create_debug_dump(request_ids=['req-1'])
+
+        kwargs = mock_dump_requests.call_args.kwargs
+        exempt = kwargs['exempt_request_ids']
+        assert exempt == {'req-1'}
+        # The expanded context (system daemons et al.) must not leak into
+        # the exempt snapshot.
+        assert not (set(debug_utils.SYSTEM_REQUEST_IDS) & exempt)
+        # And the dumped context did get expanded (the alias exists).
+        request_ids_arg = mock_dump_requests.call_args.args[0]
+        assert set(debug_utils.SYSTEM_REQUEST_IDS) <= request_ids_arg
 
     @mock.patch('sky.utils.debug_utils._dump_managed_job_info')
     @mock.patch('sky.utils.debug_utils._dump_cluster_info')
@@ -2931,6 +2972,68 @@ class TestRequestBodyAllowlistCoverage:
                 f'Stale denylist entry: {name} is not a valid RequestName')
 
 
+# Endpoint-definition modules whose routes stream a tailed log to the
+# client via stream_utils.stream_response_for_long_request. A request
+# name found next to such a call site belongs in
+# debug_utils._LOG_TAIL_REQUEST_NAMES.
+_LOG_TAIL_ENDPOINT_MODULES = (
+    'server/server.py',
+    'jobs/server/server.py',
+    'serve/server/server.py',
+)
+
+
+def _derived_log_tail_request_names() -> Set[str]:
+    """Scan the endpoint modules for names routed through the long-request
+    log streamer (the closest RequestName reference above each call site
+    is the endpoint's own request_name)."""
+    sky_pkg_dir = pathlib.Path(debug_utils.__file__).parent.parent
+    derived: Set[str] = set()
+    for rel_path in _LOG_TAIL_ENDPOINT_MODULES:
+        source = (sky_pkg_dir / rel_path).read_text()
+        for match in re.finditer(r'stream_response_for_long_request\(', source):
+            window = source[max(0, match.start() - 2000):match.start()]
+            name_refs = re.findall(r'RequestName\.([A-Z_0-9]+)', window)
+            if name_refs:
+                derived.add(server_constants.REQUEST_NAME_PREFIX +
+                            request_names.RequestName[name_refs[-1]].value)
+    return derived
+
+
+class TestLogTailRequestNamesCoverage:
+    """_LOG_TAIL_REQUEST_NAMES must track the streamed log-tail endpoints.
+
+    Requests streamed via stream_response_for_long_request have a
+    request.log that is a bridge copy of a tailed log; the dump-side
+    dedup keys off this set. A new log-tail endpoint added without
+    updating the frozenset (or a stale entry left behind) fails here.
+    """
+
+    def test_no_stale_entries(self):
+        """Every entry must be a valid REQUEST_NAME_PREFIX + RequestName."""
+        all_request_names = {
+            server_constants.REQUEST_NAME_PREFIX + r.value
+            for r in request_names.RequestName
+        }
+        for name in debug_utils._LOG_TAIL_REQUEST_NAMES:
+            assert name in all_request_names, (
+                f'Stale _LOG_TAIL_REQUEST_NAMES entry: {name} is not a '
+                'valid RequestName')
+
+    def test_covers_streamed_log_tail_endpoints(self):
+        """The set equals the names routed through the long-request log
+        streamer in the endpoint modules."""
+        derived = _derived_log_tail_request_names()
+        assert derived, 'expected at least one streamed log-tail endpoint'
+        assert derived == set(debug_utils._LOG_TAIL_REQUEST_NAMES), (
+            'streamed log-tail endpoints and _LOG_TAIL_REQUEST_NAMES '
+            f'diverged: only-in-code={sorted(derived - set(debug_utils._LOG_TAIL_REQUEST_NAMES))} '
+            f'only-in-constant='
+            f'{sorted(set(debug_utils._LOG_TAIL_REQUEST_NAMES) - derived)}. '
+            'Update _LOG_TAIL_REQUEST_NAMES in debug_utils.py (or the '
+            'endpoint module list in this test).')
+
+
 # ---------------------------------------------------------------------------
 # Tests for _sanitize_request_body
 # ---------------------------------------------------------------------------
@@ -3070,6 +3173,14 @@ class TestRedactTaskYaml:
 # ---------------------------------------------------------------------------
 class TestDumpRequestIdInfo:
     """Tests for the _dump_request_id_info function."""
+
+    @pytest.fixture(autouse=True)
+    def _mock_get_request_tasks(self):
+        # Empty metadata pre-pass: every id falls back to the per-id
+        # get_request mocks below, so tests drive behavior directly.
+        with mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks',
+                        return_value=[]):
+            yield
 
     @mock.patch('sky.utils.debug_utils.requests_lib.get_request')
     def test_happy_path_writes_request_info(self, mock_get_request, tmp_path):
@@ -3506,7 +3617,10 @@ class TestDumpRequestIdInfoLogCollection:
     @pytest.fixture(autouse=True)
     def _mock_get_request(self):
         with mock.patch('sky.utils.debug_utils.requests_lib.get_request',
-                        return_value=None):
+                        return_value=None), mock.patch(
+                            'sky.utils.debug_utils.requests_lib'
+                            '.get_request_tasks',
+                            return_value=[]):
             yield
 
     def test_logs_collected_via_log_provider(self, tmp_path):
@@ -3564,6 +3678,291 @@ class TestDumpRequestIdInfoLogCollection:
         request_dir = tmp_path / 'requests' / 'req-2'
         assert (request_dir / 'request.log').read_text() == 'local content'
         assert not errors
+
+    # ------------------------------------------------------------------
+    # Size cap, dedup, and budget behavior
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _make_log_tail_requests(count=5,
+                                name='sky.jobs.logs',
+                                cluster_name='sky-jobs-controller-1',
+                                user_id='user-1'):
+        return [
+            _make_request(request_id=f'req-{i}',
+                          name=name,
+                          cluster_name=cluster_name,
+                          user_id=user_id,
+                          created_at=1700000000.0 + i) for i in range(count)
+        ]
+
+    @staticmethod
+    def _copying_provider(request_log_content=lambda rid: f'log {rid}'):
+        """Provider mock that writes request.log (and nothing else)."""
+        provider = mock.MagicMock()
+
+        def _fake_copy(request_id, log_type, dest_path):
+            if log_type == log_provider_lib.RequestLogType.REQUEST:
+                dest_path.write_text(request_log_content(request_id))
+                return True
+            return False
+
+        provider.copy_log_file.side_effect = _fake_copy
+        return provider
+
+    def test_oversized_log_capped_end_to_end(self, tmp_path):
+        """An oversized local log is capped by the default provider."""
+        src = tmp_path / 'src.log'
+        src.write_bytes(b'A' * 500 + b'B' * 100)
+        with mock.patch('sky.server.requests.log_provider.local_log_path',
+                        return_value=src), mock.patch.object(
+                            log_provider_lib, '_MAX_LOG_COPY_BYTES', 100):
+            errors: List[Dict[str, str]] = []
+            debug_utils._dump_request_id_info({'req-2'}, str(tmp_path), errors)
+
+        dest = tmp_path / 'requests' / 'req-2' / 'request.log'
+        data = dest.read_bytes()
+        header, _, body = data.partition(b'\n')
+        assert header.startswith(b'[sky debug-dump] Truncated log:')
+        assert body == b'B' * 100
+        assert not errors
+
+    def test_oversized_provider_dest_backstopped_by_cap(self, tmp_path):
+        """A provider that ignores the cap still ends up with a capped dest.
+
+        Covers providers that override copy_log_file without a size cap;
+        the dump-side cap_log_file_in_place backstop truncates the copy
+        in place after the provider returns.
+        """
+        provider = mock.MagicMock()
+
+        def _fake_copy(request_id, log_type, dest_path):
+            del request_id, log_type
+            dest_path.write_bytes(b'X' * 500)
+            return True
+
+        provider.copy_log_file.side_effect = _fake_copy
+        with mock.patch('sky.utils.debug_utils.log_provider.get_log_provider',
+                        return_value=provider), mock.patch.object(
+                            log_provider_lib, '_MAX_LOG_COPY_BYTES', 100):
+            errors: List[Dict[str, str]] = []
+            debug_utils._dump_request_id_info({'req-1'}, str(tmp_path), errors)
+
+        dest = tmp_path / 'requests' / 'req-1' / 'request.log'
+        data = dest.read_bytes()
+        header, _, body = data.partition(b'\n')
+        assert header.startswith(b'[sky debug-dump] Truncated log:')
+        assert body == b'X' * 100
+
+    def test_log_tail_requests_deduplicated(self, tmp_path):
+        """Only the newest N log-tail copies per group are kept."""
+        requests_ = self._make_log_tail_requests(5)
+        provider = self._copying_provider()
+        with mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks',
+                        return_value=requests_), mock.patch(
+                            'sky.utils.debug_utils.log_provider'
+                            '.get_log_provider',
+                            return_value=provider):
+            errors: List[Dict[str, str]] = []
+            debug_utils._dump_request_id_info({r.request_id for r in requests_},
+                                              str(tmp_path), errors)
+
+        requests_dir = tmp_path / 'requests'
+        # Only the 3 newest get request.log copies.
+        copied = sorted(
+            p.parent.name for p in requests_dir.glob('*/request.log'))
+        assert copied == ['req-2', 'req-3', 'req-4']
+        # All five get request_info.json; the older two carry the note.
+        for i in range(5):
+            info = json.loads(
+                (requests_dir / f'req-{i}' / 'request_info.json').read_text())
+            if i < 2:
+                assert 'log_copy_skipped' in info
+            else:
+                assert 'log_copy_skipped' not in info
+        # Exactly one aggregate errors record, naming the kept ids.
+        dedup_records = [
+            e for e in errors if e['resource'].startswith('log_dedup/')
+        ]
+        assert len(dedup_records) == 1
+        assert '2 near-duplicate' in dedup_records[0]['error']
+        for kept in ('req-2', 'req-3', 'req-4'):
+            assert kept in dedup_records[0]['error']
+
+    def test_dedup_scopes_by_cluster_user_and_name(self, tmp_path):
+        """Distinct cluster, user, or request name -> not deduplicated."""
+        requests_ = [
+            _make_request(request_id='req-a',
+                          name='sky.jobs.logs',
+                          cluster_name='c1',
+                          user_id='u1',
+                          created_at=100.0),
+            _make_request(request_id='req-b',
+                          name='sky.jobs.logs',
+                          cluster_name='c2',
+                          user_id='u1',
+                          created_at=101.0),
+            _make_request(request_id='req-c',
+                          name='sky.jobs.logs',
+                          cluster_name='c1',
+                          user_id='u2',
+                          created_at=102.0),
+            _make_request(request_id='req-d',
+                          name='sky.launch',
+                          cluster_name='c1',
+                          user_id='u1',
+                          created_at=103.0),
+        ]
+        provider = self._copying_provider()
+        with mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks',
+                        return_value=requests_), mock.patch(
+                            'sky.utils.debug_utils.log_provider'
+                            '.get_log_provider',
+                            return_value=provider):
+            errors: List[Dict[str, str]] = []
+            debug_utils._dump_request_id_info({r.request_id for r in requests_},
+                                              str(tmp_path), errors)
+
+        copied = sorted(p.parent.name
+                        for p in (tmp_path / 'requests').glob('*/request.log'))
+        assert copied == ['req-a', 'req-b', 'req-c', 'req-d']
+        assert not [e for e in errors if e['resource'].startswith('log_dedup/')]
+
+    def test_exempt_request_ids_not_deduplicated(self, tmp_path):
+        """An explicitly-requested id keeps its log even in a full group."""
+        requests_ = self._make_log_tail_requests(5)
+        provider = self._copying_provider()
+        with mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks',
+                        return_value=requests_), mock.patch(
+                            'sky.utils.debug_utils.log_provider'
+                            '.get_log_provider',
+                            return_value=provider):
+            errors: List[Dict[str, str]] = []
+            debug_utils._dump_request_id_info({r.request_id for r in requests_},
+                                              str(tmp_path),
+                                              errors,
+                                              exempt_request_ids={'req-0'})
+
+        copied = sorted(p.parent.name
+                        for p in (tmp_path / 'requests').glob('*/request.log'))
+        # 3 newest plus the exempt oldest.
+        assert copied == ['req-0', 'req-2', 'req-3', 'req-4']
+
+    def test_empty_newest_copies_do_not_consume_allowance(self, tmp_path):
+        """A group's allowance is consumed only by non-empty copies."""
+        requests_ = self._make_log_tail_requests(5)
+        provider = self._copying_provider(
+            request_log_content=lambda rid: ''
+            if rid in ('req-2', 'req-3', 'req-4') else f'log {rid}')
+        with mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks',
+                        return_value=requests_), mock.patch(
+                            'sky.utils.debug_utils.log_provider'
+                            '.get_log_provider',
+                            return_value=provider):
+            errors: List[Dict[str, str]] = []
+            debug_utils._dump_request_id_info({r.request_id for r in requests_},
+                                              str(tmp_path), errors)
+
+        # The 3 newest have empty (placeholder) logs; the two older
+        # surviving copies are still collected (non-empty request.log
+        # files exist only for the older two).
+        copied = sorted(p.parent.name
+                        for p in (tmp_path / 'requests').glob('*/request.log')
+                        if p.stat().st_size > 0)
+        assert copied == ['req-0', 'req-1']
+        # Each empty copy is flagged in errors.json.
+        empty_records = [e for e in errors if 'empty' in e['error']]
+        assert len(empty_records) == 3
+
+    def test_budget_skips_later_copies(self, tmp_path, monkeypatch):
+        """Once the section's byte budget is spent, later copies are
+        skipped with a recorded reason; metadata is still written."""
+        requests_ = [
+            _make_request(request_id=f'req-{i}',
+                          name='sky.launch',
+                          created_at=100.0 + i) for i in range(3)
+        ]
+        provider = self._copying_provider(
+            request_log_content=lambda rid: 'x' * 100)
+        monkeypatch.setattr(debug_utils, '_REQUEST_LOG_BUDGET_BYTES', 50)
+        with mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks',
+                        return_value=requests_), mock.patch(
+                            'sky.utils.debug_utils.log_provider'
+                            '.get_log_provider',
+                            return_value=provider):
+            errors: List[Dict[str, str]] = []
+            debug_utils._dump_request_id_info({r.request_id for r in requests_},
+                                              str(tmp_path), errors)
+
+        # Newest-first: only the newest request fits the budget.
+        copied = sorted(p.parent.name
+                        for p in (tmp_path / 'requests').glob('*/request.log'))
+        assert copied == ['req-2']
+        budget_records = [e for e in errors if 'budget' in e['error']]
+        assert len(budget_records) == 2
+        # request_info.json is still written for every request.
+        for i in range(3):
+            assert (tmp_path / 'requests' / f'req-{i}' /
+                    'request_info.json').exists()
+
+    def test_prefetch_failure_falls_back_to_per_id(self, tmp_path):
+        """A pre-pass failure records one error and degrades to per-id
+        fetches without crashing."""
+        request = _make_request(request_id='req-1',
+                                name='sky.launch',
+                                created_at=100.0)
+        provider = self._copying_provider()
+        with mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks',
+                        side_effect=RuntimeError('DB down')), mock.patch(
+                            'sky.utils.debug_utils.requests_lib.get_request',
+                            return_value=request), mock.patch(
+                                'sky.utils.debug_utils.log_provider'
+                                '.get_log_provider',
+                                return_value=provider):
+            errors: List[Dict[str, str]] = []
+            debug_utils._dump_request_id_info({'req-1'}, str(tmp_path), errors)
+
+        metadata_errors = [
+            e for e in errors if e['resource'] == 'request_metadata'
+        ]
+        assert len(metadata_errors) == 1
+        assert 'DB down' in metadata_errors[0]['error']
+        # request_info still written via the per-id fallback.
+        assert (tmp_path / 'requests' / 'req-1' / 'request_info.json').exists()
+
+    def test_timings_newest_first_with_log_bytes(self, tmp_path):
+        """_timings.json is created_at-descending and carries per-log
+        byte counts."""
+        requests_ = self._make_log_tail_requests(3)
+        provider = self._copying_provider(request_log_content=lambda rid: 'abc')
+        with mock.patch('sky.utils.debug_utils.requests_lib.get_request_tasks',
+                        return_value=requests_), mock.patch(
+                            'sky.utils.debug_utils.log_provider'
+                            '.get_log_provider',
+                            return_value=provider):
+            errors: List[Dict[str, str]] = []
+            debug_utils._dump_request_id_info({r.request_id for r in requests_},
+                                              str(tmp_path), errors)
+
+        timings = json.loads(
+            (tmp_path / 'requests' / '_timings.json').read_text())
+        assert [t['request_id'] for t in timings] == ['req-2', 'req-1', 'req-0']
+        assert all(t['request_log_bytes'] == 3 for t in timings)
+        assert all(t['request_debug_log_bytes'] is None for t in timings)
+
+    def test_empty_copied_request_log_recorded(self, tmp_path):
+        """A successfully-copied 0-byte request.log is visible in
+        errors.json and in the timings byte counts."""
+        provider = self._copying_provider(request_log_content=lambda rid: '')
+        with mock.patch('sky.utils.debug_utils.log_provider.get_log_provider',
+                        return_value=provider):
+            errors: List[Dict[str, str]] = []
+            debug_utils._dump_request_id_info({'req-1'}, str(tmp_path), errors)
+
+        assert any(e['resource'] == 'req-1/log' and 'empty' in e['error']
+                   for e in errors)
+        timings = json.loads(
+            (tmp_path / 'requests' / '_timings.json').read_text())
+        assert timings[0]['request_log_bytes'] == 0
 
 
 class TestJobsControllerUnreachableGate:


### PR DESCRIPTION
## Summary

On a production API server with many long-lived requests, `request.log` + `request_debug.log` made up roughly half of an 11GB debug dump, dominated by two patterns the dump's copy path had no answer for:

- **No size cap anywhere.** `LogProvider.copy_log_file` was a raw `shutil.copy2`; a log-follow request's log can hold a full bridge copy of a tailed log that lives elsewhere, and one such copy was observed at 561MB (copied in 3.6s, so the existing 30s-per-copy timeout gave no protection). 41 files over 10MB summed to 1.12GB.
- **No dedup across near-duplicate poller requests.** A client polling `sky jobs logs` on one controller cluster left 2375 near-duplicate requests in the requests table, each contributing a fresh ~11.7MB copy of the same controller log tail — 86% of all request-log bytes in the dump.

This PR adds three internal levers to the request-log copy path (no new user-facing knobs; revert is the rollback):

1. **Per-file tail cap (10MB).** The default `LogProvider.copy_log_file` stats the source and, above 10MB, copies only the trailing 10MB, prefixed with a one-line `[sky debug-dump] Truncated log:` header naming the original size (mtime preserved; read length-bounded so a source still being appended to mid-copy cannot overshoot). Files at or below the cap remain byte-identical `shutil.copy2` copies. A new dump-side backstop, `log_provider.cap_log_file_in_place`, truncates any provider's oversized output in place after the copy returns — so a `LogProvider` subclass that overrides `copy_log_file` without a cap cannot dominate dump size either (idempotent via the header marker).
2. **Newest-first keep-3 dedup of log-tail requests.** Requests streamed via `stream_response_for_long_request` (`sky.logs`, `sky.hook_logs`, `sky.serve.logs`, `sky.jobs.logs`, `sky.jobs.pool_logs` — pinned by a source-scan test) have a `request.log` that is by definition a bridge copy of a tailed log. The dump now keeps only the 3 most recent `request.log` copies per `(name, cluster_name, user_id)` group, iterating newest-first via a chunked metadata pre-pass (one DB query per 500 ids instead of one per id; per-id fetch kept as the fallback for ids the pre-pass misses). Skipped requests still get `request_info.json` with a `log_copy_skipped` note, and one aggregate `errors.json` record per group names the kept ids. Explicitly-requested request IDs (prefix-resolved) are exempt, so a targeted dump never drops a named request's log. A group's allowance is consumed only by a successful non-empty copy, so a missing or empty newest log never shadows older surviving copies.
3. **Section budget + visibility.** The requests section's total log bytes are bounded by a 1GiB backstop budget (skips recorded per-request in `errors.json`, biasing to the oldest requests). A successfully-copied 0-byte `request.log` gets an informational `errors.json` entry, and `requests/_timings.json` gains `request_log_bytes` / `request_debug_log_bytes` per entry, so empties, not-founds, and cap engagement are scannable without opening files.

On the dump that motivated this, cap + dedup takes `request.log` + `request_debug.log` from ~5.2GB to roughly 1.3GB, with the budget bounding the remainder.

## Test plan

- [x] `tests/unit_tests/test_sky/server/requests/test_log_provider.py` — new tests: oversized source copies as header + exactly the trailing cap bytes; at-cap copy is byte-identical with mtime preserved; `cap_log_file_in_place` no-op at/below cap, truncate oversized, idempotent on an already-capped file.
- [x] `tests/unit_tests/test_sky/utils/test_debug_utils.py` — new tests: end-to-end cap through `_dump_request_id_info`; dump-side backstop of an oversized-writing provider; keep-3 dedup with per-request notes + one aggregate record; group scoping by cluster/user/name; exempt ids not deduped; empty newest copies not consuming the allowance; budget skip recorded with metadata preserved; pre-pass failure falls back to per-id fetch with one `request_metadata` error; newest-first `_timings.json` order with byte counts; 0-byte copy visibility; `TestLogTailRequestNamesCoverage` (staleness + source-scan of the endpoint modules); regression test that the exempt set is a snapshot (not aliased to the cross-link-expanded context).
- [x] End-to-end against a local API server running this branch (verified via `/proc/<pid>/cwd` + `PYTHONPATH`, and by the branch-only `_timings.json` fields): seeded 6 `sky.jobs.logs` requests on one cluster with distinct `created_at` (one with a 12MB log, one with an empty log) plus a `sky.launch` request, then ran `sky` debug dumps — cluster-scoped dump: exactly the 3 newest non-empty poll logs + the empty one collected, the 2 oldest skipped with `log_copy_skipped` notes and one aggregate `log_dedup/...` errors record naming the kept ids; the 12MB log landed as header + exactly 10MB of trailing bytes; the empty copy flagged in `errors.json` with `request_log_bytes=0` in `_timings.json`; the `sky.launch` log not deduped; prefix-targeted dump: all 6 poll logs collected (exemption works).
- Known devspace-only failure (reproduces on unmodified `master` in this environment; `SKY_RUNTIME_DIR` pins the request-log prefix at import time so a patched `HOME` has no effect): `TestCopyLogFile::test_uses_real_paths_by_default`.

Note: this touches `sky/utils/debug_utils.py`, which other in-flight debug-dump changes also modify — expect small textual (not semantic) merge friction there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
