### PR TITLE
[Kubernetes] Let pods with DRA claims terminate gracefully

### DIFF
--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -2691,8 +2691,17 @@ def _delete_cluster_services(cluster_name: str, namespace: str,
 def _pod_has_resource_claims(pod: Any) -> bool:
     """Whether the pod requests devices via dynamic resource allocation (DRA).
 
-    ``spec.resourceClaims`` is only modelled by kubernetes client versions that
-    know about DRA, so a missing attribute means the pod has no claims.
+    ``spec.resourceClaims`` is only modelled by kubernetes client 26.1.0 and
+    later, so on an older client the attribute is missing and every pod reads
+    as claim-free, keeping the force-delete path below. That is acceptable:
+    ``dependencies.py`` floors the client at 20.0.0, but the range is unpinned
+    and has no lock file, so an install resolves to the newest allowed version
+    (published images are many major versions past 26.1.0), and a client old
+    enough to lack the field predates DRA anyway.
+
+    Deliberately not the other way around: reading an unmodellable field as
+    "may have claims" would put *every* pod on the graceful path for those
+    clients, which is the teardown slowdown this check exists to avoid.
     """
     pod_spec = getattr(pod, 'spec', None)
     return bool(getattr(pod_spec, 'resource_claims', None))

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -2688,11 +2688,109 @@ def _delete_cluster_services(cluster_name: str, namespace: str,
                        f'{cluster_name}: {e}')
 
 
+def _pod_has_resource_claims(pod: Any) -> bool:
+    """Whether the pod requests devices via dynamic resource allocation (DRA).
+
+    ``spec.resourceClaims`` is only modelled by kubernetes client versions that
+    know about DRA, so a missing attribute means the pod has no claims.
+    """
+    pod_spec = getattr(pod, 'spec', None)
+    return bool(getattr(pod_spec, 'resource_claims', None))
+
+
+def _force_delete_pod(namespace: str, context: Optional[str],
+                      pod_name: str) -> None:
+    """Delete a pod with a zero grace period.
+
+    Some misbehaving pods do not terminate gracefully if they have open file
+    descriptors, which used to make teardown hang for many minutes, so this is
+    the default path for pod deletion.
+    """
+    kubernetes_utils.delete_k8s_resource_with_retry(
+        delete_func=lambda: kubernetes.core_api(context).delete_namespaced_pod(
+            name=pod_name,
+            namespace=namespace,
+            _request_timeout=config_lib.DELETION_TIMEOUT,
+            grace_period_seconds=0),
+        resource_type='pod',
+        resource_name=pod_name)
+
+
+def _wait_for_pod_gone(namespace: str, context: Optional[str],
+                       pod_name: str) -> bool:
+    """Polls until the pod object is gone. False if it is still there."""
+    start_time = time.time()
+    while time.time() - start_time < _TIMEOUT_FOR_POD_TERMINATION:
+        try:
+            kubernetes.core_api(context).read_namespaced_pod(
+                pod_name, namespace, _request_timeout=kubernetes.API_TIMEOUT)
+        except kubernetes.api_exception() as e:
+            if e.status == 404:
+                return True
+            # A transient API error should not short-circuit the wait into a
+            # force delete; keep polling until the timeout.
+            logger.debug(f'Error while waiting for pod {pod_name} to '
+                         f'terminate: {e}')
+        time.sleep(POLL_INTERVAL)
+    return False
+
+
+def _delete_pod(namespace: str, context: Optional[str], pod_name: str,
+                graceful: bool) -> None:
+    """Deletes a pod, optionally waiting for the kubelet to finish with it.
+
+    A zero grace period removes the pod object from etcd immediately, without
+    waiting for the kubelet to confirm that the pod is gone. That is what we
+    want for most pods (see ``_force_delete_pod``), but it is unsafe for pods
+    holding DRA resource claims: the kubelet unprepares a pod's claims after
+    its containers stop and *before* it reports the terminal pod status,
+    precisely so that the cleanup happens while the pod still exists in the
+    API. Deleting the object out from under it lets the resourceclaim
+    controller drop the claim's ``reservedFor`` entry and finalizer while the
+    kubelet may still be unpreparing, which can strand device state on the node
+    and leave claims allocated to a pod that no longer exists.
+
+    So for those pods, delete with the pod's own
+    ``terminationGracePeriodSeconds`` and wait for the object to disappear --
+    the kubelet only lets that happen once termination is complete. The wait is
+    bounded (and independent of ``terminationGracePeriodSeconds``) so that a
+    pod the container runtime cannot stop still cannot hang teardown: on
+    timeout we fall back to the force delete.
+    """
+    if not graceful:
+        _force_delete_pod(namespace, context, pod_name)
+        return
+
+    kubernetes_utils.delete_k8s_resource_with_retry(
+        delete_func=lambda: kubernetes.core_api(context).delete_namespaced_pod(
+            name=pod_name,
+            namespace=namespace,
+            _request_timeout=config_lib.DELETION_TIMEOUT),
+        resource_type='pod',
+        resource_name=pod_name)
+
+    if _wait_for_pod_gone(namespace, context, pod_name):
+        return
+
+    logger.warning(f'Pod {pod_name} did not finish terminating within '
+                   f'{_TIMEOUT_FOR_POD_TERMINATION}s. Force deleting it - '
+                   'devices held by the pod may have to be reclaimed by their '
+                   'driver before they can be used again.')
+    _force_delete_pod(namespace, context, pod_name)
+
+
 def _terminate_node(namespace: str,
                     context: Optional[str],
                     pod_name: str,
-                    is_head: bool = False) -> None:
-    """Terminate a pod and its associated services."""
+                    is_head: bool = False,
+                    has_resource_claims: bool = False) -> None:
+    """Terminate a pod and its associated services.
+
+    Args:
+        has_resource_claims: whether the pod requests DRA devices, in which
+            case it is deleted gracefully rather than force deleted. See
+            ``_delete_pod``.
+    """
     logger.debug(f'terminate_instances: namespace: {namespace}, context: '
                  f'{context}, pod_name: {pod_name}, is_head: {is_head}')
 
@@ -2707,16 +2805,7 @@ def _terminate_node(namespace: str,
     # Note - delete pod after all other resources are deleted.
     # This is to ensure there are no leftover resources if this down is run
     # from within the pod, e.g., for autodown.
-    # Note - some misbehaving pods may not terminate gracefully if they have
-    # open file descriptors. We force delete pods to avoid this.
-    kubernetes_utils.delete_k8s_resource_with_retry(
-        delete_func=lambda: kubernetes.core_api(context).delete_namespaced_pod(
-            name=pod_name,
-            namespace=namespace,
-            _request_timeout=config_lib.DELETION_TIMEOUT,
-            grace_period_seconds=0),
-        resource_type='pod',
-        resource_name=pod_name)
+    _delete_pod(namespace, context, pod_name, graceful=has_resource_claims)
 
 
 def _terminate_deployment(cluster_name: str, namespace: str,
@@ -2775,7 +2864,11 @@ def terminate_instances(
         if _is_head(pod) and worker_only:
             return
         logger.debug(f'Terminating instance {pod_name}: {pod}')
-        _terminate_node(namespace, context, pod_name, _is_head(pod))
+        _terminate_node(namespace,
+                        context,
+                        pod_name,
+                        is_head=_is_head(pod),
+                        has_resource_claims=_pod_has_resource_claims(pod))
 
     # Run pod termination in parallel
     num_threads = max(1, min(_NUM_THREADS, len(pods)))

--- a/tests/unit_tests/kubernetes/test_provision.py
+++ b/tests/unit_tests/kubernetes/test_provision.py
@@ -5067,3 +5067,112 @@ def test_command_runners_fall_back_to_the_submitting_context():
             'namespace': 'ns',
         }))
     assert [r.context for r in runners] == ['ctx-a']
+
+
+def _mock_core_api(monkeypatch):
+    """Point instance.py's core_api() at one mock, and skip sleeps."""
+    api = mock.MagicMock()
+    monkeypatch.setattr('sky.adaptors.kubernetes.core_api',
+                        lambda *a, **kw: api)
+    monkeypatch.setattr('time.sleep', lambda *args: None)
+    return api
+
+
+def _not_found():
+    return kubernetes.api_exception()(status=404)
+
+
+@pytest.mark.parametrize(('resource_claims', 'expected'), [
+    ([mock.MagicMock()], True),
+    ([], False),
+    (None, False),
+])
+def test_pod_has_resource_claims(resource_claims, expected):
+    pod = mock.MagicMock()
+    pod.spec.resource_claims = resource_claims
+    assert instance._pod_has_resource_claims(pod) is expected
+
+
+def test_pod_has_resource_claims_without_dra_aware_client():
+    """Older kubernetes clients do not model spec.resourceClaims at all."""
+    pod = mock.MagicMock()
+    del pod.spec.resource_claims
+    assert instance._pod_has_resource_claims(pod) is False
+
+
+def test_delete_pod_force_deletes_pod_without_claims(monkeypatch):
+    api = _mock_core_api(monkeypatch)
+
+    instance._delete_pod('default', 'ctx', 'pod', graceful=False)
+
+    api.delete_namespaced_pod.assert_called_once()
+    assert api.delete_namespaced_pod.call_args.kwargs[
+        'grace_period_seconds'] == 0
+    # No point waiting for a pod we just removed from the API server.
+    api.read_namespaced_pod.assert_not_called()
+
+
+def test_delete_pod_graceful_waits_for_pod_to_go_away(monkeypatch):
+    api = _mock_core_api(monkeypatch)
+    # Still there for the first two polls, gone on the third.
+    api.read_namespaced_pod.side_effect = [
+        mock.MagicMock(), mock.MagicMock(),
+        _not_found()
+    ]
+
+    instance._delete_pod('default', 'ctx', 'pod', graceful=True)
+
+    # Deleted with the pod's own terminationGracePeriodSeconds, i.e. without
+    # overriding the grace period to 0.
+    api.delete_namespaced_pod.assert_called_once()
+    assert ('grace_period_seconds'
+            not in api.delete_namespaced_pod.call_args.kwargs)
+    assert api.read_namespaced_pod.call_count == 3
+
+
+def test_delete_pod_graceful_force_deletes_on_timeout(monkeypatch):
+    api = _mock_core_api(monkeypatch)
+    monkeypatch.setattr(instance, '_TIMEOUT_FOR_POD_TERMINATION', 0)
+
+    instance._delete_pod('default', 'ctx', 'pod', graceful=True)
+
+    assert api.delete_namespaced_pod.call_count == 2
+    first, second = api.delete_namespaced_pod.call_args_list
+    assert 'grace_period_seconds' not in first.kwargs
+    assert second.kwargs['grace_period_seconds'] == 0
+
+
+def test_delete_pod_graceful_keeps_polling_through_transient_errors(
+        monkeypatch):
+    api = _mock_core_api(monkeypatch)
+    api.read_namespaced_pod.side_effect = [
+        kubernetes.api_exception()(status=500),
+        _not_found(),
+    ]
+
+    instance._delete_pod('default', 'ctx', 'pod', graceful=True)
+
+    # A 500 must not be mistaken for "gone" nor escalate to a force delete.
+    assert api.read_namespaced_pod.call_count == 2
+    api.delete_namespaced_pod.assert_called_once()
+
+
+@pytest.mark.parametrize(('has_resource_claims', 'expected_graceful'), [
+    (True, True),
+    (False, False),
+])
+def test_terminate_node_passes_claim_state_to_delete(monkeypatch,
+                                                     has_resource_claims,
+                                                     expected_graceful):
+    monkeypatch.setattr(instance, '_delete_services', lambda *a, **kw: None)
+    recorded = {}
+    monkeypatch.setattr(
+        instance, '_delete_pod',
+        lambda *a, **kw: recorded.update(graceful=kw['graceful']))
+
+    instance._terminate_node('default',
+                             'ctx',
+                             'pod',
+                             has_resource_claims=has_resource_claims)
+
+    assert recorded['graceful'] is expected_graceful


### PR DESCRIPTION
## Summary

- `_terminate_node` force deletes every pod with `grace_period_seconds=0`. That is unsafe for pods holding DRA (dynamic resource allocation) resource claims, because it removes the pod object from etcd before the kubelet has finished unpreparing the pod's claims.
- Pods that declare `spec.resourceClaims` are now deleted with their own `terminationGracePeriodSeconds` and waited on until the object disappears, with the force delete kept as a bounded fallback.
- Pods without resource claims are completely unaffected.

## Why

The kubelet unprepares a pod's DRA claims after its containers stop and *before* it reports the terminal pod status. That ordering is deliberate — see the note in `kubelet.SyncTerminatingPod`:

```go
// NOTE: resources must be unprepared AFTER all containers have stopped
// and BEFORE the pod status is changed on the API server
// to avoid race conditions with the resource deallocation code in kubernetes core.
```

A zero grace period is a non-graceful delete: `podStrategy.CheckGracefulDelete` drops the period to 0 and the object leaves etcd right away, without waiting for the kubelet. The resourceclaim controller then sees the pod as gone and clears the claim's `reservedFor` entry and its finalizer while the kubelet may still be unpreparing, or may not have started. That is exactly the race the comment above exists to prevent, and it can leave device state stranded on the node and claims allocated to a pod that no longer exists.

Under a graceful delete the wait is a sound barrier: the kubelet itself issues the final `Delete(gracePeriodSeconds=0)` only once `SyncTerminatedPod` has completed (`status_manager.canBeDeleted`), so "pod object gone" implies "unprepare finished".

The existing force delete was added in #5370 for #3755, where a pod holding open file descriptors stalled teardown for ~20 minutes. That motivation is preserved: the graceful path is bounded by `_TIMEOUT_FOR_POD_TERMINATION` (60s) and escalates to the same force delete on timeout, so a pod the container runtime cannot stop still cannot hang `sky down`.

Note the wait is a fixed bound rather than derived from `terminationGracePeriodSeconds`, so a pod configured with a very long grace period is still force deleted after 60s. Happy to make that adaptive if reviewers prefer.

## Tested

- `pytest tests/unit_tests/kubernetes/test_provision.py` — 223 passed, including 10 new cases covering:
  - `_pod_has_resource_claims` for populated / empty / absent `spec.resourceClaims` (the last for kubernetes client versions that predate DRA)
  - a pod without claims still being force deleted in a single call, with no polling
  - a pod with claims being deleted *without* a `grace_period_seconds` override, then polled until the object 404s
  - the timeout path escalating to a second, zero-grace delete
  - a transient (500) polling error neither being mistaken for "gone" nor escalating to a force delete
  - `_terminate_node` threading the claim state through to the delete
- `bash format.sh --files sky/provision/kubernetes/instance.py tests/unit_tests/kubernetes/test_provision.py` — clean.
- Manual verification on a cluster with the DRA driver installed:
  1. Launch a GPU cluster whose pod spec carries a `resourceClaims` entry.
  2. `sky down <cluster>`, and confirm the pods pass through `Terminating` rather than vanishing instantly.
  3. Confirm the kubelet plugin logs `Unprepared devices for claim ...` before the pod object disappears.
  4. Confirm the generated `ResourceClaim` objects are gone and no claim is left with a stale `status.reservedFor`.
  5. Relaunch onto the same nodes and confirm the pods schedule without stale device state blocking allocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skypilot-org/skypilot/pull/10751" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->