### PR TITLE
Add fleet GPU capacity and infra counts

### DIFF
--- a/docs/source/reference/logging.rst
+++ b/docs/source/reference/logging.rst
@@ -14,6 +14,39 @@ We collect non-sensitive data that helps us understand how SkyPilot is used. We 
 
 In addition, SkyPilot uses `Scarf <https://scarf.sh>`__ to report an anonymous ping when a command is invoked on a client machine. The ping contains only the name of the invoked command and the SkyPilot version — no PII. Internal invocations (e.g. by SkyPilot controllers or the API server) and dry runs are not reported.
 
+API server heartbeat
+~~~~~~~~~~~~~~~~~~~~
+
+In addition to the per-command data above, a SkyPilot API server sends a
+periodic heartbeat every 10 minutes for as long as the server is running. The
+heartbeat reports:
+
+- ``total_gpus`` — installed GPU capacity, summed over every node in every
+  Kubernetes and SSH context the server is allowed to use. This is capacity,
+  not usage: an idle GPU node counts the same as a busy one. Clusters on cloud
+  VMs have no node inventory to read and do not contribute. TPUs are excluded.
+- ``gpus_by_type`` — the same total broken down by accelerator type, e.g.
+  ``{"H100": 64, "A100:80GB": 16}``.
+- ``infra_count`` — how many infrastructures of each kind the server is
+  configured to use, e.g.
+  ``{"kubernetes": 3, "ssh_node_pools": 1, "slurm": 0, "clouds": 2}``. These
+  are counts only: no context names, cluster names, or cloud account
+  identifiers are included. A kind whose count could not be determined is
+  omitted rather than reported as zero.
+- ``hostname``, ``server_hash`` (a stable per-installation identifier),
+  ``sky_version``, and, when deployed via Helm, ``release_name`` and
+  ``ingress_host``.
+
+No cluster names, user names, task YAML, or cloud credentials are included.
+
+Deployments that install a plugin registering a heartbeat data provider report
+additional fields contributed by that plugin.
+
+The heartbeat is sent by the API server process, not by the client, so
+disabling it requires setting the environment variable on the server (see
+below). It is not sent when the server is running as a jobs or serve
+controller.
+
 .. _usage-disable:
 
 How to disable it
@@ -21,6 +54,9 @@ How to disable it
 To disable usage collection, set the ``SKYPILOT_DISABLE_USAGE_COLLECTION`` environment variable by :code:`export SKYPILOT_DISABLE_USAGE_COLLECTION=1`. This disables both the usage stats and the Scarf ping.
 
 The Scarf ping alone can also be disabled by setting either of the industry-standard environment variables ``DO_NOT_TRACK=1`` or ``SCARF_NO_ANALYTICS=true``.
+
+For the API server heartbeat, set it in the server's own environment; setting
+it only on the client does not stop the heartbeat.
 
 
 How does it work?

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -4536,6 +4536,29 @@ def get_kubernetes_node_info(
         context: Optional[str] = None) -> models.KubernetesNodesInfo:
     """Gets the resource information for all the nodes in the cluster.
 
+    Results are also recorded as fleet GPU capacity for the usage heartbeat
+    (see usage_lib.record_node_info), so that daemon can reuse inventory any
+    caller already fetched instead of querying again. Recording is one
+    indexed DB read when a fresh row exists, one write when it does not, and
+    never affects what this function returns.
+    """
+    nodes_info = _get_kubernetes_node_info(context)
+    try:
+        # pylint: disable=import-outside-toplevel
+        from sky.usage import usage_lib
+        resolved_context = (context if context is not None else
+                            get_current_kube_config_context_name())
+        usage_lib.record_node_info(resolved_context, nodes_info)
+    except Exception as e:  # pylint: disable=broad-except
+        # Telemetry bookkeeping must never break a node info query.
+        logger.debug(f'Failed to record node info for telemetry: {e}')
+    return nodes_info
+
+
+def _get_kubernetes_node_info(
+        context: Optional[str] = None) -> models.KubernetesNodesInfo:
+    """Gets the resource information for all the nodes in the cluster.
+
     This function returns a model with node info map as a nested field. This
     allows future extensions while keeping the client-server compatibility,
     e.g. when adding a new field to the model, the legacy clients will not be

--- a/sky/server/constants.py
+++ b/sky/server/constants.py
@@ -174,8 +174,9 @@ DEFAULT_DAEMON_LOG_MAX_BYTES = 128 * 1024 * 1024  # 128 MB
 # server. Configurable via api_server.logs_retention_hours; negative disables.
 DEFAULT_LOGS_RETENTION_HOURS = 720  # 30 days
 
-# Interval for the server-side heartbeat daemon that sends plugin metrics
-# to Loki (e.g., GPU inventory from billing plugin).
+# Interval for the server-side heartbeat daemon that sends fleet-wide GPU
+# counts to Loki, plus plugin metrics when a plugin registered a provider
+# (e.g., GPU inventory from billing plugin).
 SERVER_HEARTBEAT_INTERVAL_SECONDS = 600  # 10 minutes
 
 # Interval for the daemon that sweeps expired managed-job API access tokens

--- a/sky/server/daemons.py
+++ b/sky/server/daemons.py
@@ -345,16 +345,16 @@ def expired_token_cleanup_event():
 
 
 def server_heartbeat_event():
-    """Periodically send server-side plugin metrics to Loki."""
+    """Periodically send server-side fleet and plugin metrics to Loki."""
     # pylint: disable=import-outside-toplevel
     from sky.usage import usage_lib
 
-    # Skip if no plugins registered providers (check inside event_fn, not
-    # should_skip, because providers register in executor processes via
-    # plugin install(), not in the main process where should_skip runs),
-    # or if the user explicitly disabled usage collection.
-    if (not usage_lib.ServerHeartbeatMessage.has_providers() or
-            _user_disabled_usage_collection):
+    # The heartbeat reports fleet-wide GPU counts from every API server, so it
+    # is no longer gated on plugin providers. Plugin metrics stay opt-in:
+    # providers register in executor processes via plugin install(), and
+    # ServerHeartbeatMessage.get_properties() omits the 'plugins' field when
+    # none registered. Skip only when the user disabled usage collection.
+    if _user_disabled_usage_collection:
         time.sleep(server_constants.SERVER_HEARTBEAT_INTERVAL_SECONDS)
         return
 

--- a/sky/usage/constants.py
+++ b/sky/usage/constants.py
@@ -13,6 +13,18 @@ SCARF_GATEWAY_URL = os.environ.get('SKYPILOT_SCARF_GATEWAY_URL',
 USAGE_MESSAGE_SCHEMA_VERSION = 1
 PRIVACY_POLICY_PATH = '~/.sky/privacy_policy'
 
+# How long a recorded GPU capacity row stays valid. Installed capacity
+# changes on the timescale of node pool edits, so a fleet-size metric does not
+# need per-heartbeat freshness; at the 10 minute heartbeat interval this is
+# six heartbeats per query. Rows live in the kv_cache DB table and expire on
+# their own. This cache backs telemetry only — scheduling and `sky status`
+# continue to read node info directly, and must never be served from here.
+NODE_INFO_CACHE_TTL_SECONDS = 3600  # 1 hour
+
+# kv_cache key prefix for the per-infra capacity rows. Ids under it look like
+# 'kubernetes/<context>' and 'slurm/<cluster>'.
+NODE_INFO_CACHE_KEY_PREFIX = 'usage/gpu_capacity/'
+
 USAGE_POLICY_MESSAGE = (
     'SkyPilot collects usage data to improve its services. '
     '`setup` and `run` commands are not collected to '

--- a/sky/usage/usage_lib.py
+++ b/sky/usage/usage_lib.py
@@ -4,13 +4,15 @@ import contextlib
 import contextvars
 import datetime
 import enum
+import functools
 import json
 import os
 import threading
 import time
 import traceback
 import typing
-from typing import Any, Callable, ClassVar, Dict, List, Optional, Set, Union
+from typing import (Any, Callable, ClassVar, Collection, Dict, List, Optional,
+                    Set, Union)
 import urllib.parse
 import urllib.request
 import uuid
@@ -33,8 +35,10 @@ if typing.TYPE_CHECKING:
 
     import requests
 
+    from sky import models
     from sky import resources as resources_lib
     from sky import task as task_lib
+    from sky.adaptors import slurm as slurm_adaptor
     from sky.utils import status_lib
 else:
     # requests and inspect cost ~100ms to load, which can be postponed to
@@ -375,7 +379,15 @@ class ServerHeartbeatMessage(MessageToReport):
         sky_version: str — SkyPilot version
         ingress_host: Optional[str] — ingress DNS hostname if deployed
             with ingress (from SKYPILOT_INGRESS_HOST env var)
-        plugins: Dict[str, Any] — per-plugin data from registered providers
+        total_gpus: int — installed GPU capacity across every node in every
+            allowed Kubernetes and SSH context. Cloud VM clusters have no
+            node inventory and do not contribute.
+        gpus_by_type: Dict[str, int] — per-GPU-type breakdown of total_gpus
+        infra_count: Dict[str, int] — how many infrastructures of each kind
+            the server is configured to use, e.g.
+            ``{'kubernetes': 3, 'ssh_node_pools': 1, 'slurm': 0, 'clouds': 2}``
+        plugins: Dict[str, Any] — per-plugin data from registered providers.
+            Omitted entirely when no plugin registered a provider.
     """
 
     _data_providers: ClassVar[Dict[str, Callable[[], Dict[str, Any]]]] = {}
@@ -390,6 +402,11 @@ class ServerHeartbeatMessage(MessageToReport):
         self.server_hash: str = common_utils.get_user_hash()
         self.sky_version: str = sky.__version__
         self.ingress_host: Optional[str] = os.getenv('SKYPILOT_INGRESS_HOST')
+        self.total_gpus: int = 0
+        #: Per-GPU-type breakdown, e.g. ``{'H100': 64, 'A100:80GB': 16}``.
+        self.gpus_by_type: Dict[str, int] = {}
+        #: Per-infra-kind counts, e.g. ``{'kubernetes': 3, 'clouds': 2}``.
+        self.infra_count: Dict[str, int] = {}
 
     @classmethod
     def register_provider(cls, name: str,
@@ -397,12 +414,13 @@ class ServerHeartbeatMessage(MessageToReport):
         """Register a plugin data provider. Called during plugin install()."""
         cls._data_providers[name] = provider
 
-    @classmethod
-    def has_providers(cls) -> bool:
-        return len(cls._data_providers) > 0
-
     def get_properties(self) -> Dict[str, Any]:
         properties = super().get_properties()
+        # Plugin metrics stay opt-in: only deployments where a plugin
+        # registered a provider report a 'plugins' field at all. The GPU and
+        # infra counts above are reported by every API server.
+        if not self._data_providers:
+            return properties
         plugins_data = {}
         for name, provider in self._data_providers.items():
             try:
@@ -742,9 +760,276 @@ def send_heartbeat(
     _send_to_loki(MessageType.HEARTBEAT)
 
 
+def _try_list(kind: str,
+              fn: Callable[[], Collection[Any]]) -> Optional[Collection[Any]]:
+    """Run a lookup that returns a collection; None if it raised.
+
+    None and an empty collection mean different things to the callers:
+    nothing configured is a real zero and is reported, while a failed lookup
+    leaves that count out of the payload entirely.
+    """
+    try:
+        return fn()
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f'Heartbeat {kind} lookup failed: {e}')
+        return None
+
+
 def send_server_heartbeat():
-    """Send server-side heartbeat with plugin metrics to Loki."""
+    """Send server-side heartbeat with fleet and plugin metrics to Loki."""
+    # pylint: disable=import-outside-toplevel
+    from sky import clouds as sky_clouds
+
+    # Resolved once and shared by both collectors: each lookup re-parses the
+    # kubeconfig or ~/.slurm/config.
+    k8s_contexts = _try_list(
+        'kubernetes',
+        lambda: sky_clouds.Kubernetes.existing_allowed_contexts(silent=True))
+    ssh_contexts = _try_list(
+        'ssh', lambda: sky_clouds.SSH.existing_allowed_contexts(silent=True))
+    slurm_clusters = _try_list(
+        'slurm',
+        lambda: sky_clouds.Slurm.existing_allowed_clusters(silent=True))
+
+    msg = messages.server_heartbeat
+    msg.gpus_by_type = _collect_gpu_fleet(
+        list(k8s_contexts or []) + list(ssh_contexts or []),
+        list(slurm_clusters or []))
+    msg.total_gpus = sum(msg.gpus_by_type.values())
+    msg.infra_count = _collect_infra_count(k8s_contexts, ssh_contexts,
+                                           slurm_clusters)
     _send_to_loki(MessageType.SERVER_HEARTBEAT)
+
+
+# ---------------------------------------------------------------------------
+# Fleet GPU capacity.
+#
+# Installed GPU capacity per infrastructure, cached in the kv_cache DB table
+# under NODE_INFO_CACHE_KEY_PREFIX. The rows live in the DB rather than in
+# memory because each internal daemon runs in its own executor worker —
+# sky.server.config._get_min_short_workers() provisions one extra worker per
+# daemon — so an in-process cache filled while serving a request would never
+# be read by the heartbeat. Only derived per-type totals are stored; the node
+# inventories they come from are not.
+# ---------------------------------------------------------------------------
+
+
+def _k8s_capacity_id(context: Optional[str]) -> str:
+    """Cache id for a Kubernetes or SSH context. None is the in-cluster one."""
+    return f'kubernetes/{context or ""}'
+
+
+def _slurm_capacity_id(cluster: str) -> str:
+    return f'slurm/{cluster}'
+
+
+def _gpu_capacity_from_nodes(
+        nodes_info: 'models.KubernetesNodesInfo') -> Dict[str, int]:
+    """Reduce a context's node inventory to GPU counts per accelerator type."""
+    counts: Dict[str, int] = {}
+    for node_info in nodes_info.node_info_dict.values():
+        count = int(node_info.total.get('accelerator_count', 0) or 0)
+        if count <= 0 or node_info.accelerator_type is None:
+            continue
+        acc_type = str(node_info.accelerator_type)
+        if acc_type.lower().startswith('tpu'):
+            # TPUs are tracked separately from GPUs.
+            continue
+        counts[acc_type] = counts.get(acc_type, 0) + count
+    return counts
+
+
+def _gpu_capacity_from_slurm_nodes(
+        nodes_info: List['slurm_adaptor.NodeInfo']) -> Dict[str, int]:
+    """Reduce a Slurm cluster's ``sinfo`` rows to GPU counts per type.
+
+    ``sinfo --Node`` emits one row per node *per partition*, so a node in two
+    partitions appears twice. Dedupe by node name before summing.
+    """
+    # pylint: disable=import-outside-toplevel
+    from sky.provision.slurm import utils as slurm_utils
+
+    counts: Dict[str, int] = {}
+    seen = set()
+    for node in nodes_info:
+        if node.node in seen:
+            continue
+        seen.add(node.node)
+        gpu_type, count = slurm_utils.get_gpu_type_and_count(node.gres)
+        if count <= 0:
+            continue
+        # GRES without a type (``gpu:8``) still counts; label it plainly.
+        acc_type = gpu_type or 'gpu'
+        counts[acc_type] = counts.get(acc_type, 0) + count
+    return counts
+
+
+def _read_all_capacity() -> Dict[str, Dict[str, int]]:
+    """Read every unexpired capacity row in one query, keyed by infra id."""
+    # pylint: disable=import-outside-toplevel
+    from sky.utils.db import kv_cache
+
+    prefix = constants.NODE_INFO_CACHE_KEY_PREFIX
+    try:
+        rows = kv_cache.get_cache_entries_by_prefix(prefix)
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f'Heartbeat capacity read failed: {e}')
+        return {}
+    recorded: Dict[str, Dict[str, int]] = {}
+    for key, raw in rows.items():
+        try:
+            recorded[key[len(prefix):]] = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            continue
+    return recorded
+
+
+def record_gpu_capacity(infra: str, counts: Dict[str, int]) -> None:
+    """Record one infra's GPU capacity for the heartbeat.
+
+    A row that has not yet expired is left alone, so an infra is refreshed at
+    most once per NODE_INFO_CACHE_TTL_SECONDS no matter how many processes
+    read its inventory. That check is one indexed read. Skipped when the user
+    disabled usage collection.
+    """
+    # pylint: disable=import-outside-toplevel
+    from sky.utils.db import kv_cache
+
+    if env_options.Options.DISABLE_LOGGING.get():
+        return
+    key = constants.NODE_INFO_CACHE_KEY_PREFIX + infra
+    try:
+        if kv_cache.get_cache_entry(key) is not None:
+            return
+        kv_cache.add_or_update_cache_entry(
+            key, json.dumps(counts),
+            time.time() + constants.NODE_INFO_CACHE_TTL_SECONDS)
+    except Exception as e:  # pylint: disable=broad-except
+        logger.debug(f'Heartbeat capacity write failed for {infra!r}: {e}')
+
+
+def record_node_info(context: Optional[str],
+                     nodes_info: 'models.KubernetesNodesInfo') -> None:
+    """Record a Kubernetes context's GPU capacity from a fetched inventory.
+
+    Called for every ``get_kubernetes_node_info()`` result, whatever the
+    caller wanted it for — the dashboard, ``sky show-gpus``, provisioning, a
+    plugin's own collection — so on a server that reads node info for any
+    other reason the heartbeat adds no Kubernetes API load of its own.
+
+    InternalRequestDaemon.run_event() sets SKYPILOT_DISABLE_USAGE_COLLECTION
+    process-wide, so node info read inside *other* daemons is not recorded.
+    That is a missed refresh, not an error; the heartbeat fetches on its own
+    when a row is missing.
+    """
+    if env_options.Options.DISABLE_LOGGING.get():
+        return
+    record_gpu_capacity(_k8s_capacity_id(context),
+                        _gpu_capacity_from_nodes(nodes_info))
+
+
+def _fetch_k8s_capacity(context: Optional[str]) -> Dict[str, int]:
+    # pylint: disable=import-outside-toplevel
+    from sky.provision.kubernetes import utils as kubernetes_utils
+    # The query records itself via record_node_info on the way out.
+    return _gpu_capacity_from_nodes(
+        kubernetes_utils.get_kubernetes_node_info(context))
+
+
+def _fetch_slurm_capacity(cluster: str) -> Dict[str, int]:
+    # pylint: disable=import-outside-toplevel
+    from sky.provision.slurm import utils as slurm_utils
+    # get_slurm_nodes_info caches sinfo itself, so this is usually no SSH.
+    counts = _gpu_capacity_from_slurm_nodes(
+        slurm_utils.get_slurm_nodes_info(cluster))
+    record_gpu_capacity(_slurm_capacity_id(cluster), counts)
+    return counts
+
+
+def _collect_gpu_fleet(contexts: List[Optional[str]],
+                       slurm_clusters: List[str]) -> Dict[str, int]:
+    """Sum installed GPU capacity per accelerator type across the fleet.
+
+    Covers every allowed Kubernetes and SSH context and every allowed Slurm
+    cluster. This is capacity, not usage: an idle GPU node counts the same as
+    a busy one. Clusters on cloud VMs have no node inventory to read and do
+    not contribute. Non-GPU accelerators (currently TPUs) are excluded.
+
+    Recorded rows are read in one query; only infras with no unexpired row
+    are queried, in parallel, and each is guarded so an unreachable one drops
+    out of the total for this tick rather than failing the heartbeat.
+    """
+    # pylint: disable=import-outside-toplevel
+    from sky.utils import subprocess_utils
+
+    fetchers: Dict[str, Callable[[], Dict[str, int]]] = {}
+    for context in contexts:
+        fetchers[_k8s_capacity_id(context)] = functools.partial(
+            _fetch_k8s_capacity, context)
+    for cluster in slurm_clusters:
+        fetchers[_slurm_capacity_id(cluster)] = functools.partial(
+            _fetch_slurm_capacity, cluster)
+
+    recorded = _read_all_capacity()
+    misses = [infra for infra in fetchers if infra not in recorded]
+
+    def _fetch(infra: str) -> Dict[str, int]:
+        try:
+            return fetchers[infra]()
+        except Exception as e:  # pylint: disable=broad-except
+            logger.debug(f'Heartbeat GPU fleet skipped {infra!r}: {e}')
+            return {}
+
+    for infra, counts in zip(misses,
+                             subprocess_utils.run_in_parallel(_fetch, misses)):
+        recorded[infra] = counts
+
+    gpus_by_type: Dict[str, int] = {}
+    # Sum only what is configured now; rows for removed infras expire alone.
+    for infra in fetchers:
+        for acc_type, count in recorded.get(infra, {}).items():
+            gpus_by_type[acc_type] = gpus_by_type.get(acc_type, 0) + count
+    return gpus_by_type
+
+
+def _collect_infra_count(
+        k8s_contexts: Optional[Collection[Any]],
+        ssh_contexts: Optional[Collection[Any]],
+        slurm_clusters: Optional[Collection[Any]]) -> Dict[str, int]:
+    """Count how many infrastructures of each kind the server manages.
+
+    Counts what the server is *configured* to use, not what is in use.
+    ``clouds`` excludes the three kinds counted separately. A lookup that
+    failed (None) leaves its key out rather than reporting zero.
+    """
+    # pylint: disable=import-outside-toplevel
+    from sky import clouds as sky_clouds
+    from sky import global_user_state
+    from sky.clouds import cloud as cloud_lib
+
+    def _enabled_clouds() -> Set[str]:
+        # Enabled clouds are cached per workspace, so union across all.
+        workspaces = skypilot_config.get_nested(('workspaces',),
+                                                default_value={})
+        names = set(workspaces) | {skylet_constants.SKYPILOT_DEFAULT_WORKSPACE}
+        separately_counted = (sky_clouds.Kubernetes, sky_clouds.SSH,
+                              sky_clouds.Slurm)
+        enabled: Set[str] = set()
+        for workspace in names:
+            for cloud in global_user_state.get_cached_enabled_clouds(
+                    cloud_lib.CloudCapability.COMPUTE, workspace):
+                if not isinstance(cloud, separately_counted):
+                    enabled.add(cloud.canonical_name())
+        return enabled
+
+    infra_count: Dict[str, int] = {}
+    for key, resolved in (('kubernetes', k8s_contexts),
+                          ('ssh_node_pools', ssh_contexts), ('slurm',
+                                                             slurm_clusters),
+                          ('clouds', _try_list('clouds', _enabled_clouds))):
+        if resolved is not None:
+            infra_count[key] = len(resolved)
+    return infra_count
 
 
 def maybe_show_privacy_policy():

--- a/sky/utils/db/kv_cache.py
+++ b/sky/utils/db/kv_cache.py
@@ -1,6 +1,6 @@
 """Persistent KV cache, backed by a sqlite or postgres database."""
 import time
-from typing import Optional
+from typing import Dict, Optional
 
 import sqlalchemy
 from sqlalchemy import exc as sqlalchemy_exc
@@ -113,6 +113,32 @@ def _escape_like(value: str) -> str:
     """Escape SQL LIKE wildcard characters (%, _) in a literal value."""
     return (value.replace(_LIKE_ESCAPE_CHAR, _LIKE_ESCAPE_CHAR * 2).replace(
         '%', f'{_LIKE_ESCAPE_CHAR}%').replace('_', f'{_LIKE_ESCAPE_CHAR}_'))
+
+
+@metrics_lib.time_me
+def get_cache_entries_by_prefix(prefix: str) -> Dict[str, str]:
+    """Get all unexpired cache entries whose key starts with the given prefix.
+
+    One query for a whole key namespace, for callers that would otherwise
+    issue one ``get_cache_entry`` per key. Any SQL LIKE wildcards (%, _) in
+    *prefix* are escaped so they are matched literally.
+
+    Args:
+        prefix: The literal prefix to match against cache keys.
+
+    Returns:
+        Mapping from full key to value for every matching, unexpired entry.
+    """
+    escaped = _escape_like(prefix)
+    engine = _db_manager.get_engine()
+    with orm.Session(engine) as session:
+        rows = session.execute(
+            sqlalchemy.select(
+                kv_cache_table.c.key, kv_cache_table.c.value).where(
+                    kv_cache_table.c.key.like(
+                        f'{escaped}%', escape=_LIKE_ESCAPE_CHAR)).where(
+                            kv_cache_table.c.expires_at > time.time()))
+        return {key: value for key, value in rows}
 
 
 @metrics_lib.time_me

--- a/tests/unit_tests/test_sky/usage/test_usage_lib.py
+++ b/tests/unit_tests/test_sky/usage/test_usage_lib.py
@@ -1,11 +1,16 @@
 """Unit tests for the per-context behavior of sky.usage.usage_lib.messages."""
 import asyncio
 import contextvars
+import json
+import time
+import types
 
 import pytest
 
+from sky import clouds as sky_clouds
 from sky.usage import usage_lib
 from sky.utils import context
+from sky.utils import env_options
 
 
 def _reset_module_state():
@@ -185,3 +190,279 @@ async def test_install_fresh_messages_isolates_concurrent_tasks(monkeypatch):
 
     assert a == 'task-a', a
     assert b == 'task-b', b
+
+
+def _enable_usage_collection(monkeypatch):
+    """Undo the suite-wide SKYPILOT_DISABLE_USAGE_COLLECTION=1.
+
+    pyproject.toml sets it for every test, and the capacity recorders honour
+    it by recording nothing — so these tests have to opt back in.
+    """
+    monkeypatch.delenv('SKYPILOT_DISABLE_USAGE_COLLECTION', raising=False)
+
+
+class _FakeKvCache:
+    """Dict-backed stand-in for sky.utils.db.kv_cache honouring expires_at."""
+
+    def __init__(self):
+        self.rows = {}
+        self.writes = []
+
+    def get_cache_entry(self, key):
+        row = self.rows.get(key)
+        if row is None or row[1] <= time.time():
+            return None
+        return row[0]
+
+    def add_or_update_cache_entry(self, key, value, expires_at):
+        self.writes.append(key)
+        self.rows[key] = (value, expires_at)
+
+    def get_cache_entries_by_prefix(self, prefix):
+        return {
+            k: v
+            for k, (v, exp) in self.rows.items()
+            if k.startswith(prefix) and exp > time.time()
+        }
+
+    def expire(self, key):
+        value, _ = self.rows[key]
+        self.rows[key] = (value, time.time() - 1)
+
+
+@pytest.fixture
+def capacity_store(monkeypatch):
+    """A heartbeat process with an empty capacity cache and telemetry on."""
+    _reset_module_state()
+    _enable_usage_collection(monkeypatch)
+    fake = _FakeKvCache()
+    monkeypatch.setattr('sky.utils.db.kv_cache.get_cache_entry',
+                        fake.get_cache_entry)
+    monkeypatch.setattr('sky.utils.db.kv_cache.add_or_update_cache_entry',
+                        fake.add_or_update_cache_entry)
+    monkeypatch.setattr('sky.utils.db.kv_cache.get_cache_entries_by_prefix',
+                        fake.get_cache_entries_by_prefix)
+    return fake
+
+
+def _fake_node(acc_type, count):
+    return types.SimpleNamespace(accelerator_type=acc_type,
+                                 total={'accelerator_count': count})
+
+
+def _fake_nodes_info(*nodes):
+    return types.SimpleNamespace(node_info_dict={
+        f'n{i}': n for i, n in enumerate(nodes)
+    })
+
+
+def _fake_slurm_node(node, gres, partition='batch'):
+    return types.SimpleNamespace(node=node, gres=gres, partition=partition)
+
+
+def _k8s_key(context):
+    return (usage_lib.constants.NODE_INFO_CACHE_KEY_PREFIX +
+            usage_lib._k8s_capacity_id(context))
+
+
+def _slurm_key(cluster):
+    return (usage_lib.constants.NODE_INFO_CACHE_KEY_PREFIX +
+            usage_lib._slurm_capacity_id(cluster))
+
+
+def test_collect_gpu_fleet(monkeypatch, capacity_store):
+    """Capacity is summed over Kubernetes, SSH and Slurm node inventory."""
+    per_context = {
+        'ctx-a': _fake_nodes_info(_fake_node('H100', 8), _fake_node('H100', 8),
+                                  _fake_node(None, 0)),
+        # Unreachable context — drops out, does not fail the heartbeat.
+        'ctx-b': None,
+        'ssh-pool': _fake_nodes_info(_fake_node('A100:80GB', 4),
+                                     _fake_node('tpu-v5e-8', 8)),
+    }
+
+    def fake_node_info(context=None):
+        info = per_context[context]
+        if info is None:
+            raise RuntimeError('context unreachable')
+        return info
+
+    monkeypatch.setattr(
+        'sky.provision.kubernetes.utils._get_kubernetes_node_info',
+        fake_node_info)
+    monkeypatch.setattr(
+        'sky.provision.slurm.utils.get_slurm_nodes_info', lambda cluster: [
+            _fake_slurm_node('s1', 'gpu:h100:4'),
+            _fake_slurm_node('s2', 'gpu:2'),
+        ])
+
+    counts = usage_lib._collect_gpu_fleet(['ctx-a', 'ctx-b', 'ssh-pool'],
+                                          ['slurm-a'])
+    assert counts == {'H100': 16, 'A100:80GB': 4, 'h100': 4, 'gpu': 2}
+
+    # Every reachable infra was recorded for the next tick.
+    assert _k8s_key('ctx-a') in capacity_store.rows
+    assert _k8s_key('ssh-pool') in capacity_store.rows
+    assert _slurm_key('slurm-a') in capacity_store.rows
+    assert _k8s_key('ctx-b') not in capacity_store.rows
+
+
+def test_slurm_nodes_are_deduped_across_partitions():
+    """sinfo --Node repeats a node per partition; count it once."""
+    counts = usage_lib._gpu_capacity_from_slurm_nodes([
+        _fake_slurm_node('s1', 'gpu:h100:8', partition='batch'),
+        _fake_slurm_node('s1', 'gpu:h100:8', partition='debug'),
+        _fake_slurm_node('s2', '(null)'),
+    ])
+    assert counts == {'h100': 8}
+
+
+def test_recorded_rows_skip_the_fetch(monkeypatch, capacity_store):
+    """Fresh rows are read in one query and their infras are not fetched."""
+    fetched = []
+
+    def fake_node_info(context=None):
+        fetched.append(context)
+        return _fake_nodes_info(_fake_node('H100', 8))
+
+    monkeypatch.setattr(
+        'sky.provision.kubernetes.utils._get_kubernetes_node_info',
+        fake_node_info)
+
+    # Something else — a dashboard request, say — already recorded ctx-a.
+    usage_lib.record_node_info('ctx-a', _fake_nodes_info(_fake_node('H100', 8)))
+
+    counts = usage_lib._collect_gpu_fleet(['ctx-a', 'ctx-b'], [])
+    assert counts == {'H100': 16}
+    assert fetched == ['ctx-b']
+
+    # Once the row expires the context is fetched again.
+    capacity_store.expire(_k8s_key('ctx-a'))
+    usage_lib._collect_gpu_fleet(['ctx-a'], [])
+    assert fetched == ['ctx-b', 'ctx-a']
+
+
+def test_record_gpu_capacity_leaves_fresh_rows_alone(capacity_store):
+    """A busy node-info reader must not upsert on every call."""
+    counts = {'H100': 8}
+    for _ in range(20):
+        usage_lib.record_gpu_capacity('kubernetes/ctx', counts)
+    assert len(capacity_store.writes) == 1
+
+    capacity_store.expire(_k8s_key('ctx'))
+    usage_lib.record_gpu_capacity('kubernetes/ctx', counts)
+    assert len(capacity_store.writes) == 2
+
+    # Only the derived counts are stored, never the inventory.
+    value, _ = capacity_store.rows[_k8s_key('ctx')]
+    assert json.loads(value) == counts
+
+
+def test_node_info_not_recorded_when_usage_collection_disabled(
+        monkeypatch, capacity_store):
+    """An opted-out server accumulates no capacity state."""
+    monkeypatch.setenv('SKYPILOT_DISABLE_USAGE_COLLECTION', '1')
+    usage_lib.record_node_info('ctx', _fake_nodes_info(_fake_node('H100', 8)))
+    assert not capacity_store.rows
+
+
+def test_enforced_usage_collection_overrides_the_env_var(monkeypatch):
+    """A deployment that pins usage collection on must keep recording.
+
+    An enterprise plugin enforces collection by patching
+    ``env_options.Options.get`` so ``DISABLE_LOGGING`` reads False whatever
+    the environment says. Every opt-out check on the heartbeat path must go
+    through that accessor, never the environment directly, or the plugin's
+    override silently stops applying to the new fields.
+    """
+    _reset_module_state()
+    fake = _FakeKvCache()
+    monkeypatch.setattr('sky.utils.db.kv_cache.get_cache_entry',
+                        fake.get_cache_entry)
+    monkeypatch.setattr('sky.utils.db.kv_cache.add_or_update_cache_entry',
+                        fake.add_or_update_cache_entry)
+
+    # The user opted out...
+    monkeypatch.setenv('SKYPILOT_DISABLE_USAGE_COLLECTION', '1')
+    # ...but the deployment pins collection on, the way the plugin does.
+    original_get = env_options.Options.get
+
+    def _enforced_get(self):
+        if self == env_options.Options.DISABLE_LOGGING:
+            return False
+        return original_get(self)
+
+    monkeypatch.setattr(env_options.Options, 'get', _enforced_get)
+
+    usage_lib.record_node_info('ctx', _fake_nodes_info(_fake_node('H100', 8)))
+    assert _k8s_key('ctx') in fake.rows, 'enforcement must reach recording'
+
+    # And the message itself is still sent.
+    sent = []
+    monkeypatch.setattr(
+        usage_lib.requests, 'post',
+        lambda *a, **k: sent.append(k) or types.SimpleNamespace(status_code=204,
+                                                                text=''))
+    usage_lib._send_to_loki(usage_lib.MessageType.SERVER_HEARTBEAT)
+    assert len(sent) == 1, 'enforcement must reach the Loki send'
+
+
+def test_collect_infra_count(monkeypatch):
+    """Each infra kind is counted; 'clouds' excludes the separate keys."""
+    monkeypatch.setattr('sky.skypilot_config.get_nested',
+                        lambda keys, default_value=None, **kw: {'team-a': {}}
+                        if keys == ('workspaces',) else default_value)
+    # 'kubernetes' and 'slurm' are already counted under their own keys, so
+    # they must not also land in the 'clouds' total.
+    monkeypatch.setattr(
+        'sky.global_user_state.get_cached_enabled_clouds',
+        lambda capability, workspace: [
+            sky_clouds.AWS(),
+            sky_clouds.GCP(),
+            sky_clouds.Kubernetes(),
+            sky_clouds.Slurm(),
+        ])
+
+    infra_count = usage_lib._collect_infra_count(['ctx-a', 'ctx-b', 'ctx-c'],
+                                                 ['ssh-pool'], [])
+    assert infra_count == {
+        'kubernetes': 3,
+        'ssh_node_pools': 1,
+        'slurm': 0,
+        'clouds': 2,
+    }
+
+
+def test_collect_infra_count_omits_failed_lookups(monkeypatch):
+    """A failed lookup (None) drops its key; an empty one reports zero."""
+    monkeypatch.setattr('sky.skypilot_config.get_nested',
+                        lambda keys, default_value=None, **kw: default_value)
+    monkeypatch.setattr('sky.global_user_state.get_cached_enabled_clouds',
+                        lambda capability, workspace: [sky_clouds.AWS()])
+
+    infra_count = usage_lib._collect_infra_count(None, ['ssh-pool'],
+                                                 ['slurm-a'])
+    assert 'kubernetes' not in infra_count
+    assert infra_count == {'ssh_node_pools': 1, 'slurm': 1, 'clouds': 1}
+
+
+def test_plugins_field_is_provider_gated():
+    """'plugins' appears only with a provider; the counts always send."""
+    _reset_module_state()
+    original = dict(usage_lib.ServerHeartbeatMessage._data_providers)
+    usage_lib.ServerHeartbeatMessage._data_providers.clear()
+    try:
+        properties = usage_lib.messages.server_heartbeat.get_properties()
+        assert 'plugins' not in properties
+        # The GPU and infra fields are present regardless.
+        assert properties['total_gpus'] == 0
+        assert properties['gpus_by_type'] == {}
+        assert properties['infra_count'] == {}
+
+        usage_lib.ServerHeartbeatMessage.register_provider(
+            'billing', lambda: {'gpu_inventory': 8})
+        properties = usage_lib.messages.server_heartbeat.get_properties()
+        assert properties['plugins'] == {'billing': {'gpu_inventory': 8}}
+    finally:
+        usage_lib.ServerHeartbeatMessage._data_providers.clear()
+        usage_lib.ServerHeartbeatMessage._data_providers.update(original)


### PR DESCRIPTION
## Summary

Add accelerator capacity and infrastructure counts to the API server heartbeat, including servers without a registered plugin provider.

- Report `total_gpus` and `gpus_by_type` from allowed Kubernetes, SSH, and Slurm node inventories. Despite the GPU-oriented field names, the total includes GPU, TPU, and Neuron device counts; `gpus_by_type` preserves their distinct accelerator types (for example, `H100`, `tpu-v5e-8`, and `TRAINIUM2`). These are raw installed device counts, not equivalent compute capacity, allocation, or utilization. Cloud VM capacity is not included. Preserve unlabeled accelerator capacity under `gpu`. Deduplicate Slurm nodes across partitions.
- Report `infra_count` for Kubernetes contexts, SSH pools, Slurm clusters, and distinct enabled cloud providers. Union infrastructure across configured workspaces, including default, without counting shared contexts twice. Omit an infrastructure count if its lookup fails.
- Reuse capacity recorded by `get_kubernetes_node_info()` in the DB-backed `kv_cache` with a one-hour TTL. The heartbeat fetches missing or expired capacity in parallel. Normal node-info queries still use the existing inventory path; the telemetry cache does not serve scheduling queries.
- Keep the ten-minute heartbeat interval, usage-collection opt-out, and optional plugin payloads. No changes to public logging documentation.

## Tested:

- `PYTHONPATH=. pytest -q -o addopts='' tests/unit_tests/test_sky/usage/test_usage_lib.py`: **19 passed**.
- Regression coverage includes workspace union/deduplication through the sender's serialized payload, failed workspace lookups, unlabeled GPUs, mixed GPU/TPU/Neuron totals and type breakdowns, cache reuse/expiry, Slurm partition deduplication, and optional plugin fields. Infrastructure calls, the capacity DB, and HTTP delivery are mocked in these tests.
- YAPF and isort checks passed for the updated files. Pylint passed for `sky/usage/usage_lib.py` and `sky/provision/kubernetes/utils.py`.
- `format.sh --files ...` completed formatting/import sorting but stopped at local mypy: 11 diagnostics, including missing stubs and errors outside this change. Full-script success is not claimed; updated CI checks are pending.

### Manual server verification plan (not yet run)

1. On an isolated test server, configure two workspaces with distinct and overlapping allowed contexts, then run `sky api start`. Keep usage collection enabled and use a known node inventory as the expected accelerator count, including any TPU and Neuron devices.
2. After a heartbeat interval, inspect that installation's `server_heartbeat` payload in the usage backend. Verify `total_gpus == sum(gpus_by_type.values())`, shared contexts count once, and `infra_count` covers both workspaces. Repeat without a registered provider; the fleet fields should remain and `plugins` should be absent.
3. Run `sky show-gpus --infra kubernetes/<context>` against the server. Inspect `usage/gpu_capacity/` rows in its `kv_cache`: only per-type totals should be stored. Verify the next heartbeat reuses an unexpired row; after expiry it refreshes capacity.
4. Restart the test server with `SKYPILOT_DISABLE_USAGE_COLLECTION=1` in the server environment. Verify it emits no new heartbeat and records no new capacity rows.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10749" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
