### PR TITLE
[Core] Reserve and allocate distinct cloud names before provisioning

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1,5 +1,6 @@
 """Util constants/functions for the backends."""
 import asyncio
+import contextlib
 from datetime import datetime
 import enum
 import fnmatch
@@ -40,6 +41,7 @@ from sky import provision as provision_lib
 from sky import sky_logging
 from sky import skypilot_config
 from sky.adaptors import common as adaptors_common
+from sky.backends import cluster_name as cluster_name_lib
 from sky.jobs import utils as managed_job_utils
 from sky.provision import common as provision_common
 from sky.provision import instance_setup
@@ -763,6 +765,9 @@ def write_cluster_config(
     volume_mounts: Optional[List['volume_utils.VolumeMount']] = None,
     cloud_specific_failover_overrides: Optional[Dict[str, Any]] = None,
     extra_template_variables: Optional[Dict[str, Any]] = None,
+    name_reservation: Optional[contextlib.ExitStack] = None,
+    cloud_user_identity: Optional[List[str]] = None,
+    cluster_name_on_cloud: Optional[str] = None,
 ) -> Dict[str, str]:
     """Fills in cluster configuration templates and writes them out.
 
@@ -792,8 +797,14 @@ def write_cluster_config(
     cloud = to_provision.cloud
     assert cloud is not None, to_provision
 
-    cluster_name_on_cloud = common_utils.make_cluster_name_on_cloud(
-        cluster_name, max_length=cloud.max_cluster_name_length())
+    yaml_path = _get_yaml_path_from_cluster_name(cluster_name)
+    old_yaml_content = global_user_state.get_cluster_yaml_str(yaml_path)
+    if old_yaml_content is not None and keep_launch_fields_in_existing_config:
+        cluster_name_on_cloud = yaml_utils.safe_load(
+            old_yaml_content)['cluster_name']
+    if cluster_name_on_cloud is None:
+        cluster_name_on_cloud = common_utils.make_cluster_name_on_cloud(
+            cluster_name, max_length=cloud.max_cluster_name_length())
 
     # This can raise a ResourcesUnavailableError when:
     #  * The region/zones requested does not appear in the catalog. It can be
@@ -919,8 +930,6 @@ def write_cluster_config(
     private_key_path, _ = auth_utils.get_or_generate_keys()
     auth_config = {'ssh_private_key': private_key_path}
     region_name = resources_vars.get('region')
-
-    yaml_path = _get_yaml_path_from_cluster_name(cluster_name)
 
     # Retrieve the ssh_proxy_command for the given cloud / region.
     ssh_proxy_command_config = skypilot_config.get_effective_region_config(
@@ -1364,10 +1373,24 @@ def write_cluster_config(
             logger.warning(f'Failed to calculate config_hash: {e}')
             logger.debug('Full exception:', exc_info=e)
         return config_dict
+    with open(tmp_yaml_path, 'r', encoding='utf-8') as f:
+        reservation_yaml = f.read()
+    if old_yaml_content is not None and keep_launch_fields_in_existing_config:
+        reservation_yaml = _replace_yaml_dicts(
+            reservation_yaml, old_yaml_content,
+            _RAY_YAML_KEYS_TO_RESTORE_FOR_BACK_COMPATIBILITY,
+            _RAY_YAML_KEYS_TO_RESTORE_EXCEPTIONS)
+    if name_reservation is None:
+        raise ValueError('Provisioning must reserve the cloud name until the '
+                         'initial cluster handle is committed.')
+    name_reservation.enter_context(
+        cluster_name_lib.reserve(cluster_name,
+                                 yaml_utils.safe_load(reservation_yaml), cloud,
+                                 cloud_user_identity))
     _add_auth_to_cluster_config(cloud, tmp_yaml_path)
 
-    # Restore the old yaml content for backward compatibility.
-    old_yaml_content = global_user_state.get_cluster_yaml_str(yaml_path)
+    # Auth setup must precede restoration: it can overwrite persisted SSH
+    # users, keys and proxy commands that existing clusters still require.
     if old_yaml_content is not None and keep_launch_fields_in_existing_config:
         with open(tmp_yaml_path, 'r', encoding='utf-8') as f:
             new_yaml_content = f.read()

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1,4 +1,5 @@
 """Backend: runs on cloud virtual machines, managed by Ray."""
+import contextlib
 import copy
 import dataclasses
 import enum
@@ -40,6 +41,7 @@ from sky import skypilot_config
 from sky import task as task_lib
 from sky.adaptors import common as adaptors_common
 from sky.backends import backend_utils
+from sky.backends import cluster_name as cluster_name_lib
 from sky.backends import task_codegen
 from sky.backends import wheel_utils
 from sky.clouds import cloud as sky_cloud
@@ -1145,128 +1147,146 @@ class RetryingVmProvisioner(object):
 
             for failover_overrides in to_provision.cloud.yield_cloud_specific_failover_overrides(
                     region=to_provision.region):
-                try:
-                    config_dict = backend_utils.write_cluster_config(
-                        to_provision,
-                        num_nodes,
-                        template,
+                with contextlib.ExitStack() as name_reservation:
+                    try:
+                        candidates = cluster_name_lib.candidates(
+                            cluster_name, to_provision.cloud)
+                        for candidate in candidates:
+                            try:
+                                config_dict = backend_utils.write_cluster_config(
+                                    to_provision,
+                                    num_nodes,
+                                    template,
+                                    cluster_name,
+                                    self._local_wheel_path,
+                                    self._wheel_hash,
+                                    region=region,
+                                    zones=zones,
+                                    dryrun=dryrun,
+                                    keep_launch_fields_in_existing_config=
+                                    cluster_exists,
+                                    volume_mounts=volume_mounts,
+                                    cloud_specific_failover_overrides=
+                                    failover_overrides,
+                                    extra_template_variables=extra_vars,
+                                    name_reservation=name_reservation,
+                                    cloud_user_identity=cloud_user_identity,
+                                    cluster_name_on_cloud=candidate,
+                                )
+                                break
+                            except exceptions.ClusterNameCollisionError:
+                                # Re-render name-derived resources before auth.
+                                # Existing mappings are never reassigned.
+                                if cluster_exists or candidate == candidates[-1]:
+                                    raise
+                    except exceptions.ResourcesUnavailableError as e:
+                        # Failed due to catalog issue, e.g. image not found, or
+                        # GPUs are requested in a Kubernetes cluster but the cluster
+                        # does not have nodes labeled with GPU types.
+                        logger.info(f'{e}')
+                        continue
+                    except exceptions.InvalidCloudCredentials as e:
+                        # Failed due to invalid cloud credentials.
+                        logger.warning(f'{common_utils.format_exception(e)}')
+                        # We should block the entire cloud for invalid cloud credentials
+                        _add_to_blocked_resources(
+                            self._blocked_resources,
+                            to_provision.copy(region=None, zone=None))
+                        raise exceptions.ResourcesUnavailableError(
+                            f'Failed to provision on cloud {to_provision.cloud} due to '
+                            f'invalid cloud credentials: '
+                            f'{common_utils.format_exception(e)}')
+                    except exceptions.InvalidCloudConfigs as e:
+                        # Failed due to invalid user configs in ~/.sky/config.yaml.
+                        logger.warning(f'{common_utils.format_exception(e)}')
+                        # We should block the entire cloud if the user config is
+                        # invalid.
+                        _add_to_blocked_resources(
+                            self._blocked_resources,
+                            to_provision.copy(region=None, zone=None))
+                        raise exceptions.ResourcesUnavailableError(
+                            f'Failed to provision on cloud {to_provision.cloud} due to '
+                            f'invalid cloud config: {common_utils.format_exception(e)}'
+                        )
+
+                    if ('config_hash' in config_dict and
+                            skip_if_config_hash_matches
+                            == config_dict['config_hash']):
+                        logger.debug(
+                            'Skipping provisioning of cluster with matching '
+                            'config hash.')
+                        config_dict['provisioning_skipped'] = True
+                        return config_dict
+                    config_dict['provisioning_skipped'] = False
+
+                    if dryrun:
+                        return config_dict
+
+                    cluster_config_file = config_dict['ray']
+
+                    launched_resources = to_provision.copy(region=region.name)
+                    if zones and len(zones) == 1:
+                        launched_resources = launched_resources.copy(
+                            zone=zones[0].name)
+
+                    prev_cluster_ips, prev_ssh_ports, prev_cluster_info = (None,
+                                                                           None,
+                                                                           None)
+                    if prev_handle is not None:
+                        prev_cluster_ips = prev_handle.stable_internal_external_ips
+                        prev_ssh_ports = prev_handle.stable_ssh_ports
+                        prev_cluster_info = prev_handle.cached_cluster_info
+                    # Record early, so if anything goes wrong, 'sky status' will show
+                    # the cluster name and users can appropriately 'sky down'.  It also
+                    # means a second 'sky launch -c <name>' will attempt to reuse.
+                    handle = CloudVmRayResourceHandle(
+                        cluster_name=cluster_name,
+                        # Backward compatibility will be guaranteed by the underlying
+                        # backend_utils.write_cluster_config, which gets the cluster
+                        # name on cloud from the ray yaml file, if the previous cluster
+                        # exists.
+                        cluster_name_on_cloud=config_dict[
+                            'cluster_name_on_cloud'],
+                        cluster_yaml=cluster_config_file,
+                        launched_nodes=num_nodes,
+                        # OK for this to be shown in CLI as status == INIT.
+                        launched_resources=launched_resources,
+                        # Use the previous cluster's IPs and ports if available to
+                        # optimize the case where the cluster is restarted, i.e., no
+                        # need to query IPs and ports from the cloud provider.
+                        stable_internal_external_ips=prev_cluster_ips,
+                        stable_ssh_ports=prev_ssh_ports,
+                        cluster_info=prev_cluster_info,
+                    )
+                    usage_lib.messages.usage.update_final_cluster_status(
+                        status_lib.ClusterStatus.INIT)
+
+                    # Capture the task YAML.
+                    user_specified_task_config = None
+                    if task is not None:
+                        user_specified_task_config = task.to_yaml_config(
+                            use_user_specified_yaml=True)
+
+                    # This sets the status to INIT (even for a normal, UP cluster).
+                    global_user_state.add_or_update_cluster(
                         cluster_name,
-                        self._local_wheel_path,
-                        self._wheel_hash,
-                        region=region,
-                        zones=zones,
-                        dryrun=dryrun,
-                        keep_launch_fields_in_existing_config=cluster_exists,
-                        volume_mounts=volume_mounts,
-                        cloud_specific_failover_overrides=failover_overrides,
-                        extra_template_variables=extra_vars,
-                    )
-                except exceptions.ResourcesUnavailableError as e:
-                    # Failed due to catalog issue, e.g. image not found, or
-                    # GPUs are requested in a Kubernetes cluster but the cluster
-                    # does not have nodes labeled with GPU types.
-                    logger.info(f'{e}')
-                    continue
-                except exceptions.InvalidCloudCredentials as e:
-                    # Failed due to invalid cloud credentials.
-                    logger.warning(f'{common_utils.format_exception(e)}')
-                    # We should block the entire cloud for invalid cloud credentials
-                    _add_to_blocked_resources(
-                        self._blocked_resources,
-                        to_provision.copy(region=None, zone=None))
-                    raise exceptions.ResourcesUnavailableError(
-                        f'Failed to provision on cloud {to_provision.cloud} due to '
-                        f'invalid cloud credentials: '
-                        f'{common_utils.format_exception(e)}')
-                except exceptions.InvalidCloudConfigs as e:
-                    # Failed due to invalid user configs in ~/.sky/config.yaml.
-                    logger.warning(f'{common_utils.format_exception(e)}')
-                    # We should block the entire cloud if the user config is
-                    # invalid.
-                    _add_to_blocked_resources(
-                        self._blocked_resources,
-                        to_provision.copy(region=None, zone=None))
-                    raise exceptions.ResourcesUnavailableError(
-                        f'Failed to provision on cloud {to_provision.cloud} due to '
-                        f'invalid cloud config: {common_utils.format_exception(e)}'
+                        cluster_handle=handle,
+                        requested_resources=requested_resources,
+                        ready=False,
+                        is_managed=self._is_managed,
+                        provision_log_path=log_abs_path,
+                        task_config=user_specified_task_config,
                     )
 
-                if ('config_hash' in config_dict and skip_if_config_hash_matches
-                        == config_dict['config_hash']):
-                    logger.debug(
-                        'Skipping provisioning of cluster with matching '
-                        'config hash.')
-                    config_dict['provisioning_skipped'] = True
-                    return config_dict
-                config_dict['provisioning_skipped'] = False
+                    # Add cluster event for actual provisioning start.
+                    global_user_state.add_cluster_event(
+                        cluster_name, status_lib.ClusterStatus.INIT,
+                        f'Provisioning on {to_provision.cloud.display_name()} '
+                        + f'in {to_provision.region}',
+                        global_user_state.ClusterEventType.STATUS_CHANGE)
 
-                if dryrun:
-                    return config_dict
-
-                cluster_config_file = config_dict['ray']
-
-                launched_resources = to_provision.copy(region=region.name)
-                if zones and len(zones) == 1:
-                    launched_resources = launched_resources.copy(
-                        zone=zones[0].name)
-
-                prev_cluster_ips, prev_ssh_ports, prev_cluster_info = (None,
-                                                                       None,
-                                                                       None)
-                if prev_handle is not None:
-                    prev_cluster_ips = prev_handle.stable_internal_external_ips
-                    prev_ssh_ports = prev_handle.stable_ssh_ports
-                    prev_cluster_info = prev_handle.cached_cluster_info
-                # Record early, so if anything goes wrong, 'sky status' will show
-                # the cluster name and users can appropriately 'sky down'.  It also
-                # means a second 'sky launch -c <name>' will attempt to reuse.
-                handle = CloudVmRayResourceHandle(
-                    cluster_name=cluster_name,
-                    # Backward compatibility will be guaranteed by the underlying
-                    # backend_utils.write_cluster_config, which gets the cluster
-                    # name on cloud from the ray yaml file, if the previous cluster
-                    # exists.
-                    cluster_name_on_cloud=config_dict['cluster_name_on_cloud'],
-                    cluster_yaml=cluster_config_file,
-                    launched_nodes=num_nodes,
-                    # OK for this to be shown in CLI as status == INIT.
-                    launched_resources=launched_resources,
-                    # Use the previous cluster's IPs and ports if available to
-                    # optimize the case where the cluster is restarted, i.e., no
-                    # need to query IPs and ports from the cloud provider.
-                    stable_internal_external_ips=prev_cluster_ips,
-                    stable_ssh_ports=prev_ssh_ports,
-                    cluster_info=prev_cluster_info,
-                )
-                usage_lib.messages.usage.update_final_cluster_status(
-                    status_lib.ClusterStatus.INIT)
-
-                # Capture the task YAML.
-                user_specified_task_config = None
-                if task is not None:
-                    user_specified_task_config = task.to_yaml_config(
-                        use_user_specified_yaml=True)
-
-                # This sets the status to INIT (even for a normal, UP cluster).
-                global_user_state.add_or_update_cluster(
-                    cluster_name,
-                    cluster_handle=handle,
-                    requested_resources=requested_resources,
-                    ready=False,
-                    is_managed=self._is_managed,
-                    provision_log_path=log_abs_path,
-                    task_config=user_specified_task_config,
-                )
-
-                # Add cluster event for actual provisioning start.
-                global_user_state.add_cluster_event(
-                    cluster_name, status_lib.ClusterStatus.INIT,
-                    f'Provisioning on {to_provision.cloud.display_name()} ' +
-                    f'in {to_provision.region}',
-                    global_user_state.ClusterEventType.STATUS_CHANGE)
-
-                global_user_state.set_owner_identity_for_cluster(
-                    cluster_name, cloud_user_identity)
+                    global_user_state.set_owner_identity_for_cluster(
+                        cluster_name, cloud_user_identity)
 
                 if (to_provision.cloud.PROVISIONER_VERSION ==
                         clouds.ProvisionerVersion.SKYPILOT):

--- a/sky/backends/cluster_name.py
+++ b/sky/backends/cluster_name.py
@@ -1,0 +1,127 @@
+"""Reserve cloud resource names before provisioning can adopt resources."""
+import contextlib
+import hashlib
+import json
+from typing import Any, Dict, Iterator, List, Optional, Tuple
+
+from sky import clouds
+from sky import exceptions
+from sky import global_user_state
+from sky.utils import common_utils
+from sky.utils import locks
+from sky.utils import yaml_utils
+
+
+def candidates(display_name: str, cloud: clouds.Cloud) -> List[str]:
+    """Keep live mappings; offer bounded alternatives only for new mappings."""
+    handle = global_user_state.get_handle_from_cluster_name(display_name)
+    if (handle is not None and
+            cloud.is_same_cloud(handle.launched_resources.cloud)):
+        return [handle.cluster_name_on_cloud]
+
+    max_length = cloud.max_cluster_name_length()
+    names = [common_utils.make_cluster_name_on_cloud(display_name, max_length)]
+    prefix = common_utils.make_cluster_name_on_cloud(display_name,
+                                                     max_length=None,
+                                                     add_user_hash=False)
+    user_hash = common_utils.get_user_hash()
+    # Retain the user suffix, including on clouds with short name limits.
+    hash_length = 8 if max_length is None else min(
+        8, max_length - len(user_hash) - 3)
+    assert hash_length > 0, (display_name, max_length)
+    for attempt in range(8):
+        digest = hashlib.sha256(
+            f'{display_name}:{user_hash}:{attempt}'.encode()).hexdigest()
+        suffix = f'-{digest[:hash_length]}-{user_hash}'
+        shortened = (prefix if max_length is None else
+                     prefix[:max_length - len(suffix)].rstrip('-'))
+        names.append(shortened + suffix)
+    return names
+
+
+def _namespace(cloud: Optional[clouds.Cloud], provider: Dict[str, Any],
+               owner: Optional[List[str]]) -> Tuple[Optional[str], ...]:
+    if cloud is None:
+        return (None,)
+    if isinstance(cloud, clouds.Azure):
+        subscription = provider.get('subscription_id')
+        resource_group = provider.get('resource_group')
+        return ('azure', subscription.lower() if subscription else None,
+                resource_group.lower() if resource_group else None)
+    if isinstance(cloud, clouds.GCP):
+        return ('gcp', provider.get('project_id'))
+    if isinstance(cloud, clouds.Kubernetes):
+        # Different contexts (and API URLs) may address the same cluster.
+        # Without an authoritative cluster identity, only namespaces prove
+        # that identically named pods cannot be the same resource.
+        # An omitted namespace is resolved from kubeconfig, not necessarily
+        # "default", so leave it unknown here.
+        return ('kubernetes', provider.get('namespace'))
+    if isinstance(cloud, clouds.AWS):
+        return ('aws', owner[-1] if owner else None, provider.get('region'))
+    return (cloud.canonical_name(),)
+
+
+@contextlib.contextmanager
+def reserve(cluster_name: str, config: Dict[str, Any], cloud: clouds.Cloud,
+            owner: Optional[List[str]]) -> Iterator[None]:
+    """Reject another live cluster's cloud name while its INIT row is saved.
+
+    The caller must keep this context open until add_or_update_cluster()
+    commits the initial handle. Existing INIT and STOPPED rows reserve names;
+    terminated history does not. The lock covers namespaces conservatively so
+    missing legacy account metadata cannot let concurrent callers bypass it.
+    This protects launches sharing one SkyPilot state database.
+
+    Args:
+        cluster_name: Logical cluster being launched or resumed.
+        config: Resolved configuration, including persisted launch fields.
+        cloud: The cloud being provisioned.
+        owner: Native cloud identity for the provision attempt.
+
+    Raises:
+        ClusterNameCollisionError: Another live logical cluster owns the name.
+        ExecutionPausedError: A concurrent launch is reserving the same name.
+    """
+    cloud_name: str = config['cluster_name']
+    provider: Dict[str, Any] = config['provider']
+    namespace = _namespace(cloud, provider, owner)
+    lock_key = json.dumps([namespace[0], cloud_name])
+    lock_id = 'cloud-name-' + hashlib.sha256(lock_key.encode()).hexdigest()
+    lock = locks.get_lock(lock_id)
+    try:
+        lock.acquire(blocking=not common_utils.is_in_request_context())
+    except locks.LockTimeout as error:
+        raise exceptions.ExecutionPausedError(
+            f'Cloud name {cloud_name!r} is being reserved by another launch.',
+            hint='Waiting for the concurrent cluster reservation to finish.',
+            retry_wait_seconds=1,
+            continue_condition=locks.LockAcquirableCondition(
+                lock_id)) from error
+    try:
+        for record in global_user_state.get_cluster_name_reservations():
+            if record['name'] == cluster_name:
+                continue
+            handle = record['handle']
+            if getattr(handle, 'cluster_name_on_cloud', None) != cloud_name:
+                continue
+            yaml = record['yaml']
+            if yaml is None:
+                yaml = global_user_state.get_cluster_yaml_str(
+                    handle.cluster_yaml)
+            if yaml is not None:
+                existing = yaml_utils.safe_load(yaml)
+                resources = getattr(handle, 'launched_resources', None)
+                existing_namespace = _namespace(
+                    getattr(resources, 'cloud', None), existing['provider'],
+                    record['owner'])
+                if any(left is not None and right is not None and left != right
+                       for left, right in zip(namespace, existing_namespace)):
+                    continue
+            raise exceptions.ClusterNameCollisionError(
+                f'Cluster {cluster_name!r} maps to cloud name {cloud_name!r}, '
+                f'which is already used by cluster {record["name"]!r}. '
+                'Choose a different cluster name.')
+        yield
+    finally:
+        lock.release()

--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -474,6 +474,10 @@ class ManagedJobUserCancelledError(Exception):
     pass
 
 
+class ClusterNameCollisionError(ValueError):
+    """Another live cluster owns the resolved cloud resource name."""
+
+
 class InvalidClusterNameError(Exception):
     """Raised when the cluster name is invalid."""
     pass

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -776,7 +776,9 @@ def launch(
     Args:
         task: sky.Task, or sky.Dag (experimental; 1-task only) to launch.
         cluster_name: name of the cluster to create/reuse.  If None,
-            auto-generate a name.
+            auto-generate a name. New clusters receive a distinct cloud name
+            if normalization or truncation conflicts with another live cluster
+            in this SkyPilot state database. Existing cloud names are preserved.
         retry_until_up: whether to retry launching the cluster until it is
             up.
         idle_minutes_to_autostop: automatically stop the cluster after this
@@ -812,6 +814,8 @@ def launch(
         exceptions.ClusterOwnerIdentityMismatchError: if the cluster is
             owned by another user.
         exceptions.InvalidClusterNameError: if the cluster name is invalid.
+        exceptions.ClusterNameCollisionError: if an existing cloud name is
+            ambiguous or no unused name can be allocated for a new cluster.
         exceptions.ResourcesMismatchError: if the requested resources
             do not match the existing cluster.
         exceptions.NotSupportedError: if required features are not supported

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -2411,6 +2411,23 @@ def cluster_with_name_exists(cluster_name: str) -> bool:
 
 
 @metrics_lib.time_me
+def get_cluster_name_reservations() -> List[Dict[str, Any]]:
+    """Return live cluster handles and their persisted provisioning scope."""
+    with orm.Session(_db_manager.get_engine()) as session:
+        rows = session.query(cluster_table.c.name, cluster_table.c.handle,
+                             cluster_table.c.owner,
+                             cluster_yaml_table.c.yaml).outerjoin(
+                                 cluster_yaml_table, cluster_table.c.name ==
+                                 cluster_yaml_table.c.cluster_name).all()
+    return [{
+        'name': row.name,
+        'handle': pickle.loads(row.handle),
+        'owner': json.loads(row.owner) if row.owner is not None else None,
+        'yaml': row.yaml,
+    } for row in rows]
+
+
+@metrics_lib.time_me
 def get_clusters(
     *,  # keyword only separator
     exclude_managed_clusters: bool = False,

--- a/sky/jobs/recovery_strategy.py
+++ b/sky/jobs/recovery_strategy.py
@@ -54,6 +54,7 @@ logger = sky_logging.init_logger(__name__)
 # the job with FAILED_PRECHECKS instead of entering the retry loop, so a job
 # does not sit there re-attempting something only an operator can resolve.
 PRECHECK_FAILURES = (
+    exceptions.ClusterNameCollisionError,
     exceptions.InvalidClusterNameError,
     exceptions.NoCloudAccessError,
     exceptions.ResourcesMismatchError,

--- a/tests/unit_tests/test_cluster_name_reservation.py
+++ b/tests/unit_tests/test_cluster_name_reservation.py
@@ -1,0 +1,567 @@
+import concurrent.futures
+import contextlib
+import pathlib
+import threading
+from types import SimpleNamespace
+from typing import Any, Callable, ContextManager, Dict, Iterator, List, Optional
+from unittest import mock
+
+import pytest
+import sqlalchemy
+
+from sky import clouds
+from sky import exceptions
+from sky import global_user_state
+from sky import models
+from sky import skypilot_config
+from sky.backends import backend_utils
+from sky.backends import cloud_vm_ray_backend
+from sky.backends import cluster_name
+from sky.resources import Resources
+from sky.utils import common_utils
+from sky.utils import locks
+from sky.utils import registry
+from sky.utils import status_lib
+from sky.utils import yaml_utils
+
+
+@pytest.fixture
+def state(tmp_path: pathlib.Path,
+          monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    engine = sqlalchemy.create_engine(f'sqlite:///{tmp_path}/state.db')
+    monkeypatch.setattr(global_user_state._db_manager, 'get_engine',
+                        lambda: engine)
+    global_user_state.create_table(engine)
+    monkeypatch.setattr(locks, 'SKY_LOCKS_DIR', str(tmp_path / 'locks'))
+    monkeypatch.setattr(locks, '_detect_lock_type', lambda: 'filelock')
+    monkeypatch.setattr(common_utils, 'is_in_request_context', lambda: False)
+    monkeypatch.setattr(common_utils, 'get_current_user',
+                        lambda: models.User('test-user', 'test'))
+    monkeypatch.setattr(common_utils, 'get_user_hash', lambda: 'test-user')
+    monkeypatch.setattr(skypilot_config, 'get_active_workspace',
+                        lambda: 'default')
+    yield
+    engine.dispose()
+
+
+def config(name: str = 'my-cluster-test-user',
+           **provider: Any) -> Dict[str, Any]:
+    return {
+        'cluster_name': name,
+        'auth': {
+            'ssh_user': 'test-user'
+        },
+        'provider': {
+            'module': 'sky.provision.azure',
+            'subscription_id': 'account',
+            'resource_group': 'workers',
+            **provider,
+        },
+    }
+
+
+def cloud_for(rendered: Dict[str, Any]) -> clouds.Cloud:
+    provider = rendered['provider']
+    name = provider.get('module', provider.get('type')).split('.')[-1]
+    return registry.CLOUD_REGISTRY.from_str(name)
+
+
+def reserve(name: str, rendered: Dict[str, Any],
+            owner: Optional[List[str]]) -> ContextManager[None]:
+    return cluster_name.reserve(name, rendered, cloud_for(rendered), owner)
+
+
+def save_cluster(name: str,
+                 rendered: Dict[str, Any],
+                 ready: bool = False,
+                 owner: Optional[List[str]] = None) -> None:
+    handle = SimpleNamespace(
+        cluster_name=name,
+        cluster_name_on_cloud=rendered['cluster_name'],
+        cluster_yaml=f'/unused/{name}.yml',
+        launched_resources=SimpleNamespace(cloud=cloud_for(rendered),
+                                           region='eastus',
+                                           zone=None),
+    )
+    global_user_state.set_cluster_yaml(name, yaml_utils.dump_yaml_str(rendered))
+    global_user_state.add_or_update_cluster(name, handle, None, ready=ready)
+    global_user_state.set_owner_identity_for_cluster(name, owner)
+
+
+@pytest.mark.parametrize('status', [
+    status_lib.ClusterStatus.INIT, status_lib.ClusterStatus.UP,
+    status_lib.ClusterStatus.STOPPED
+])
+def test_live_status_reserves_cloud_name(
+        state: None, status: status_lib.ClusterStatus) -> None:
+    rendered = config()
+    save_cluster('my-cluster',
+                 rendered,
+                 ready=status == status_lib.ClusterStatus.UP)
+    if status == status_lib.ClusterStatus.STOPPED:
+        global_user_state.remove_cluster('my-cluster', terminate=False)
+    with pytest.raises(exceptions.ClusterNameCollisionError,
+                       match='my-cluster'):
+        with reserve('my_cluster', rendered, None):
+            pytest.fail('Collision reached provisioning')
+    assert global_user_state.get_cluster_from_name('my_cluster') is None
+    assert global_user_state.get_cluster_from_name(
+        'my-cluster')['status'] == status
+
+
+def test_same_logical_cluster_preserves_persisted_name(state: None) -> None:
+    rendered = config('persisted-name-from-an-older-release')
+    save_cluster('My.Cluster', rendered)
+    with reserve('My.Cluster', rendered, None):
+        save_cluster('My.Cluster', rendered, ready=True)
+    handle = global_user_state.get_handle_from_cluster_name('My.Cluster')
+    assert handle.cluster_name_on_cloud == rendered['cluster_name']
+
+
+def test_terminated_history_does_not_reserve_name(state: None) -> None:
+    rendered = config()
+    save_cluster('my-cluster', rendered, ready=True)
+    global_user_state.remove_cluster('my-cluster', terminate=True)
+    assert global_user_state.get_cluster_yaml_str('/unused/my-cluster.yml')
+    with reserve('my_cluster', rendered, None):
+        save_cluster('my_cluster', rendered)
+
+
+@pytest.mark.parametrize('provider,other,owner,other_owner', [
+    ({}, {
+        'resource_group': 'other-workers'
+    }, None, None),
+    ({}, {
+        'subscription_id': 'other-account'
+    }, None, None),
+    ({
+        'module': 'sky.provision.gcp',
+        'project_id': 'a'
+    }, {
+        'module': 'sky.provision.gcp',
+        'project_id': 'b'
+    }, None, None),
+    ({
+        'module': 'sky.provision.kubernetes',
+        'context': 'ctx',
+        'namespace': 'a'
+    }, {
+        'module': 'sky.provision.kubernetes',
+        'context': 'ctx',
+        'namespace': 'b'
+    }, None, None),
+    ({
+        'module': 'sky.provision.aws',
+        'region': 'us-east-1'
+    }, {
+        'module': 'sky.provision.aws',
+        'region': 'us-east-1'
+    }, ['principal-a', 'a'], ['principal-b', 'b']),
+    ({
+        'module': 'sky.provision.aws',
+        'region': 'us-east-1'
+    }, {
+        'module': 'sky.provision.aws',
+        'region': 'us-west-2'
+    }, ['principal', 'a'], ['principal', 'a']),
+])
+def test_disjoint_provider_namespaces(state: None, provider: Dict[str, Any],
+                                      other: Dict[str, Any],
+                                      owner: Optional[List[str]],
+                                      other_owner: Optional[List[str]]) -> None:
+    save_cluster('first', config(**provider), owner=owner)
+    with reserve('second', config(**other), other_owner):
+        save_cluster('second', config(**other), owner=other_owner)
+
+
+def test_same_aws_account_different_principal_collides(state: None) -> None:
+    rendered = config(module='sky.provision.aws', region='us-east-1')
+    save_cluster('first', rendered, owner=['role-a', 'account'])
+    with pytest.raises(exceptions.ClusterNameCollisionError):
+        with reserve('second', rendered, ['role-b', 'account']):
+            pytest.fail('Principal changes must not bypass account ownership')
+
+
+def test_kubernetes_context_aliases_do_not_prove_disjoint_namespaces(
+        state: None) -> None:
+    save_cluster(
+        'first',
+        config(module='sky.provision.kubernetes', context='a',
+               namespace='same'))
+    with pytest.raises(exceptions.ClusterNameCollisionError):
+        with reserve(
+                'second',
+                config(module='sky.provision.kubernetes',
+                       context='b',
+                       namespace='same'), None):
+            pytest.fail('Kubeconfig contexts may refer to the same cluster')
+
+
+def test_missing_legacy_namespace_fails_closed(state: None) -> None:
+    save_cluster('first', config(subscription_id=None, resource_group=None))
+    with pytest.raises(exceptions.ClusterNameCollisionError):
+        with reserve('second', config(), None):
+            pytest.fail('Missing metadata cannot prove a different namespace')
+
+
+def test_omitted_kubernetes_namespace_is_not_assumed_default(
+        state: None) -> None:
+    save_cluster('first', config(module='sky.provision.kubernetes',
+                                 context='a'))
+    with pytest.raises(exceptions.ClusterNameCollisionError):
+        with reserve(
+                'second',
+                config(module='sky.provision.kubernetes',
+                       context='b',
+                       namespace='workers'), None):
+            pytest.fail('An omitted namespace may resolve to workers')
+
+
+def test_legacy_provider_spelling_and_azure_case_collide(state: None) -> None:
+    save_cluster(
+        'first',
+        config(module='azure',
+               resource_group='WORKERS',
+               subscription_id='ACCOUNT'))
+    with pytest.raises(exceptions.ClusterNameCollisionError):
+        with reserve('second', config(), None):
+            pytest.fail('Provider aliases must use the same namespace')
+
+
+def test_concurrent_reservation_commits_before_contender_checks(
+        state: None) -> None:
+    entered = threading.Event()
+    release = threading.Event()
+    contender_started = threading.Event()
+    rendered = config()
+
+    def first() -> None:
+        with reserve('my-cluster', rendered, None):
+            entered.set()
+            assert release.wait(5)
+            save_cluster('my-cluster', rendered)
+
+    def second() -> None:
+        assert entered.wait(5)
+        contender_started.set()
+        with pytest.raises(exceptions.ClusterNameCollisionError):
+            with reserve('my_cluster', rendered, None):
+                pytest.fail('Concurrent launch adopted the first reservation')
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        winner = executor.submit(first)
+        contender = executor.submit(second)
+        assert contender_started.wait(5)
+        release.set()
+        winner.result(timeout=5)
+        contender.result(timeout=5)
+    assert global_user_state.get_cluster_from_name('my_cluster') is None
+
+
+def test_reservation_exception_releases_lock_without_persisting(
+        state: None) -> None:
+    rendered = config()
+    with pytest.raises(RuntimeError, match='before INIT'):
+        with reserve('first', rendered, None):
+            raise RuntimeError('before INIT')
+    with reserve('second', rendered, None):
+        save_cluster('second', rendered)
+
+
+def test_exit_stack_holds_reservation_until_init_commit(
+        state: None, monkeypatch: pytest.MonkeyPatch) -> None:
+    rendered = config()
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(reserve('first', rendered, None))
+        monkeypatch.setattr(common_utils, 'is_in_request_context', lambda: True)
+        with pytest.raises(exceptions.ExecutionPausedError) as paused:
+            with reserve('second', rendered, None):
+                pytest.fail('Contender acquired an unfinished reservation')
+        assert isinstance(paused.value.continue_condition,
+                          locks.LockAcquirableCondition)
+        save_cluster('first', rendered)
+    with pytest.raises(exceptions.ClusterNameCollisionError):
+        with reserve('second', rendered, None):
+            pytest.fail('Committed INIT name is still reserved')
+
+
+@pytest.mark.parametrize('first,second,user', [
+    ('My-Cluster', 'my_cluster', 'test-user'),
+    ('my.cluster', 'my-cluster', 'test-user'),
+    ('managed-job-collision-0007-7', 'managed-job-collision-0017-17',
+     'sa-0000000000000000'),
+])
+def test_native_normalization_and_truncation_hash_collision(
+        state: None, monkeypatch: pytest.MonkeyPatch, first: str, second: str,
+        user: str) -> None:
+    monkeypatch.setattr(common_utils, 'get_user_hash', lambda: user)
+    first_cloud = common_utils.make_cluster_name_on_cloud(first, max_length=42)
+    second_cloud = common_utils.make_cluster_name_on_cloud(second,
+                                                           max_length=42)
+    assert first_cloud == second_cloud
+    save_cluster(first, config(first_cloud))
+    with pytest.raises(exceptions.ClusterNameCollisionError):
+        with reserve(second, config(second_cloud), None):
+            pytest.fail('Native alias must be rejected')
+
+
+@pytest.fixture
+def write_config(
+        state: None, tmp_path: pathlib.Path,
+        monkeypatch: pytest.MonkeyPatch) -> Callable[..., Dict[str, Any]]:
+    monkeypatch.setattr(Resources, 'make_deploy_variables',
+                        lambda *args, **kwargs: {})
+    monkeypatch.setattr(backend_utils.sky_check,
+                        'get_cloud_credential_file_mounts', lambda *args: {})
+    monkeypatch.setattr(backend_utils.auth_utils, 'get_or_generate_keys',
+                        lambda: ('/unused/private-key', '/unused/public-key'))
+    monkeypatch.setattr(backend_utils, '_get_yaml_path_from_cluster_name',
+                        lambda name: str(tmp_path / f'{name}.yml'))
+    monkeypatch.setattr(backend_utils, '_optimize_file_mounts',
+                        lambda path: None)
+    monkeypatch.setattr(backend_utils, '_deterministic_cluster_yaml_hash',
+                        lambda path: 'hash')
+    monkeypatch.setattr(backend_utils.usage_lib.messages.usage,
+                        'update_ray_yaml', lambda path: None)
+
+    def fill_template(template: str, variables: Dict[str, Any],
+                      output_path: str) -> None:
+        rendered = config(variables['cluster_name_on_cloud'])
+        rendered['auth'] = {'ssh_user': 'rendered-user'}
+        yaml_utils.dump_yaml(output_path, rendered)
+
+    monkeypatch.setattr(common_utils, 'fill_template', fill_template)
+
+    def write(name: str, stack: contextlib.ExitStack,
+              **kwargs: Any) -> Dict[str, Any]:
+        return backend_utils.write_cluster_config(Resources(
+            cloud=clouds.Azure(), instance_type='test'),
+                                                  1,
+                                                  'unused-template',
+                                                  name,
+                                                  pathlib.Path('/unused/wheel'),
+                                                  'wheel-hash',
+                                                  clouds.Region('eastus'),
+                                                  name_reservation=stack,
+                                                  **kwargs)
+
+    return write
+
+
+def test_config_collision_precedes_auth_and_yaml_commit(
+        write_config: Callable[..., Dict[str, Any]],
+        monkeypatch: pytest.MonkeyPatch) -> None:
+    native_name = common_utils.make_cluster_name_on_cloud('my-cluster', 42)
+    save_cluster('my-cluster', config(native_name))
+    auth = mock.Mock()
+    monkeypatch.setattr(backend_utils, '_add_auth_to_cluster_config', auth)
+    with contextlib.ExitStack() as stack:
+        with pytest.raises(exceptions.ClusterNameCollisionError):
+            write_config('my_cluster', stack)
+    auth.assert_not_called()
+    assert global_user_state.get_cluster_yaml_str(
+        '/unused/my_cluster.yml') is None
+    assert global_user_state.get_cluster_from_name('my_cluster') is None
+
+
+def test_existing_config_preserves_auth_after_auth_setup(
+        write_config: Callable[..., Dict[str, Any]],
+        monkeypatch: pytest.MonkeyPatch) -> None:
+    persisted = config('persisted-name')
+    persisted['auth'] = {
+        'ssh_user': 'existing-user',
+        'ssh_private_key': '/existing/private-key',
+        'ssh_proxy_command': 'existing-proxy %h %p',
+    }
+    save_cluster('existing', persisted)
+
+    def change_auth(cloud: clouds.Cloud, path: str) -> None:
+        rendered = yaml_utils.read_yaml(path)
+        rendered['auth'] = {
+            'ssh_user': 'new-user',
+            'ssh_private_key': '/new/private-key',
+            'ssh_proxy_command': 'new-proxy %h %p'
+        }
+        yaml_utils.dump_yaml(path, rendered)
+
+    monkeypatch.setattr(backend_utils, '_add_auth_to_cluster_config',
+                        change_auth)
+    with contextlib.ExitStack() as stack:
+        result = write_config('existing', stack)
+        restored = yaml_utils.safe_load(
+            global_user_state.get_cluster_yaml_str(result['ray']))
+        assert restored['cluster_name'] == persisted['cluster_name']
+        assert restored['auth'] == persisted['auth']
+
+
+@pytest.fixture
+def provision(write_config: Callable[..., Dict[str,
+                                               Any]], tmp_path: pathlib.Path,
+              monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
+    monkeypatch.setattr(Resources, 'assert_launchable', lambda self: self)
+    monkeypatch.setattr(clouds.Azure, 'check_quota_available',
+                        lambda *args: True)
+    monkeypatch.setattr(clouds.Azure, 'make_deploy_resources_variables',
+                        lambda *args: {})
+    monkeypatch.setattr(cloud_vm_ray_backend.provision_lib,
+                        'get_registered_provisioner', lambda cloud: None)
+    monkeypatch.setattr(cloud_vm_ray_backend.RetryingVmProvisioner,
+                        '_yield_zones', lambda *args: iter([None]))
+    auth = mock.Mock()
+    bulk = mock.Mock()
+    cleanup = mock.Mock()
+    monkeypatch.setattr(backend_utils, '_add_auth_to_cluster_config', auth)
+    monkeypatch.setattr(cloud_vm_ray_backend.provisioner, 'bulk_provision',
+                        bulk)
+    monkeypatch.setattr(cloud_vm_ray_backend.CloudVmRayBackend,
+                        'post_teardown_cleanup', cleanup)
+    provisioner = cloud_vm_ray_backend.RetryingVmProvisioner(
+        str(tmp_path / 'logs'),
+        None,
+        None,
+        set(),
+        pathlib.Path('/unused/wheel'),
+        'wheel-hash',
+        is_managed=False,
+        extra_launch_context={})
+
+    def launch(name: str, existing: bool = False) -> Dict[str, Any]:
+        resources = Resources(cloud=clouds.Azure(),
+                              instance_type='test',
+                              region='eastus')
+        previous = (global_user_state.get_handle_from_cluster_name(name)
+                    if existing else None)
+        return provisioner._retry_zones(
+            resources, 1, {resources}, False, False, name, None,
+            status_lib.ClusterStatus.INIT if existing else None, previous,
+            False, None, None, None)
+
+    return SimpleNamespace(launch=launch, auth=auth, bulk=bulk, cleanup=cleanup)
+
+
+@pytest.mark.parametrize('first,second,user', [
+    ('My-Cluster', 'my_cluster', 'test-user'),
+    ('managed-job-collision-0007-7', 'managed-job-collision-0017-17',
+     'sa-0000000000000000'),
+])
+def test_new_colliding_launches_allocate_and_persist_distinct_names(
+        provision: SimpleNamespace, monkeypatch: pytest.MonkeyPatch, first: str,
+        second: str, user: str) -> None:
+    monkeypatch.setattr(common_utils, 'get_user_hash', lambda: user)
+    one = provision.launch(first)
+    two = provision.launch(second)
+    assert one['cluster_name_on_cloud'] != two['cluster_name_on_cloud']
+    assert one[
+        'cluster_name_on_cloud'] == common_utils.make_cluster_name_on_cloud(
+            first, 42)
+    assert len(two['cluster_name_on_cloud']) <= 42
+    assert two['cluster_name_on_cloud'].endswith('-' + user)
+    # The rejected candidate must not reach authentication or provisioning.
+    assert provision.auth.call_count == provision.bulk.call_count == 2
+    provision.cleanup.assert_not_called()
+    assert cluster_name.candidates(
+        second, clouds.Azure()) == [two['cluster_name_on_cloud']]
+
+    monkeypatch.setattr(common_utils, 'get_user_hash', lambda: 'another-user')
+    retry = provision.launch(second, existing=True)
+    assert retry['cluster_name_on_cloud'] == two['cluster_name_on_cloud']
+    persisted = yaml_utils.safe_load(
+        global_user_state.get_cluster_yaml_str(retry['ray']))
+    assert persisted['cluster_name'] == two['cluster_name_on_cloud']
+
+
+def test_allocation_exhaustion_precedes_every_cloud_mutator(
+        provision: SimpleNamespace) -> None:
+    for i, name in enumerate(
+            cluster_name.candidates('new-cluster', clouds.Azure())):
+        save_cluster(f'owner-{i}', config(name))
+    with pytest.raises(exceptions.ClusterNameCollisionError):
+        provision.launch('new-cluster')
+    provision.auth.assert_not_called()
+    provision.bulk.assert_not_called()
+    provision.cleanup.assert_not_called()
+    assert global_user_state.get_cluster_from_name('new-cluster') is None
+    assert global_user_state.get_cluster_yaml_str(
+        '/unused/new-cluster.yml') is None
+
+
+def test_concurrent_launches_allocate_distinct_committed_handles(
+        provision: SimpleNamespace, monkeypatch: pytest.MonkeyPatch) -> None:
+    first_render = threading.Barrier(2)
+    fill_template = common_utils.fill_template
+    default_name = common_utils.make_cluster_name_on_cloud('my-cluster', 42)
+
+    def synchronized_template(template: str, variables: Dict[str, Any],
+                              output_path: str) -> None:
+        fill_template(template, variables, output_path)
+        if variables['cluster_name_on_cloud'] == default_name:
+            first_render.wait(timeout=5)
+
+    monkeypatch.setattr(common_utils, 'fill_template', synchronized_template)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        first = executor.submit(provision.launch, 'my-cluster')
+        second = executor.submit(provision.launch, 'my_cluster')
+        results = [first.result(timeout=10), second.result(timeout=10)]
+    names = {result['cluster_name_on_cloud'] for result in results}
+    assert len(names) == 2
+    assert default_name in names
+    assert {
+        global_user_state.get_handle_from_cluster_name(
+            name).cluster_name_on_cloud for name in ('my-cluster', 'my_cluster')
+    } == names
+    assert {
+        call.args[3].name_on_cloud for call in provision.bulk.call_args_list
+    } == names
+    assert provision.auth.call_count == provision.bulk.call_count == 2
+    provision.cleanup.assert_not_called()
+
+
+def test_constant_custom_template_exhausts_before_cloud_mutation(
+        provision: SimpleNamespace, monkeypatch: pytest.MonkeyPatch) -> None:
+    save_cluster('victim', config('constant-cloud-name'))
+    fill_template = common_utils.fill_template
+    renders = 0
+
+    def constant_template(template: str, variables: Dict[str, Any],
+                          output_path: str) -> None:
+        nonlocal renders
+        renders += 1
+        fill_template(template, variables, output_path)
+        rendered = yaml_utils.read_yaml(output_path)
+        rendered['cluster_name'] = 'constant-cloud-name'
+        yaml_utils.dump_yaml(output_path, rendered)
+
+    monkeypatch.setattr(common_utils, 'fill_template', constant_template)
+    with pytest.raises(exceptions.ClusterNameCollisionError):
+        provision.launch('new-cluster')
+    assert renders == 9
+    provision.auth.assert_not_called()
+    provision.bulk.assert_not_called()
+    provision.cleanup.assert_not_called()
+    assert global_user_state.get_cluster_from_name('new-cluster') is None
+
+
+def test_existing_collision_cannot_allocate_away_from_persisted_resources(
+        provision: SimpleNamespace) -> None:
+    name = common_utils.make_cluster_name_on_cloud('first', 42)
+    save_cluster('first', config(name))
+    save_cluster('second', config(name))
+    with pytest.raises(exceptions.ClusterNameCollisionError):
+        provision.launch('second', existing=True)
+    provision.auth.assert_not_called()
+    provision.bulk.assert_not_called()
+    provision.cleanup.assert_not_called()
+
+
+@pytest.mark.parametrize('maximum', [15, 35, 42, None])
+def test_alternative_names_respect_provider_limits(
+        state: None, monkeypatch: pytest.MonkeyPatch,
+        maximum: Optional[int]) -> None:
+    monkeypatch.setattr(clouds.Azure, 'max_cluster_name_length',
+                        lambda self: maximum)
+    monkeypatch.setattr(common_utils, 'get_user_hash', lambda: '12345678')
+    names = cluster_name.candidates('my-cluster-with-a-long-name',
+                                    clouds.Azure())
+    assert len(set(names)) == 9
+    assert all(name.endswith('-12345678') for name in names)
+    assert maximum is None or all(len(name) <= maximum for name in names)

--- a/tests/unit_tests/test_sky/jobs/test_recovery_strategy.py
+++ b/tests/unit_tests/test_sky/jobs/test_recovery_strategy.py
@@ -274,6 +274,27 @@ def _patch_launch_environment(monkeypatch):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize('raise_on_failure', [True, False])
+async def test_cloud_name_collision_never_cleans_up_or_retries(
+        monkeypatch: pytest.MonkeyPatch, raise_on_failure: bool) -> None:
+    executor = _make_launch_executor()
+    patches = _patch_launch_environment(monkeypatch)
+    collision = exceptions.ClusterNameCollisionError('Already owned')
+    executor._await_launch_request = mock.AsyncMock(side_effect=collision)
+
+    if raise_on_failure:
+        with pytest.raises(exceptions.ProvisionPrechecksError) as error:
+            await executor._launch(raise_on_failure=True)
+        assert error.value.reasons == [collision]
+    else:
+        assert await executor._launch(raise_on_failure=False) is None
+
+    patches.sdk_launch.assert_called_once()
+    executor._cleanup_cluster.assert_not_called()
+    patches.set_backoff_pending.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_launch_parks_and_reattaches_without_teardown(monkeypatch):
     """A parked launch request releases the slot and re-attaches on resume."""
     executor = _make_launch_executor()


### PR DESCRIPTION
SkyPilot can map distinct logical cluster names to the same cloud resource name: `My-Cluster` and `my_cluster` normalize identically, and sufficiently long names can share the two-character truncation hash. A second launch can then adopt the first cluster’s resources, making status, execution and teardown act on the wrong cluster.

Reserve the resolved provider namespace and cloud name with SkyPilot’s existing locks until the native INIT handle and owner are committed. New mappings try the unchanged default name, then a bounded set of deterministic alternatives, re-rendering name-derived resources before authentication. Existing mappings and SSH configuration remain unchanged. An ambiguous existing mapping or exhausted allocation fails as a managed-job precheck, before authentication, provisioning or cleanup.

The reservation covers launches sharing one SkyPilot state database. Different state databases are outside this guard. No schema migration or global hash-length change is required.

Fixes #10742.

Tested:

- [x] `bash format.sh`: mypy (602 files), pylint, dashboard lint and formatting.
- [x] 59 reservation/config/provision/recovery unit tests: full concurrent launches, normalization and synthetic truncation collision, INIT/STOPPED/history, provider namespaces and legacy unknown metadata, persisted names and SSH configuration, bounded custom-template exhaustion, and no cleanup on rejected allocation.
- [x] Same 59 tests against a minimal 0.13.1rc1 backport, plus three native lock-wait helper tests.
- [ ] Live cloud smoke tests (not run).

The broader `test_backend_utils.py` suite has three failures also reproduced on the unchanged base: two fake AWS-region endpoint lookups and a cached controller-handle assertion.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10750" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->